### PR TITLE
refactor: introduce possibility to observe host for named slot changes

### DIFF
--- a/src/components/sbb-form-field/sbb-form-field.e2e.ts
+++ b/src/components/sbb-form-field/sbb-form-field.e2e.ts
@@ -1,14 +1,31 @@
 // FIXME slotchange is not triggered, see https://github.com/ionic-team/stencil/issues/3536
-import { newE2EPage } from '@stencil/core/testing';
+import { E2EElement, E2EPage, newE2EPage } from '@stencil/core/testing';
 
 describe('sbb-form-field', () => {
-  let element, page;
+  let element: E2EElement, page: E2EPage;
 
   it('renders', async () => {
     page = await newE2EPage();
-    await page.setContent('<sbb-form-field><input slot="input"/></sbb-form-field>');
+    await page.setContent('<sbb-form-field><input/></sbb-form-field>');
 
     element = await page.find('sbb-form-field');
     expect(element).toHaveClass('hydrated');
+  });
+
+  it('should remove the label element if no label is configured', async () => {
+    page = await newE2EPage();
+    await page.setContent(`
+      <sbb-form-field>
+        <input slot="input"/>
+      </sbb-form-field>
+    `);
+
+    expect(await page.findAll('sbb-form-field >>> label')).toEqual([]);
+
+    element = await page.find('sbb-form-field');
+    expect(element.shadowRoot.querySelector('label')).toBeNull();
+    element.setAttribute('label', 'Label');
+    await page.waitForChanges();
+    expect(element.shadowRoot.querySelector('label')).not.toBeNull();
   });
 });

--- a/src/components/sbb-form-field/sbb-form-field.e2e.ts
+++ b/src/components/sbb-form-field/sbb-form-field.e2e.ts
@@ -27,5 +27,9 @@ describe('sbb-form-field', () => {
     element.setAttribute('label', 'Label');
     await page.waitForChanges();
     expect(element.shadowRoot.querySelector('label')).not.toBeNull();
+
+    element.removeAttribute('label');
+    await page.waitForChanges();
+    expect(element.shadowRoot.querySelector('label')).toBeNull();
   });
 });

--- a/src/components/sbb-form-field/sbb-form-field.scss
+++ b/src/components/sbb-form-field/sbb-form-field.scss
@@ -143,10 +143,6 @@
   user-select: none;
   pointer-events: none;
 
-  &[hidden] {
-    display: none;
-  }
-
   :host(.form-field--select) & {
     padding-inline-end: var(--form-field-select-inline-padding-end);
   }

