### PR TITLE
feat: improvement in LinkButtonProperties interface

### DIFF
--- a/src/components/sbb-button/sbb-button.tsx
+++ b/src/components/sbb-button/sbb-button.tsx
@@ -14,10 +14,11 @@ import { InterfaceButtonAttributes } from './sbb-button.custom';
 import {
   ButtonType,
   forwardHostClick,
-  getButtonAttributeList,
-  getLinkAttributeList,
+  getButtonRenderVariables,
   getLinkButtonBaseAttributeList,
+  getLinkRenderVariables,
   LinkButtonProperties,
+  LinkButtonRenderVariables,
   LinkTargetType,
   PopupType,
 } from '../../global/interfaces/link-button-properties';
@@ -172,24 +173,16 @@ export class SbbButton implements LinkButtonProperties, ComponentInterface {
       .some((n) => !!n.textContent.trim());
   }
 
-  private _resolveRenderVariables(): {
-    screenReaderNewWindowInfo?: boolean;
-    attributes: Record<string, string>;
-    tagName: 'a' | 'button' | 'span';
-  } {
+  public resolveRenderVariables(): LinkButtonRenderVariables {
     if (this.isStatic) {
       return {
         tagName: 'span',
         attributes: getLinkButtonBaseAttributeList(this),
       };
     } else if (this.href) {
-      return {
-        tagName: 'a',
-        attributes: getLinkAttributeList(this, this),
-        screenReaderNewWindowInfo: !this.accessibilityLabel && this.target === '_blank',
-      };
+      return getLinkRenderVariables(this);
     }
-    return { tagName: 'button', attributes: getButtonAttributeList(this) };
+    return getButtonRenderVariables(this);
   }
 
   public render(): JSX.Element {
@@ -197,7 +190,7 @@ export class SbbButton implements LinkButtonProperties, ComponentInterface {
       tagName: TAG_NAME,
       attributes,
       screenReaderNewWindowInfo,
-    } = this._resolveRenderVariables();
+    } = this.resolveRenderVariables();
 
     // See https://github.com/ionic-team/stencil/issues/2703#issuecomment-1050943715 on why form attribute is set with `setAttribute`
     return (

--- a/src/components/sbb-button/sbb-button.tsx
+++ b/src/components/sbb-button/sbb-button.tsx
@@ -14,13 +14,11 @@ import { InterfaceButtonAttributes } from './sbb-button.custom';
 import {
   ButtonType,
   forwardHostClick,
-  getButtonRenderVariables,
-  getLinkButtonBaseAttributeList,
-  getLinkRenderVariables,
   LinkButtonProperties,
   LinkButtonRenderVariables,
   LinkTargetType,
   PopupType,
+  resolveRenderVariables,
 } from '../../global/interfaces/link-button-properties';
 import { ACTION_ELEMENTS, hostContext } from '../../global/helpers/host-context';
 import {
@@ -174,15 +172,7 @@ export class SbbButton implements LinkButtonProperties, ComponentInterface {
   }
 
   public resolveRenderVariables(): LinkButtonRenderVariables {
-    if (this.isStatic) {
-      return {
-        tagName: 'span',
-        attributes: getLinkButtonBaseAttributeList(this),
-      };
-    } else if (this.href) {
-      return getLinkRenderVariables(this);
-    }
-    return getButtonRenderVariables(this);
+    return resolveRenderVariables(this, this.isStatic);
   }
 
   public render(): JSX.Element {

--- a/src/components/sbb-button/sbb-button.tsx
+++ b/src/components/sbb-button/sbb-button.tsx
@@ -171,16 +171,12 @@ export class SbbButton implements LinkButtonProperties, ComponentInterface {
       .some((n) => !!n.textContent.trim());
   }
 
-  public resolveRenderVariables(): LinkButtonRenderVariables {
-    return resolveRenderVariables(this, this.isStatic);
-  }
-
   public render(): JSX.Element {
     const {
       tagName: TAG_NAME,
       attributes,
       screenReaderNewWindowInfo,
-    } = this.resolveRenderVariables();
+    }: LinkButtonRenderVariables = resolveRenderVariables(this, this.isStatic);
 
     // See https://github.com/ionic-team/stencil/issues/2703#issuecomment-1050943715 on why form attribute is set with `setAttribute`
     return (

--- a/src/components/sbb-card/sbb-card.e2e.ts
+++ b/src/components/sbb-card/sbb-card.e2e.ts
@@ -18,7 +18,7 @@ describe('sbb-card', () => {
     expect(element).toEqualHtml(`
       <sbb-card class='hydrated sbb-card--has-badge' size="xl" href="https://github.com/lyne-design-system/lyne-components" target="_blank">
         <mock:shadow-root>
-          <a class="sbb-card sbb-card__link" dir="ltr" href="https://github.com/lyne-design-system/lyne-components" target="_blank" rel="external noopener nofollow" >
+          <a class="sbb-card" dir="ltr" href="https://github.com/lyne-design-system/lyne-components" target="_blank" rel="external noopener nofollow" >
             <slot name="badge"></slot>
             <span class="sbb-card__content">
               <slot></slot>
@@ -49,7 +49,7 @@ describe('sbb-card', () => {
     expect(element).toEqualHtml(`
       <sbb-card class='hydrated sbb-card--has-badge' size="xl" name="button" form="form" value="value">
         <mock:shadow-root>
-          <button class="sbb-card sbb-card__button" dir="ltr" type='button' name="button" form="form" value="value">
+          <button class="sbb-card" dir="ltr" type='button' name="button" form="form" value="value">
             <slot name="badge"></slot>
             <span class="sbb-card__content">
               <slot></slot>

--- a/src/components/sbb-card/sbb-card.scss
+++ b/src/components/sbb-card/sbb-card.scss
@@ -92,6 +92,7 @@
   :host([href]) &,
   :host(:not([href])) & {
     width: 100%;
+    border-radius: var(--sbb-card-border-radius);
     background-color: var(--sbb-card-background-color);
     padding-inline: var(--sbb-card-padding-inline);
     padding-block-start: var(--sbb-card-padding-block-start);

--- a/src/components/sbb-card/sbb-card.scss
+++ b/src/components/sbb-card/sbb-card.scss
@@ -58,9 +58,14 @@
 
 .sbb-card {
   position: relative;
+  width: 100%;
   overflow: hidden;
-  transition: box-shadow var(--sbb-card-animation-duration) var(--sbb-card-animation-easing);
+  padding-inline: var(--sbb-card-padding-inline);
+  padding-block-start: var(--sbb-card-padding-block-start);
+  padding-block-end: var(--sbb-card-padding-block-end);
   border-radius: var(--sbb-card-border-radius);
+  background-color: var(--sbb-card-background-color);
+  transition: box-shadow var(--sbb-card-animation-duration) var(--sbb-card-animation-easing);
 
   &::before {
     position: absolute;
@@ -82,23 +87,16 @@
 
   // stylelint-disable-next-line plugin/stylelint-bem-namics
   :host(:not([href])) & {
-    @include buttonReset;
     @include text-inherit;
 
     cursor: pointer;
-  }
 
-  // stylelint-disable plugin/stylelint-bem-namics
-  :host([href]) &,
-  :host(:not([href])) & {
-    width: 100%;
-    border-radius: var(--sbb-card-border-radius);
-    background-color: var(--sbb-card-background-color);
-    padding-inline: var(--sbb-card-padding-inline);
-    padding-block-start: var(--sbb-card-padding-block-start);
-    padding-block-end: var(--sbb-card-padding-block-end);
+    // can't use @include buttonReset because overrides paddings, backgrounds..., only basic rules added
+    border: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    -webkit-tap-highlight-color: transparent;
   }
-  // stylelint-enable plugin/stylelint-bem-namics
 }
 
 :host([active]) {

--- a/src/components/sbb-card/sbb-card.scss
+++ b/src/components/sbb-card/sbb-card.scss
@@ -73,35 +73,37 @@
   &:focus-visible {
     @include focusOutline;
   }
+
+  :host([href]) & {
+    display: block;
+    color: inherit;
+    text-decoration: none;
+  }
+
+  // stylelint-disable-next-line plugin/stylelint-bem-namics
+  :host(:not([href])) & {
+    @include buttonReset;
+    @include text-inherit;
+
+    cursor: pointer;
+  }
+
+  // stylelint-disable plugin/stylelint-bem-namics
+  :host([href]) &,
+  :host(:not([href])) & {
+    width: 100%;
+    background-color: var(--sbb-card-background-color);
+    padding-inline: var(--sbb-card-padding-inline);
+    padding-block-start: var(--sbb-card-padding-block-start);
+    padding-block-end: var(--sbb-card-padding-block-end);
+  }
+  // stylelint-enable plugin/stylelint-bem-namics
 }
 
 :host([active]) {
   .sbb-card::before {
     border: var(--sbb-border-width-2x) solid var(--sbb-color-smoke-default);
   }
-}
-
-.sbb-card__link {
-  display: block;
-  color: inherit;
-  text-decoration: none;
-}
-
-.sbb-card__button {
-  @include buttonReset;
-  @include text-inherit;
-
-  cursor: pointer;
-}
-
-.sbb-card__button,
-.sbb-card__link {
-  width: 100%;
-  border-radius: var(--sbb-card-border-radius);
-  background-color: var(--sbb-card-background-color);
-  padding-inline: var(--sbb-card-padding-inline);
-  padding-block-start: var(--sbb-card-padding-block-start);
-  padding-block-end: var(--sbb-card-padding-block-end);
 }
 
 .sbb-card__content {

--- a/src/components/sbb-card/sbb-card.spec.ts
+++ b/src/components/sbb-card/sbb-card.spec.ts
@@ -19,7 +19,7 @@ describe('sbb-card', () => {
     expect(root).toEqualHtml(`
       <sbb-card class='sbb-card--has-badge' size="xl" href="https://github.com/lyne-design-system/lyne-components" target="_blank">
         <mock:shadow-root>
-          <a class="sbb-card sbb-card__link" dir="ltr" href="https://github.com/lyne-design-system/lyne-components" target="_blank" rel="external noopener nofollow" >
+          <a class="sbb-card" dir="ltr" href="https://github.com/lyne-design-system/lyne-components" target="_blank" rel="external noopener nofollow" >
             <slot name="badge"></slot>
             <span class="sbb-card__content">
               <slot></slot>
@@ -53,7 +53,7 @@ describe('sbb-card', () => {
     expect(root).toEqualHtml(`
       <sbb-card class='sbb-card--has-badge' size="xl" name="button" form="form" value="value">
         <mock:shadow-root>
-          <button class="sbb-card sbb-card__button" dir="ltr" type='button' name="button" form="form" value="value">
+          <button class="sbb-card" dir="ltr" type='button' name="button" form="form" value="value">
             <slot name="badge"></slot>
             <span class="sbb-card__content">
               <slot></slot>
@@ -81,7 +81,7 @@ describe('sbb-card', () => {
     expect(root).toEqualHtml(`
       <sbb-card size="s" href="https://github.com/lyne-design-system/lyne-components" target="_blank">
         <mock:shadow-root>
-          <a class="sbb-card sbb-card__link" dir="ltr" href="https://github.com/lyne-design-system/lyne-components" target="_blank" rel="external noopener nofollow" >
+          <a class="sbb-card" dir="ltr" href="https://github.com/lyne-design-system/lyne-components" target="_blank" rel="external noopener nofollow" >
             <span class="sbb-card__content">
               <slot></slot>
               <span class="sbb-card__opens-in-new-window">
@@ -110,7 +110,7 @@ describe('sbb-card', () => {
     expect(root).toEqualHtml(`
       <sbb-card size="s" name="button" form="form" value="value" active="">
         <mock:shadow-root>
-          <button class="sbb-card sbb-card__button" dir="ltr" type="button" name="button" form="form" value="value">
+          <button class="sbb-card" dir="ltr" type="button" name="button" form="form" value="value">
             <span class="sbb-card__content">
               <slot></slot>
             </span>

--- a/src/components/sbb-card/sbb-card.tsx
+++ b/src/components/sbb-card/sbb-card.tsx
@@ -147,16 +147,12 @@ export class SbbCard implements LinkButtonProperties {
     return this.size === 'm' || this.size === 'l' || this.size === 'xl' || this.size === 'xxl';
   }
 
-  public resolveRenderVariables(): LinkButtonRenderVariables {
-    return resolveRenderVariables(this);
-  }
-
   public render(): JSX.Element {
     const {
       tagName: TAG_NAME,
       attributes,
       screenReaderNewWindowInfo,
-    } = this.resolveRenderVariables();
+    }: LinkButtonRenderVariables = resolveRenderVariables(this);
 
     return (
       <Host class={{ 'sbb-card--has-badge': this._showSBBBadge() && this._hasBadge }}>

--- a/src/components/sbb-card/sbb-card.tsx
+++ b/src/components/sbb-card/sbb-card.tsx
@@ -15,8 +15,8 @@ import { i18nTargetOpensInNewWindow } from '../../global/i18n';
 import {
   ButtonType,
   forwardHostClick,
-  getButtonAttributeList,
-  getLinkAttributeList,
+  getButtonRenderVariables,
+  getLinkRenderVariables,
   LinkButtonProperties,
   LinkButtonRenderVariables,
   LinkTargetType,
@@ -151,15 +151,12 @@ export class SbbCard implements LinkButtonProperties {
   public resolveRenderVariables(): LinkButtonRenderVariables {
     if (this.href) {
       return {
-        tagName: 'a',
-        attributes: getLinkAttributeList(this, this),
+        ...getLinkRenderVariables(this),
         cssClass: 'sbb-card sbb-card__link',
-        screenReaderNewWindowInfo: !this.accessibilityLabel && this.target === '_blank',
       };
     } else {
       return {
-        tagName: 'button',
-        attributes: getButtonAttributeList(this),
+        ...getButtonRenderVariables(this),
         cssClass: 'sbb-card sbb-card__button',
       };
     }

--- a/src/components/sbb-card/sbb-card.tsx
+++ b/src/components/sbb-card/sbb-card.tsx
@@ -58,7 +58,7 @@ export class SbbCard implements LinkButtonProperties {
   /**
    *  The href value you want to link to.
    */
-  @Prop() public href: string | undefined;
+  @Prop({ reflect: true }) public href: string | undefined;
 
   /**
    * Where to display the linked URL.

--- a/src/components/sbb-card/sbb-card.tsx
+++ b/src/components/sbb-card/sbb-card.tsx
@@ -15,11 +15,10 @@ import { i18nTargetOpensInNewWindow } from '../../global/i18n';
 import {
   ButtonType,
   forwardHostClick,
-  getButtonRenderVariables,
-  getLinkRenderVariables,
   LinkButtonProperties,
   LinkButtonRenderVariables,
   LinkTargetType,
+  resolveRenderVariables,
 } from '../../global/interfaces/link-button-properties';
 import { InterfaceSbbCardAttributes } from './sbb-card.custom';
 
@@ -149,24 +148,13 @@ export class SbbCard implements LinkButtonProperties {
   }
 
   public resolveRenderVariables(): LinkButtonRenderVariables {
-    if (this.href) {
-      return {
-        ...getLinkRenderVariables(this),
-        cssClass: 'sbb-card sbb-card__link',
-      };
-    } else {
-      return {
-        ...getButtonRenderVariables(this),
-        cssClass: 'sbb-card sbb-card__button',
-      };
-    }
+    return resolveRenderVariables(this);
   }
 
   public render(): JSX.Element {
     const {
       tagName: TAG_NAME,
       attributes,
-      cssClass,
       screenReaderNewWindowInfo,
     } = this.resolveRenderVariables();
 
@@ -174,7 +162,7 @@ export class SbbCard implements LinkButtonProperties {
       <Host class={{ 'sbb-card--has-badge': this._showSBBBadge() && this._hasBadge }}>
         <TAG_NAME
           id={this.idValue}
-          class={cssClass}
+          class="sbb-card"
           {...attributes}
           ref={(btn) => this.form && btn?.setAttribute('form', this.form)}
         >

--- a/src/components/sbb-card/sbb-card.tsx
+++ b/src/components/sbb-card/sbb-card.tsx
@@ -18,6 +18,7 @@ import {
   getButtonAttributeList,
   getLinkAttributeList,
   LinkButtonProperties,
+  LinkButtonRenderVariables,
   LinkTargetType,
 } from '../../global/interfaces/link-button-properties';
 import { InterfaceSbbCardAttributes } from './sbb-card.custom';
@@ -147,27 +148,37 @@ export class SbbCard implements LinkButtonProperties {
     return this.size === 'm' || this.size === 'l' || this.size === 'xl' || this.size === 'xxl';
   }
 
-  public render(): JSX.Element {
-    let TAG_NAME: string;
-    let className = 'sbb-card';
-    let attributeList: Record<string, string>;
-
+  public resolveRenderVariables(): LinkButtonRenderVariables {
     if (this.href) {
-      TAG_NAME = 'a';
-      className += ' sbb-card__link';
-      attributeList = getLinkAttributeList(this, this);
+      return {
+        tagName: 'a',
+        attributes: getLinkAttributeList(this, this),
+        cssClass: 'sbb-card sbb-card__link',
+        screenReaderNewWindowInfo: !this.accessibilityLabel && this.target === '_blank',
+      };
     } else {
-      TAG_NAME = 'button';
-      className += ' sbb-card__button';
-      attributeList = getButtonAttributeList(this);
+      return {
+        tagName: 'button',
+        attributes: getButtonAttributeList(this),
+        cssClass: 'sbb-card sbb-card__button',
+      };
     }
+  }
+
+  public render(): JSX.Element {
+    const {
+      tagName: TAG_NAME,
+      attributes,
+      cssClass,
+      screenReaderNewWindowInfo,
+    } = this.resolveRenderVariables();
 
     return (
       <Host class={{ 'sbb-card--has-badge': this._showSBBBadge() && this._hasBadge }}>
         <TAG_NAME
           id={this.idValue}
-          class={className}
-          {...attributeList}
+          class={cssClass}
+          {...attributes}
           ref={(btn) => this.form && btn?.setAttribute('form', this.form)}
         >
           {this._showSBBBadge() && (
@@ -180,7 +191,7 @@ export class SbbCard implements LinkButtonProperties {
           )}
           <span class="sbb-card__content">
             <slot />
-            {this.href && (
+            {screenReaderNewWindowInfo && (
               <span class="sbb-card__opens-in-new-window">
                 . {i18nTargetOpensInNewWindow[getDocumentLang()]}
               </span>

--- a/src/components/sbb-link/sbb-link.tsx
+++ b/src/components/sbb-link/sbb-link.tsx
@@ -13,9 +13,9 @@ import {
 import {
   ButtonType,
   forwardHostClick,
-  getButtonAttributeList,
-  getLinkAttributeList,
+  getButtonRenderVariables,
   getLinkButtonBaseAttributeList,
+  getLinkRenderVariables,
   LinkButtonProperties,
   LinkButtonRenderVariables,
   LinkTargetType,
@@ -176,13 +176,9 @@ export class SbbLink implements LinkButtonProperties, ComponentInterface {
         attributes: getLinkButtonBaseAttributeList(this),
       };
     } else if (this.href) {
-      return {
-        tagName: 'a',
-        attributes: getLinkAttributeList(this, this),
-        screenReaderNewWindowInfo: !this.accessibilityLabel && this.target === '_blank',
-      };
+      return getLinkRenderVariables(this);
     }
-    return { tagName: 'button', attributes: getButtonAttributeList(this) };
+    return getButtonRenderVariables(this);
   }
 
   public render(): JSX.Element {

--- a/src/components/sbb-link/sbb-link.tsx
+++ b/src/components/sbb-link/sbb-link.tsx
@@ -167,16 +167,12 @@ export class SbbLink implements LinkButtonProperties, ComponentInterface {
     this._namedSlots = queryNamedSlotState(this._element, this._namedSlots, event.detail);
   }
 
-  public resolveRenderVariables(): LinkButtonRenderVariables {
-    return resolveRenderVariables(this, this.isStatic);
-  }
-
   public render(): JSX.Element {
     const {
       tagName: TAG_NAME,
       attributes,
       screenReaderNewWindowInfo,
-    } = this.resolveRenderVariables();
+    }: LinkButtonRenderVariables = resolveRenderVariables(this, this.isStatic);
 
     // See https://github.com/ionic-team/stencil/issues/2703#issuecomment-1050943715 on why form attribute is set with `setAttribute`
     return (

--- a/src/components/sbb-link/sbb-link.tsx
+++ b/src/components/sbb-link/sbb-link.tsx
@@ -13,13 +13,11 @@ import {
 import {
   ButtonType,
   forwardHostClick,
-  getButtonRenderVariables,
-  getLinkButtonBaseAttributeList,
-  getLinkRenderVariables,
   LinkButtonProperties,
   LinkButtonRenderVariables,
   LinkTargetType,
   PopupType,
+  resolveRenderVariables,
 } from '../../global/interfaces/link-button-properties';
 import { InterfaceLinkAttributes } from './sbb-link.custom';
 import { ACTION_ELEMENTS, hostContext } from '../../global/helpers/host-context';
@@ -170,15 +168,7 @@ export class SbbLink implements LinkButtonProperties, ComponentInterface {
   }
 
   public resolveRenderVariables(): LinkButtonRenderVariables {
-    if (this.isStatic) {
-      return {
-        tagName: 'span',
-        attributes: getLinkButtonBaseAttributeList(this),
-      };
-    } else if (this.href) {
-      return getLinkRenderVariables(this);
-    }
-    return getButtonRenderVariables(this);
+    return resolveRenderVariables(this, this.isStatic);
   }
 
   public render(): JSX.Element {

--- a/src/components/sbb-link/sbb-link.tsx
+++ b/src/components/sbb-link/sbb-link.tsx
@@ -17,6 +17,7 @@ import {
   getLinkAttributeList,
   getLinkButtonBaseAttributeList,
   LinkButtonProperties,
+  LinkButtonRenderVariables,
   LinkTargetType,
   PopupType,
 } from '../../global/interfaces/link-button-properties';
@@ -168,11 +169,7 @@ export class SbbLink implements LinkButtonProperties, ComponentInterface {
     this._namedSlots = queryNamedSlotState(this._element, this._namedSlots, event.detail);
   }
 
-  private _resolveRenderVariables(): {
-    screenReaderNewWindowInfo?: boolean;
-    attributes: Record<string, string>;
-    tagName: 'a' | 'button' | 'span';
-  } {
+  public resolveRenderVariables(): LinkButtonRenderVariables {
     if (this.isStatic) {
       return {
         tagName: 'span',
@@ -193,7 +190,7 @@ export class SbbLink implements LinkButtonProperties, ComponentInterface {
       tagName: TAG_NAME,
       attributes,
       screenReaderNewWindowInfo,
-    } = this._resolveRenderVariables();
+    } = this.resolveRenderVariables();
 
     // See https://github.com/ionic-team/stencil/issues/2703#issuecomment-1050943715 on why form attribute is set with `setAttribute`
     return (

--- a/src/global/interfaces/link-button-properties.spec.ts
+++ b/src/global/interfaces/link-button-properties.spec.ts
@@ -3,9 +3,14 @@ import {
   ButtonProperties,
   forwardHostClick,
   getButtonAttributeList,
+  getButtonRenderVariables,
   getLinkAttributeList,
   getLinkButtonBaseAttributeList,
+  getLinkButtonStaticRenderVariables,
+  getLinkRenderVariables,
+  LinkButtonProperties,
   LinkProperties,
+  resolveRenderVariables,
 } from './link-button-properties';
 
 describe('getLinkButtonBaseAttributeList', () => {
@@ -157,6 +162,136 @@ describe('getButtonAttributeList', () => {
 
     // jest can't compare functions as emitButtonClick, so objectContaining(...) API is used
     expect(getButtonAttributeList(buttonProperties)).toEqual(expect.objectContaining(expectedObj));
+  });
+});
+
+describe('getLinkRenderVariables', () => {
+  const linkButtonProperties: LinkButtonProperties<void> = {
+    href: 'link',
+    target: '_blank',
+    accessibilityDescribedby: undefined,
+    accessibilityLabel: undefined,
+    accessibilityLabelledby: undefined,
+    click: undefined,
+    emitButtonClick: () => true,
+    name: undefined,
+    type: undefined,
+  };
+
+  it('should return the correct variables with screenReaderNewWindowInfo true', () => {
+    const expectedObj = {
+      tagName: 'a',
+      attributes: {
+        dir: 'ltr',
+        href: 'link',
+        target: '_blank',
+        rel: 'external noopener nofollow',
+      },
+      screenReaderNewWindowInfo: true,
+    };
+    expect(getLinkRenderVariables(linkButtonProperties)).toEqual(expectedObj);
+  });
+
+  it('should return the correct variables with screenReaderNewWindowInfo false', () => {
+    const linkButtonPropertiesNoScreenReader: LinkButtonProperties<void> = {
+      ...linkButtonProperties,
+      accessibilityLabel: 'accessibilityLabel',
+      target: 'custom',
+    };
+    const expectedObj = {
+      tagName: 'a',
+      attributes: {
+        dir: 'ltr',
+        href: 'link',
+        target: 'custom',
+        'aria-label': 'accessibilityLabel',
+      },
+      screenReaderNewWindowInfo: false,
+    };
+    expect(getLinkRenderVariables(linkButtonPropertiesNoScreenReader)).toEqual(expectedObj);
+  });
+});
+
+describe('getButtonRenderVariables', () => {
+  const linkButtonProperties: LinkButtonProperties<void> = {
+    href: undefined,
+    target: undefined,
+    accessibilityDescribedby: undefined,
+    accessibilityLabel: undefined,
+    accessibilityLabelledby: undefined,
+    click: undefined,
+    emitButtonClick: () => true,
+    type: 'submit',
+    name: 'name',
+  };
+
+  it('should return the correct variables', () => {
+    const expectedObj = {
+      tagName: 'button',
+      attributes: {
+        dir: 'ltr',
+        name: 'name',
+        type: 'submit',
+      },
+    };
+
+    expect(JSON.stringify(getButtonRenderVariables(linkButtonProperties))).toEqual(
+      JSON.stringify(expectedObj)
+    );
+  });
+});
+
+describe('getLinkButtonStaticRenderVariables', () => {
+  const linkButtonProperties: LinkButtonProperties<void> = {
+    href: undefined,
+    target: undefined,
+    accessibilityDescribedby: undefined,
+    accessibilityLabel: undefined,
+    accessibilityLabelledby: undefined,
+    click: undefined,
+    emitButtonClick: () => undefined,
+    type: undefined,
+    name: undefined,
+  };
+  it('should return the correct variables', () => {
+    const expectedObj = {
+      tagName: 'span',
+      attributes: {
+        dir: 'ltr',
+      },
+    };
+
+    expect(getLinkButtonStaticRenderVariables(linkButtonProperties)).toEqual(expectedObj);
+  });
+});
+
+// FIXME how to spy on imported function without workaround? https://github.com/jasmine/jasmine/issues/1414
+describe('resolveRenderVariables', () => {
+  const linkButtonProperties: LinkButtonProperties<void> = {
+    href: 'link',
+    target: undefined,
+    accessibilityDescribedby: undefined,
+    accessibilityLabel: undefined,
+    accessibilityLabelledby: undefined,
+    click: undefined,
+    emitButtonClick: () => undefined,
+    type: undefined,
+    name: undefined,
+  };
+
+  it('should return variables for the static case', () => {
+    const retObj = resolveRenderVariables(linkButtonProperties, true);
+    expect(retObj.tagName).toEqual('span');
+  });
+
+  it('should return variables for the link case', () => {
+    const retObj = resolveRenderVariables(linkButtonProperties);
+    expect(retObj.tagName).toEqual('a');
+  });
+
+  it('should return variables for the button case', () => {
+    const retObj = resolveRenderVariables({ ...linkButtonProperties, href: undefined });
+    expect(retObj.tagName).toEqual('button');
   });
 });
 

--- a/src/global/interfaces/link-button-properties.ts
+++ b/src/global/interfaces/link-button-properties.ts
@@ -105,14 +105,7 @@ export interface LinkButtonRenderVariables {
  */
 export interface LinkButtonProperties<ParameterType = any>
   extends LinkProperties,
-    ButtonProperties<ParameterType> {
-  /**
-   * Used to set the correct value of LinkButtonRenderVariables under certain conditions.
-   * If you want to check only the href value, you should use the resolveRenderVariables function at line 229.
-   * If you have more complex logic, use getLinkRenderVariables(...) and getButtonRenderVariables(...).
-   */
-  resolveRenderVariables: () => LinkButtonRenderVariables;
-}
+    ButtonProperties<ParameterType> {}
 
 /**
  * Creates the basic attribute list for the link/button tag; undefined/null properties are not set.

--- a/src/global/interfaces/link-button-properties.ts
+++ b/src/global/interfaces/link-button-properties.ts
@@ -73,7 +73,7 @@ export interface ButtonProperties<T = any> extends AccessibilityProperties {
   click: EventEmitter<T> | undefined;
 
   /** The function triggered on button click. */
-  emitButtonClick: (() => void) | undefined;
+  emitButtonClick: ((event: MouseEvent) => void) | undefined;
 }
 
 /**

--- a/src/global/interfaces/link-button-properties.ts
+++ b/src/global/interfaces/link-button-properties.ts
@@ -77,7 +77,7 @@ export interface ButtonProperties<T = any> extends AccessibilityProperties {
 }
 
 /**
- * A set of variables used in `render` function in components that implement LinkButtonProperties.
+ * A component that implement LinkButtonProperties could use this interface to set useful variables for render function.
  */
 export interface LinkButtonRenderVariables {
   /**
@@ -86,7 +86,7 @@ export interface LinkButtonRenderVariables {
   tagName: 'a' | 'button' | 'span';
 
   /**
-   * The tag attributes; can be set using getLinkButtonBaseAttributeList(...),
+   * The tag's attributes; can be set using getLinkButtonBaseAttributeList(...),
    * getLinkAttributeList(...) or getButtonAttributeList(...) methods.
    */
   attributes: Record<string, string>;

--- a/src/global/interfaces/link-button-properties.ts
+++ b/src/global/interfaces/link-button-properties.ts
@@ -77,7 +77,7 @@ export interface ButtonProperties<T = any> extends AccessibilityProperties {
 }
 
 /**
- * A component that implement LinkButtonProperties could use this interface to set useful variables for render function.
+ * A component that implements LinkButtonProperties should use this interface to set useful variables for render function.
  */
 export interface LinkButtonRenderVariables {
   /**
@@ -112,7 +112,7 @@ export interface LinkButtonProperties<ParameterType = any>
   extends LinkProperties,
     ButtonProperties<ParameterType> {
   /**
-   * Can be used to set the correct LinkButtonRenderVariables under certain conditions.
+   * Used to set the correct value of LinkButtonRenderVariables under certain conditions.
    * E.g. if href is not set, use getLinkRenderVariables(...), otherwise use getButtonRenderVariables(...).
    */
   resolveRenderVariables: () => LinkButtonRenderVariables;

--- a/src/global/interfaces/link-button-properties.ts
+++ b/src/global/interfaces/link-button-properties.ts
@@ -92,11 +92,6 @@ export interface LinkButtonRenderVariables {
   attributes: Record<string, string>;
 
   /**
-   * The tag's CSS classes.
-   */
-  cssClass?: string;
-
-  /**
    * Indicates whether the screen reader has to announce that the link will open in a new window.
    */
   screenReaderNewWindowInfo?: boolean;
@@ -113,7 +108,8 @@ export interface LinkButtonProperties<ParameterType = any>
     ButtonProperties<ParameterType> {
   /**
    * Used to set the correct value of LinkButtonRenderVariables under certain conditions.
-   * E.g. if href is not set, use getLinkRenderVariables(...), otherwise use getButtonRenderVariables(...).
+   * If you want to check only the href value, you should use the resolveRenderVariables function at line 229.
+   * If you have more complex logic, use getLinkRenderVariables(...) and getButtonRenderVariables(...).
    */
   resolveRenderVariables: () => LinkButtonRenderVariables;
 }
@@ -190,7 +186,7 @@ export function getButtonAttributeList(buttonProperties: ButtonProperties): Reco
  */
 export function getLinkRenderVariables(
   linkButtonProperties: LinkButtonProperties
-): Pick<LinkButtonRenderVariables, 'tagName' | 'attributes' | 'screenReaderNewWindowInfo'> {
+): LinkButtonRenderVariables {
   return {
     tagName: 'a',
     attributes: getLinkAttributeList(linkButtonProperties, linkButtonProperties),
@@ -205,11 +201,41 @@ export function getLinkRenderVariables(
  */
 export function getButtonRenderVariables(
   linkButtonProperties: LinkButtonProperties
-): Pick<LinkButtonRenderVariables, 'tagName' | 'attributes'> {
+): LinkButtonRenderVariables {
   return {
     tagName: 'button',
     attributes: getButtonAttributeList(linkButtonProperties),
   };
+}
+
+/**
+ * Set default render variables when the element is static (button/link inside another button/link).
+ * @param linkButtonProperties used to set the 'attributes' property.
+ */
+export function getLinkButtonStaticRenderVariables(
+  linkButtonProperties: LinkButtonProperties
+): LinkButtonRenderVariables {
+  return {
+    tagName: 'span',
+    attributes: getLinkButtonBaseAttributeList(linkButtonProperties),
+  };
+}
+
+/**
+ * Set default render variables based on the 'default' condition, checking first `isStatic` parameter, then the `href`.
+ * @param linkButtonProperties used to set the 'attributes' property and to check for `href` value.
+ * @param isStatic renders the default static variable whether is true.
+ */
+export function resolveRenderVariables(
+  linkButtonProperties: LinkButtonProperties,
+  isStatic = false
+): LinkButtonRenderVariables {
+  if (isStatic) {
+    return getLinkButtonStaticRenderVariables(linkButtonProperties);
+  } else if (linkButtonProperties.href) {
+    return getLinkRenderVariables(linkButtonProperties);
+  }
+  return getButtonRenderVariables(linkButtonProperties);
 }
 
 /**

--- a/src/global/interfaces/link-button-properties.ts
+++ b/src/global/interfaces/link-button-properties.ts
@@ -112,8 +112,8 @@ export interface LinkButtonProperties<ParameterType = any>
   extends LinkProperties,
     ButtonProperties<ParameterType> {
   /**
-   * Used to set the correct LinkButtonRenderVariables based on some conditions.
-   * E.g. if href is not set, return tagName = 'button' and attributes = getButtonAttributeList(...).
+   * Can be used to set the correct LinkButtonRenderVariables under certain conditions.
+   * E.g. if href is not set, use getLinkRenderVariables(...), otherwise use getButtonRenderVariables(...).
    */
   resolveRenderVariables: () => LinkButtonRenderVariables;
 }
@@ -182,6 +182,34 @@ export function getButtonAttributeList(buttonProperties: ButtonProperties): Reco
     'aria-controls': buttonProperties?.accessibilityControls ?? undefined,
     'aria-haspopup': buttonProperties?.accessibilityHaspopup ?? undefined,
   });
+}
+
+/**
+ * Set default render variables for link case.
+ * @param linkButtonProperties used to set the 'attributes' property.
+ */
+export function getLinkRenderVariables(
+  linkButtonProperties: LinkButtonProperties
+): Pick<LinkButtonRenderVariables, 'tagName' | 'attributes' | 'screenReaderNewWindowInfo'> {
+  return {
+    tagName: 'a',
+    attributes: getLinkAttributeList(linkButtonProperties, linkButtonProperties),
+    screenReaderNewWindowInfo:
+      !linkButtonProperties.accessibilityLabel && linkButtonProperties.target === '_blank',
+  };
+}
+
+/**
+ * Set default render variables for button case.
+ * @param linkButtonProperties used to set the 'attributes' property.
+ */
+export function getButtonRenderVariables(
+  linkButtonProperties: LinkButtonProperties
+): Pick<LinkButtonRenderVariables, 'tagName' | 'attributes'> {
+  return {
+    tagName: 'button',
+    attributes: getButtonAttributeList(linkButtonProperties),
+  };
 }
 
 /**

--- a/src/global/interfaces/link-button-properties.ts
+++ b/src/global/interfaces/link-button-properties.ts
@@ -77,6 +77,32 @@ export interface ButtonProperties<T = any> extends AccessibilityProperties {
 }
 
 /**
+ * A set of variables used in `render` function in components that implement LinkButtonProperties.
+ */
+export interface LinkButtonRenderVariables {
+  /**
+   * The tag's name rendered by the component.
+   */
+  tagName: 'a' | 'button' | 'span';
+
+  /**
+   * The tag attributes; can be set using getLinkButtonBaseAttributeList(...),
+   * getLinkAttributeList(...) or getButtonAttributeList(...) methods.
+   */
+  attributes: Record<string, string>;
+
+  /**
+   * The tag's CSS classes.
+   */
+  cssClass?: string;
+
+  /**
+   * Indicates whether the screen reader has to announce that the link will open in a new window.
+   */
+  screenReaderNewWindowInfo?: boolean;
+}
+
+/**
  * The interface contains the possible attributes of both the <a> and the <button> tags.
  * It is intended to be used in all cases where a component needs to render a tag that can be an <a> or a <button>,
  * for instance depending on whether the value of the href attribute is present or not.
@@ -84,7 +110,13 @@ export interface ButtonProperties<T = any> extends AccessibilityProperties {
  */
 export interface LinkButtonProperties<ParameterType = any>
   extends LinkProperties,
-    ButtonProperties<ParameterType> {}
+    ButtonProperties<ParameterType> {
+  /**
+   * Used to set the correct LinkButtonRenderVariables based on some conditions.
+   * E.g. if href is not set, return tagName = 'button' and attributes = getButtonAttributeList(...).
+   */
+  resolveRenderVariables: () => LinkButtonRenderVariables;
+}
 
 /**
  * Creates the basic attribute list for the link/button tag; undefined/null properties are not set.


### PR DESCRIPTION
## Preflight Checklist

<!-- Please ensure you've completed the following steps by replacing [ ] with [x]-->

- [x] I have read the [Contributing Guidelines](https://github.com/lyne-design-system/lyne-components/blob/master/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/lyne-design-system/lyne-components/blob/master/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [pull request tracker](https://github.com/lyne-design-system/lyne-components/pulls) for a Pull Request (PR) that matches the one I want to submit, without success.

## Issue

This PR Closes #

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

See [Review Guidelines](../REVIEW.md) for more information what is checked during review process.

## Changes

Changes in this pull request:

- since all the components that implement the `LinkButtonProperties` need to set some variables in `render` function (basic case: set the tag name to \<a\> or \<button\> based on the href value),  a new helper function named `resolveRenderVariables` has been added, in order to provide default values for static, link and button cases with the following logic:
    - if static, return a `span` with the attributes given by `getLinkButtonBaseAttributeList`;
    - if href, return an `a` with the attributes given by `getLinkAttributeList` and the correct value for `screenReaderNewWindowInfo`;
    - otherwise, return a `button` with the attributes given by `getButtonAttributeList`.
- if a more complex logic is needed, the methods `getLinkRenderVariables`, `getButtonRenderVariables` and `getLinkButtonStaticRenderVariables` can be directly used;
- all the functions return an object typed as `LinkButtonRenderVariables`;
- the `sbb-card` SCSS has been revisited, removing the different classes for button and anchor cases;
- the `emitButtonClick` function in `ButtonProperties` now exposes the MouseEvent;
- useful for: link, button, card, header-action, menu-action. . . .

## Browsers

I tested the build on the following browsers:

- [ ] Firefox Desktop
- [ ] Chrome Desktop
- [ ] Edge Desktop
- [ ] Safari Desktop
- [ ] Chrome Mobile
- [ ] Safari Mobile

## Screen readers

I tested the build on the following browsers:

- [ ] JAWS Firefox Desktop
- [ ] JAWS Chrome Desktop
- [ ] NVDA Firefox Desktop
- [ ] NVDA Chrome Desktop
- [ ] VoiceOver Safari Desktop
- [ ] VoiceOver Chrome Desktop
- [ ] VoiceOver Safari Mobile
- [ ] Android Accessibility Suite Chrome Mobile

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): improvement

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
