### PR TITLE
feat: add experimental sass output

### DIFF
--- a/_index.scss
+++ b/_index.scss
@@ -1,0 +1,6 @@
+@import 'src/global/core/components/utilities.scss';
+@import 'src/global/functions.scss';
+@import 'src/global/mediaqueries.scss';
+@import 'src/global/mixins.scss';
+@import 'src/global/core/shared/variables.scss';
+@warn "The sass API of @sbb-esta/lyne-components is still experimental and subject to change.";

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   "files": [
     "dist/",
     "loader/",
-    "hydrate"
+    "hydrate",
+    "_index.scss",
+    "src/global/**/*.scss"
   ],
   "scripts": {
     "build:stencil": "stencil build --ci --prod --docs",


### PR DESCRIPTION
With this PR our sass code can be used by consumers (e.g. via `@import "@sbb-esta/lyne-components";`).
This is still experimental and sass code in our code base WILL change in the future.