### PR TITLE
build: migrate GitHub Actions set-output to $GITHUB_OUTPUT

### DIFF
--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - name: 'Yarn: Get cache directory path'
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       shell: bash
     - name: 'Yarn: Restore dependencies from cache'
       uses: actions/cache@v3

--- a/.github/workflows/continuous-integration-secure.yml
+++ b/.github/workflows/continuous-integration-secure.yml
@@ -25,7 +25,7 @@ jobs:
       - run: unzip coverage.zip -d coverage
       - name: Read PR number
         id: pr-number
-        run: echo "::set-output name=pr::$(<NR)"
+        run: echo "pr=$(<NR)" >> $GITHUB_OUTPUT
         shell: bash
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,9 +63,9 @@ jobs:
         run: |
           if [[ "$REF" == *"-"* ]]
           then
-              echo "::set-output name=npm_tag::next"
+              echo "npm_tag=next" >> $GITHUB_OUTPUT
           else
-              echo "::set-output name=npm_tag::latest"
+              echo "npm_tag=latest" >> $GITHUB_OUTPUT
           fi
         env:
           REF: ${{ github.ref }}


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/