### PR TITLE
refactor: introduce functionality to mark slotted elements

### DIFF
--- a/src/components/sbb-form-field/sbb-form-field.e2e.ts
+++ b/src/components/sbb-form-field/sbb-form-field.e2e.ts
@@ -1,14 +1,43 @@
 // FIXME slotchange is not triggered, see https://github.com/ionic-team/stencil/issues/3536
-import { newE2EPage } from '@stencil/core/testing';
+import { E2EElement, E2EPage, newE2EPage } from '@stencil/core/testing';
 
 describe('sbb-form-field', () => {
-  let element, page;
+  let element: E2EElement, page: E2EPage;
 
   it('renders', async () => {
     page = await newE2EPage();
-    await page.setContent('<sbb-form-field><input slot="input"/></sbb-form-field>');
+    await page.setContent('<sbb-form-field><input/></sbb-form-field>');
 
     element = await page.find('sbb-form-field');
     expect(element).toHaveClass('hydrated');
+  });
+
+  it('marks slotted elements', async () => {
+    page = await newE2EPage();
+    await page.setContent(`
+      <sbb-form-field>
+        <span slot="label">Label</span>
+        <input />
+      </sbb-form-field>
+    `);
+
+    element = await page.find('sbb-form-field');
+    const labelSpan = await element.find('span');
+    expect(labelSpan).toHaveAttribute('data-slot-context');
+    expect(labelSpan.getAttribute('data-slot-context')).toEqual('sbb-form-field/label');
+    const input = await element.find('input');
+    expect(input.getAttribute('data-slot-context')).toEqual('sbb-form-field');
+
+    const slotContext = await page.evaluate(async () => {
+      const input = document.querySelector('sbb-form-field input') as HTMLInputElement;
+      input.setAttribute('disabled', '');
+      await new Promise((r) => setTimeout(r));
+      return input.dataset.slotContext;
+    });
+    await page.evaluate(() => new Promise((r) => setTimeout(r)));
+    expect(slotContext).toEqual('sbb-form-field/disabled');
+    expect((await element.find('span')).getAttribute('data-slot-context')).toEqual(
+      'sbb-form-field/label/disabled'
+    );
   });
 });

--- a/src/global/helpers/slot-marker.ts
+++ b/src/global/helpers/slot-marker.ts
@@ -1,0 +1,89 @@
+/**
+ * Class to annotate slotted elements with the data-slot-context attribute.
+ */
+export class SlotMarker {
+  private _history = new WeakMap<Node, { mark: string; elements: Element[] }>();
+
+  /**
+   * @param _markerFactory Factory function to append to the marker.
+   */
+  public constructor(private _markerFactory?: () => string | void) {}
+
+  /**
+   * Mark slotted elements of the given slot element/event.
+   * Combines the element name of the host and the slot name, optionally appended
+   * with the result of the marker factory.
+   */
+  public mark = (origin: Event | HTMLSlotElement): void => {
+    const slot: HTMLSlotElement =
+      origin instanceof HTMLSlotElement
+        ? origin
+        : (origin.target as HTMLSlotElement) ?? (origin.composedPath()[0] as HTMLSlotElement);
+    if (!slot) {
+      return;
+    }
+
+    const entry = this._history.get(slot);
+    if (entry) {
+      this._unmarkElements(entry.elements);
+    }
+
+    const markAppendage = this._markerFactory?.();
+    const mark = `${(slot.getRootNode() as ShadowRoot).host.tagName.toLowerCase()}${
+      slot.name ? `/${slot.name}` : ''
+    }${markAppendage ? `/${markAppendage}` : ''}`;
+
+    const elements = slot.assignedElements();
+    if (!elements) {
+      return;
+    }
+
+    for (const element of elements) {
+      if (element instanceof HTMLElement) {
+        element.dataset.slotContext = mark;
+      }
+    }
+    this._history.set(slot, { elements, mark });
+  };
+
+  /**
+   * Apply marker to slotted elements and add event listener to the inner shadow root of the given
+   * element, to mark slotted elements on slot change.
+   * @param element The element to add the event listener to.
+   */
+  public connect(element: HTMLElement): void {
+    element.shadowRoot?.addEventListener('slotchange', this.mark);
+    element.shadowRoot?.querySelectorAll('slot').forEach((s) => this.mark(s));
+  }
+
+  /**
+   * Removes the marker from the slotted elements and removes the event listener from the inner
+   * shadow root.
+   * @param element The element to remove the event listener from.
+   */
+  public disconnect(element: HTMLElement): void {
+    element.shadowRoot?.removeEventListener('slotchange', this.mark);
+    element.shadowRoot?.querySelectorAll('slot').forEach((s) => this.unmark(s));
+  }
+
+  /**
+   * Removes the marker fro the slotted elements of the given slot.
+   * @param slot The slot whose slotted elements should have the marker removed.
+   */
+  public unmark(slot: HTMLSlotElement): void {
+    const entry = this._history.get(slot);
+    if (!entry?.elements) {
+      return;
+    }
+    this._history.delete(slot);
+    this._unmarkElements(entry.elements);
+  }
+
+  private _unmarkElements(elements: Element[]): void {
+    for (const element of elements) {
+      if (element instanceof HTMLElement) {
+        delete element.dataset.slotContext;
+      }
+    }
+  }
+}


### PR DESCRIPTION
We have some use cases where it would be beneficial to have the context of a slotted element that can be addressed via a CSS selector. This PR adds a `SlotMarker` class, which can set the `data-slot-context` attribute of slotted elements.