### PR TITLE
fix: update design tokens and adapt imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@brightlayer-ui/storybook-rtl-addon": "1.1.0",
     "@commitlint/cli": "17.0.2",
     "@commitlint/config-conventional": "17.0.2",
-    "@sbb-esta/lyne-design-tokens": "0.1.4",
+    "@sbb-esta/lyne-design-tokens": "0.1.5",
     "@stencil/core": "2.17.0",
     "@stencil/sass": "1.5.2",
     "@storybook/addon-a11y": "6.5.9",

--- a/src/components/sbb-accordion-item/sbb-accordion-item.stories.js
+++ b/src/components/sbb-accordion-item/sbb-accordion-item.stories.js
@@ -1,7 +1,4 @@
-import {
-  SbbColorMilkDefault,
-  SbbColorWhiteDefault,
-} from '@sbb-esta/lyne-design-tokens/dist/js/sbb-tokens.mjs';
+import { SbbColorMilkDefault, SbbColorWhiteDefault } from '@sbb-esta/lyne-design-tokens';
 import events from './sbb-accordion-item.events.ts';
 import { h } from 'jsx-dom';
 import readme from './readme.md';

--- a/src/components/sbb-accordion/sbb-accordion.stories.js
+++ b/src/components/sbb-accordion/sbb-accordion.stories.js
@@ -1,7 +1,4 @@
-import {
-  SbbColorMilkDefault,
-  SbbColorWhiteDefault,
-} from '@sbb-esta/lyne-design-tokens/dist/js/sbb-tokens.mjs';
+import { SbbColorMilkDefault, SbbColorWhiteDefault } from '@sbb-esta/lyne-design-tokens';
 import events from '../sbb-accordion-item/sbb-accordion-item.events.ts';
 import { h } from 'jsx-dom';
 

--- a/src/components/sbb-button/sbb-button.stories.js
+++ b/src/components/sbb-button/sbb-button.stories.js
@@ -1,8 +1,5 @@
 import images from '../../global/images';
-import {
-  SbbColorCharcoalDefault,
-  SbbColorWhiteDefault,
-} from '@sbb-esta/lyne-design-tokens/dist/js/sbb-tokens.mjs';
+import { SbbColorCharcoalDefault, SbbColorWhiteDefault } from '@sbb-esta/lyne-design-tokens';
 import events from './sbb-button.events.ts';
 import getMarkupForSvg from '../../global/helpers/get-markup-for-svg';
 import { h } from 'jsx-dom';

--- a/src/components/sbb-card-badge/sbb-card-badge.stories.js
+++ b/src/components/sbb-card-badge/sbb-card-badge.stories.js
@@ -1,7 +1,4 @@
-import {
-  SbbColorCharcoalDefault,
-  SbbColorWhiteDefault,
-} from '@sbb-esta/lyne-design-tokens/dist/js/sbb-tokens.mjs';
+import { SbbColorCharcoalDefault, SbbColorWhiteDefault } from '@sbb-esta/lyne-design-tokens';
 import { h } from 'jsx-dom';
 import readme from './readme.md';
 

--- a/src/components/sbb-card-product/sbb-card-product.stories.js
+++ b/src/components/sbb-card-product/sbb-card-product.stories.js
@@ -1,7 +1,4 @@
-import {
-  SbbColorMilkDefault,
-  SbbColorWhiteDefault,
-} from '@sbb-esta/lyne-design-tokens/dist/js/sbb-tokens.mjs';
+import { SbbColorMilkDefault, SbbColorWhiteDefault } from '@sbb-esta/lyne-design-tokens';
 import getMarkupForSvg from '../../global/helpers/get-markup-for-svg';
 import { h } from 'jsx-dom';
 import readme from './readme.md';

--- a/src/components/sbb-footer/sbb-footer.stories.js
+++ b/src/components/sbb-footer/sbb-footer.stories.js
@@ -1,7 +1,4 @@
-import {
-  SbbColorCharcoalDefault,
-  SbbColorWhiteDefault,
-} from '@sbb-esta/lyne-design-tokens/dist/js/sbb-tokens.mjs';
+import { SbbColorCharcoalDefault, SbbColorWhiteDefault } from '@sbb-esta/lyne-design-tokens';
 import { h } from 'jsx-dom';
 import readme from './readme.md';
 