--- a/src/components/sbb-form-field/sbb-form-field.spec.ts
+++ b/src/components/sbb-form-field/sbb-form-field.spec.ts
@@ -169,7 +169,7 @@ describe('sbb-form-field', () => {
     `);
   });
 
-  it('should renders select without label', async () => {
+  it('should render select without label', async () => {
     const { root } = await newSpecPage({
       components: [SbbFormField],
       html: `
@@ -189,11 +189,6 @@ describe('sbb-form-field', () => {
             <div class="form-field__wrapper">
               <slot name="prefix"></slot>
               <div class="form-field__input-container">
-                <label class="form-field__label" hidden>
-                  <slot name="label">
-                    <span></span>
-                  </slot>
-                </label>
                 <div class="form-field__input">
                   <slot></slot>
                 </div>

--- a/src/components/sbb-form-field/sbb-form-field.tsx
+++ b/src/components/sbb-form-field/sbb-form-field.tsx
@@ -116,7 +116,7 @@ export class SbbFormField implements ComponentInterface {
     this._formFieldAttributeObserver.disconnect();
   }
 
-  @Listen('sbbSlotNameChange', { passive: true })
+  @Listen('sbbNamedSlotChange', { passive: true })
   public handleSlotNameChange(event: CustomEvent<Set<string>>): void {
     this._namedSlots = queryNamedSlotState(this._element, this._namedSlots, event.detail);
   }

--- a/src/components/sbb-link-list/sbb-link-list.spec.ts
+++ b/src/components/sbb-link-list/sbb-link-list.spec.ts
@@ -16,24 +16,16 @@ describe('sbb-link-list', () => {
               <sbb-link href='https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html' text-size='s'>Sachbeschädigung melden</sbb-link>
             </sbb-link-list>`,
     });
-    /*
-    Due to the missing onSlotEvent the following content is missing in this test case.
-    `
-      ...
-      <mock:shadow-root>
-        <sbb-title level="2" visual-level="5">
-          <slot name="title">Help &amp; Contact</slot>
-        </sbb-title>
-        <ul aria-labelledby="sbb-link-list-title-1">
-      ...
-    `
-    */
+
     expect(root).toEqualHtml(`
         <sbb-link-list
             title-level="2">
           <mock:shadow-root>
             <div class="sbb-link-list">
-              <ul>
+              <sbb-title level="2" title-id="sbb-link-list-title-1" visual-level="5">
+                <slot name="title"></slot>
+              </sbb-title>
+              <ul aria-labelledby="sbb-link-list-title-1">
                 <li><slot name="link-0"></slot></li>
                 <li><slot name="link-1"></slot></li>
                 <li><slot name="link-2"></slot></li>
@@ -72,7 +64,7 @@ describe('sbb-link-list', () => {
             title-content="Help &amp; Contact">
           <mock:shadow-root>
             <div class="sbb-link-list">
-              <sbb-title level="2" titleid="sbb-link-list-title-2" visual-level="5">
+              <sbb-title level="2" title-id="sbb-link-list-title-2" visual-level="5">
                 <slot name="title">
                 Help &amp; Contact
               </sbb-title>

--- a/src/components/sbb-link-list/sbb-link-list.tsx
+++ b/src/components/sbb-link-list/sbb-link-list.tsx
@@ -91,7 +91,7 @@ export class SbbLinkList {
             level={this.titleLevel}
             visual-level="5"
             negative={this.negative}
-            titleId={this.titleId}
+            title-id={this.titleId}
           >
             <slot name="title">{this.titleContent}</slot>
           </sbb-title>

--- a/src/global/helpers/observe-named-slot-changes.ts
+++ b/src/global/helpers/observe-named-slot-changes.ts
@@ -1,0 +1,81 @@
+import { AgnosticMutationObserver } from './mutation-observer';
+
+const extractSlotNames = (nodeLists: NodeList[], slotNames = new Set<string>()): Set<string> => {
+  for (const nodeList of nodeLists) {
+    nodeList.forEach((node) => {
+      const slotName = (node as Element).getAttribute?.('slot');
+      if (slotName) {
+        slotNames.add(slotName);
+      }
+    });
+  }
+
+  return slotNames;
+};
+
+const observer = new AgnosticMutationObserver((mutations) => {
+  const mutationMap = mutations.reduce(
+    (map, mutation) =>
+      map.set(
+        mutation.target,
+        extractSlotNames([mutation.addedNodes, mutation.removedNodes], map.get(mutation.target))
+      ),
+    new Map<Node, Set<string>>()
+  );
+  mutationMap.forEach((slotNames, host) => {
+    if (slotNames.size) {
+      host.dispatchEvent(new CustomEvent('◬slotNameChange', { detail: slotNames }));
+    }
+  });
+});
+
+/**
+ * Observes a host element for changes in light DOM children.
+ *
+ * Only a single mutation observer is used for this purpose, as it is the most performant option.
+ * https://www.peterkroener.de/100000-mutationobserver-vs-100000-funktionen/
+ *
+ * Calling observe on the same node multiple times has no observable negative performance impact
+ * and observed nodes can still be garbage collected.
+ * https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/disconnect#usage_notes
+ *
+ * @example
+ * ```
+ * private _hasTitle = false;
+ *
+ * @Element() private _element: HTMLElement;
+ *
+ * public connectedCallback(): void {
+ *   this._hasTitle = !!this._element.query
+ *   observeNamedSlotChanges(this._element);
+ * }
+ *
+ * @Listen('◬slotNameChange', { passive: true })
+ * public handleSlotNameChange(event: CustomEvent<Set<string>>): void {
+ *   console.log(Date.now(), event);
+ * }
+ * ```
+ *
+ * @param element The host element to observe.
+ */
+export function observeNamedSlotChanges(element: Element): void {
+  // We only observe the child list of the host element, both for performance and to reduce
+  // complexity. If we were to observe the slot attribute of the children, this could only be done
+  // via subtree (which includes host and children of children), which would make it more difficult
+  // to differentiate between intended observed element and potentially other ancestors or
+  // descendents that are observed as well.
+  // This means that changes to the slot attribute of children would not be detected.
+  observer.observe(element, { childList: true });
+}
+
+/**
+ * Checks whether an element with the given slot attribute name exists as a child of the given
+ * element.
+ *
+ * @param element The host element.
+ * @param name The name of the slot.
+ * @returns Whether an element with the given slot attribute name exists.
+ */
+export function hasNamedSlotElement(element: Element, name: string): boolean {
+  return !!element.querySelector(`[slot="${name}"]`);
+}

--- a/src/global/helpers/observe-named-slot-changes.ts
+++ b/src/global/helpers/observe-named-slot-changes.ts
@@ -57,14 +57,29 @@ function hasNamedSlotElement(element: Element, name: string): boolean {
   return !!element.querySelector(`[slot="${name}"]`);
 }
 
-export type NamedSlotState = Readonly<Record<string, boolean>>;
+/**
+ * Type for named slot states. Either a generic readonly record or a named record, if provided
+ * with keys via generic parameter.
+ *
+ * e.g. either { [key: string]: boolean } or { name1: boolean, name2: boolean }
+ */
+export type NamedSlotState<K = unknown> = K extends string
+  ? Readonly<Pick<Record<string, boolean>, K>>
+  : Readonly<Record<string, boolean>>;
 
 /**
  * Creates a frozen object with the given names as key with the value being false.
- *
- * @param names Names of slots.
- * @returns A frozen object with the given slot names as keys.
  */
+export function createNamedSlotState<K extends string>(name: K): NamedSlotState<K>;
+export function createNamedSlotState<K1 extends string, K2 extends string>(
+  name1: K1,
+  name2: K2
+): NamedSlotState<K1 | K2>;
+export function createNamedSlotState<K1 extends string, K2 extends string, K3 extends string>(
+  name1: K1,
+  name2: K2,
+  name3: K3
+): NamedSlotState<K1 | K2 | K3>;
 export function createNamedSlotState(...names: string[]): NamedSlotState {
   return Object.freeze(
     names.reduce(
@@ -83,12 +98,12 @@ export function createNamedSlotState(...names: string[]): NamedSlotState {
  * @returns A new frozen object with values being set to true, if the host contains elements
  *   with the corresponding slot name.
  */
-export function queryNamedSlotState(
+export function queryNamedSlotState<S extends NamedSlotState>(
   element: HTMLElement,
-  state: Record<string, boolean>,
+  state: S,
   names?: Set<string>
-): NamedSlotState {
-  const newState = { ...state };
+): S {
+  const newState: Record<string, boolean> = { ...state };
   if (names) {
     names.forEach((name) => {
       if (name in newState) {
@@ -101,7 +116,7 @@ export function queryNamedSlotState(
     }
   }
 
-  return Object.freeze(newState);
+  return Object.freeze(newState) as S;
 }
 
 /**
@@ -128,10 +143,10 @@ export function queryNamedSlotState(
  * @returns A new frozen object with values being set to true, if the host contains elements
  *   with the corresponding slot name.
  */
-export function queryAndObserveNamedSlotState(
+export function queryAndObserveNamedSlotState<S extends NamedSlotState>(
   element: HTMLElement,
-  state: Record<string, boolean>
-): NamedSlotState {
+  state: S
+): S {
   observeNamedSlotChanges(element);
   return queryNamedSlotState(element, state);
 }

--- a/src/global/helpers/observe-named-slot-changes.ts
+++ b/src/global/helpers/observe-named-slot-changes.ts
@@ -15,7 +15,7 @@ const extractSlotNames = (nodeLists: NodeList[], slotNames = new Set<string>()):
 
 const observer = new AgnosticMutationObserver((mutations) => {
   // Aggregate multiple mutations to the corresponding target.
-  // This prevents the sbbSlotNameChange to be triggered multiple times for the same target.
+  // This prevents the sbbNamedSlotChange to be triggered multiple times for the same target.
   const mutationMap = mutations.reduce(
     (map, mutation) =>
       map.set(
@@ -26,7 +26,7 @@ const observer = new AgnosticMutationObserver((mutations) => {
   );
   mutationMap.forEach((slotNames, host) => {
     if (slotNames.size) {
-      host.dispatchEvent(new CustomEvent('sbbSlotNameChange', { detail: slotNames }));
+      host.dispatchEvent(new CustomEvent('sbbNamedSlotChange', { detail: slotNames }));
     }
   });
 });
@@ -117,7 +117,7 @@ export function queryNamedSlotState(
  *   this._namedSlots = queryAndObserveNamedSlotState(this._element, this._namedSlots);
  * }
  *
- * @Listen('sbbSlotNameChange', { passive: true })
+ * @Listen('sbbNamedSlotChange', { passive: true })
  * public handleSlotNameChange(event: CustomEvent<Set<string>>): void {
  *   this._namedSlots = queryNamedSlotState(this._element, this._namedSlots, event.detail);
  * }

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -11,6 +11,7 @@ export const config: Config = {
   globalScript: 'src/global/global.ts',
   globalStyle: 'src/global/global.shared.scss',
   namespace: 'lyne-components',
+  sourceMap: true,
   outputTargets: [
     {
       type: 'dist-hydrate-script',


### PR DESCRIPTION
We have various use cases where we want to remove or render an entire section of elements, depending on whether a specific element is slotted into a named slot.
This PR introduces functionality to define a named slot state and a way to observe the light DOM of the host for changes.