--- a/src/components/sbb-grid/sbb-grid.stories.js
+++ b/src/components/sbb-grid/sbb-grid.stories.js
@@ -1,7 +1,4 @@
-import {
-  SbbColorCharcoalDefault,
-  SbbColorWhiteDefault,
-} from '@sbb-esta/lyne-design-tokens/dist/js/sbb-tokens.mjs';
+import { SbbColorCharcoalDefault, SbbColorWhiteDefault } from '@sbb-esta/lyne-design-tokens';
 import { h } from 'jsx-dom';
 import readme from './readme.md';
 

--- a/src/components/sbb-journey-header/sbb-journey-header.stories.js
+++ b/src/components/sbb-journey-header/sbb-journey-header.stories.js
@@ -1,7 +1,4 @@
-import {
-  SbbColorCharcoalDefault,
-  SbbColorWhiteDefault,
-} from '@sbb-esta/lyne-design-tokens/dist/js/sbb-tokens.mjs';
+import { SbbColorCharcoalDefault, SbbColorWhiteDefault } from '@sbb-esta/lyne-design-tokens';
 import { h } from 'jsx-dom';
 import readme from './readme.md';
 

--- a/src/components/sbb-link-button/sbb-link-button.stories.js
+++ b/src/components/sbb-link-button/sbb-link-button.stories.js
@@ -1,7 +1,4 @@
-import {
-  SbbColorCharcoalDefault,
-  SbbColorWhiteDefault,
-} from '@sbb-esta/lyne-design-tokens/dist/js/sbb-tokens.mjs';
+import { SbbColorCharcoalDefault, SbbColorWhiteDefault } from '@sbb-esta/lyne-design-tokens';
 import getMarkupForSvg from '../../global/helpers/get-markup-for-svg';
 import { h } from 'jsx-dom';
 import readme from './readme.md';

--- a/src/components/sbb-link-list/sbb-link-list.stories.js
+++ b/src/components/sbb-link-list/sbb-link-list.stories.js
@@ -1,7 +1,4 @@
-import {
-  SbbColorCharcoalDefault,
-  SbbColorWhiteDefault,
-} from '@sbb-esta/lyne-design-tokens/dist/js/sbb-tokens.mjs';
+import { SbbColorCharcoalDefault, SbbColorWhiteDefault } from '@sbb-esta/lyne-design-tokens';
 import { h } from 'jsx-dom';
 import readme from './readme.md';
 

--- a/src/components/sbb-link/sbb-link.stories.js
+++ b/src/components/sbb-link/sbb-link.stories.js
@@ -1,7 +1,4 @@
-import {
-  SbbColorCharcoalDefault,
-  SbbColorWhiteDefault,
-} from '@sbb-esta/lyne-design-tokens/dist/js/sbb-tokens.mjs';
+import { SbbColorCharcoalDefault, SbbColorWhiteDefault } from '@sbb-esta/lyne-design-tokens';
 import getMarkupForSvg from '../../global/helpers/get-markup-for-svg';
 import { h } from 'jsx-dom';
 import readme from './readme.md';

--- a/src/components/sbb-logo/sbb-logo.stories.js
+++ b/src/components/sbb-logo/sbb-logo.stories.js
@@ -1,7 +1,4 @@
-import {
-  SbbColorCharcoalDefault,
-  SbbColorWhiteDefault,
-} from '@sbb-esta/lyne-design-tokens/dist/js/sbb-tokens.mjs';
+import { SbbColorCharcoalDefault, SbbColorWhiteDefault } from '@sbb-esta/lyne-design-tokens';
 import { h } from 'jsx-dom';
 import readme from './readme.md';
 

--- a/src/components/sbb-section/sbb-section.stories.js
+++ b/src/components/sbb-section/sbb-section.stories.js
@@ -1,7 +1,4 @@
-import {
-  SbbColorCharcoalDefault,
-  SbbColorWhiteDefault,
-} from '@sbb-esta/lyne-design-tokens/dist/js/sbb-tokens.mjs';
+import { SbbColorCharcoalDefault, SbbColorWhiteDefault } from '@sbb-esta/lyne-design-tokens';
 import { h } from 'jsx-dom';
 import readme from './readme.md';
 

--- a/src/components/sbb-signet/sbb-signet.stories.js
+++ b/src/components/sbb-signet/sbb-signet.stories.js
@@ -1,4 +1,4 @@
-import { SbbColorCharcoalDefault } from '@sbb-esta/lyne-design-tokens/dist/js/sbb-tokens.mjs';
+import { SbbColorCharcoalDefault } from '@sbb-esta/lyne-design-tokens';
 import { h } from 'jsx-dom';
 import readme from './readme.md';
 

--- a/src/components/sbb-stack/sbb-stack.stories.js
+++ b/src/components/sbb-stack/sbb-stack.stories.js
@@ -1,7 +1,4 @@
-import {
-  SbbColorCharcoalDefault,
-  SbbColorWhiteDefault,
-} from '@sbb-esta/lyne-design-tokens/dist/js/sbb-tokens.mjs';
+import { SbbColorCharcoalDefault, SbbColorWhiteDefault } from '@sbb-esta/lyne-design-tokens';
 import { h } from 'jsx-dom';
 import readme from './readme.md';
 

--- a/src/components/sbb-title/sbb-title.stories.js
+++ b/src/components/sbb-title/sbb-title.stories.js
@@ -1,7 +1,4 @@
-import {
-  SbbColorCharcoalDefault,
-  SbbColorWhiteDefault,
-} from '@sbb-esta/lyne-design-tokens/dist/js/sbb-tokens.mjs';
+import { SbbColorCharcoalDefault, SbbColorWhiteDefault } from '@sbb-esta/lyne-design-tokens';
 import { h } from 'jsx-dom';
 import readme from './readme.md';
 

--- a/src/pages/home/home--logged-in.stories.js
+++ b/src/pages/home/home--logged-in.stories.js
@@ -1,8 +1,5 @@
 /* eslint-disable max-len */
-import {
-  SbbColorCharcoalDefault,
-  SbbColorWhiteDefault,
-} from '@sbb-esta/lyne-design-tokens/dist/js/sbb-tokens.mjs';
+import { SbbColorCharcoalDefault, SbbColorWhiteDefault } from '@sbb-esta/lyne-design-tokens';
 import getMarkupForSvg from '../../global/helpers/get-markup-for-svg';
 import { h } from 'jsx-dom';
 import readme from './readme.md';

--- a/src/pages/home/home.stories.js
+++ b/src/pages/home/home.stories.js
@@ -1,8 +1,5 @@
 /* eslint-disable max-len */
-import {
-  SbbColorCharcoalDefault,
-  SbbColorWhiteDefault,
-} from '@sbb-esta/lyne-design-tokens/dist/js/sbb-tokens.mjs';
+import { SbbColorCharcoalDefault, SbbColorWhiteDefault } from '@sbb-esta/lyne-design-tokens';
 import getMarkupForSvg from '../../global/helpers/get-markup-for-svg';
 import { h } from 'jsx-dom';
 import readme from './readme.md';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1736,10 +1736,10 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@sbb-esta/lyne-design-tokens@0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@sbb-esta/lyne-design-tokens/-/lyne-design-tokens-0.1.4.tgz#d934ef582e95845e194d61e609bc1859f879b95d"
-  integrity sha512-JNjYMdeFVT8b0UmvI3dWd7nmwQoYpc7jDwpUsX5ZHmrwB+0+3U6r0s3CSAwYc9zmDCr3Bs+tPAOJ61bLDDJp8w==
+"@sbb-esta/lyne-design-tokens@0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@sbb-esta/lyne-design-tokens/-/lyne-design-tokens-0.1.5.tgz#ce93238c083bceb44ccc9589b959fe36600c3759"
+  integrity sha512-QwBdlt/ZlfEEhT/Qtw8SpK5fA6Vap869HWHEWcmy0WlXCElnbKTzDWoGj5aSBsewfWYhBAuDuc21CXWwutmmIg==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"


### PR DESCRIPTION
Update `@sbb-esta/lyne-design-tokens` to version 0.1.5, which allows imports directly from the package root.