### PR TITLE
feat(sbb-dialog): add `sbb-dialog-close` attribute option to close the dialog

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -511,7 +511,7 @@ export namespace Components {
         /**
           * Closes the dialog element.
          */
-        "close": (result?: any) => Promise<any>;
+        "close": (result?: any, target?: HTMLElement) => Promise<any>;
         /**
           * This id will be forwarded to the relevant inner element.
          */

--- a/src/components/sbb-dialog/readme.md
+++ b/src/components/sbb-dialog/readme.md
@@ -32,7 +32,7 @@ In order to show a modal you need to call the `open(event?: PointerEvent)` metho
 
 Note that it is necessary to pass the event object to the `open()` method to allow the dialog to detect whether it has been opened by click or keyboard, so that the focus can be better handled.
 
-To dismiss the dialog you need to get a reference to the `sbb-dialog` element and call the `close(result?: any)` method, which will close the dialog element and emit a close event with an optional result as a payload.
+To dismiss the dialog you need to get a reference to the `sbb-dialog` element and call the `close(result?: any, target?: HTMLElement)` method, which will close the dialog element and emit a close event with an optional result as a payload. You can also indicate that an element within the dialog content should close the dialog when clicked by marking it with the `sbb-dialog-close` attribute.
 
 ### Usage notes
 The dialog title can be provided via the `titleContent` property and via slot `name="title"` (e.g. `<span slot="title">My dialog title</span>`). You can also set the property `titleBackButton` to display the back button in the title section (or content section, if title is omitted) which will emit the event `sbb-dialog_request-back-action` when clicked. 
@@ -91,7 +91,7 @@ The ARIA attributes `aria-labelledby` an `aria-describedby` can be set to improv
 
 ## Methods
 
-### `close(result?: any) => Promise<any>`
+### `close(result?: any, target?: HTMLElement) => Promise<any>`
 
 Closes the dialog element.
 

--- a/src/components/sbb-dialog/sbb-dialog.spec.ts
+++ b/src/components/sbb-dialog/sbb-dialog.spec.ts
@@ -18,6 +18,7 @@ describe('sbb-dialog', () => {
                   accessibility-label="Close modal"
                   class="sbb-dialog__close"
                   icon-name="cross-small"
+                  sbb-dialog-close=""
                   size="m"
                   type="button"
                   variant="secondary"

--- a/src/components/sbb-dialog/sbb-dialog.stories.js
+++ b/src/components/sbb-dialog/sbb-dialog.stories.js
@@ -128,11 +128,6 @@ const openDialog = (event, id) => {
   dialog.open(event);
 };
 
-const closeDialog = (id, returnValue) => {
-  const dialog = document.getElementById(id);
-  dialog.close(returnValue);
-};
-
 const onFormDialogClose = (dialog) => {
   dialog.addEventListener('sbb-dialog_will-close', (event) => {
     if (event.detail) {
@@ -282,13 +277,7 @@ const FormTemplate = (args) => [
       <code style={codeStyle}>close(result?: any, target?: HTMLElement)</code>
       method and returning the form values to update the details.
     </div>
-    <form
-      style={formStyle}
-      onSubmit={(e) => {
-        e.preventDefault();
-        closeDialog('my-dialog-4', e.target);
-      }}
-    >
+    <form style={formStyle} onSubmit={(e) => e.preventDefault()}>
       <sbb-form-field error-space="none" label="Message" size="m">
         <input placeholder="Your custom massage" value="Hello 👋" name="message" />
       </sbb-form-field>
@@ -300,7 +289,7 @@ const FormTemplate = (args) => [
           <option>Elephant</option>
         </select>
       </sbb-form-field>
-      <sbb-button type="submit" size="m">
+      <sbb-button type="submit" size="m" sbb-dialog-close>
         Update details
       </sbb-button>
     </form>

--- a/src/components/sbb-dialog/sbb-dialog.stories.js
+++ b/src/components/sbb-dialog/sbb-dialog.stories.js
@@ -138,8 +138,10 @@ const onFormDialogClose = (dialog) => {
     if (event.detail) {
       document.getElementById(
         'returned-value-message'
-      ).innerHTML = `${event.detail.message?.value}`;
-      document.getElementById('returned-value-animal').innerHTML = `${event.detail.animal?.value}`;
+      ).innerHTML = `${event.detail.returnValue.message?.value}`;
+      document.getElementById(
+        'returned-value-animal'
+      ).innerHTML = `${event.detail.returnValue.animal?.value}`;
     }
   });
 };
@@ -156,7 +158,7 @@ const triggerButton = (dialogId) => (
   </sbb-button>
 );
 
-const actionGroup = (negative, dialogId) => (
+const actionGroup = (negative) => (
   <sbb-action-group
     slot="action-group"
     align-group="stretch"
@@ -171,13 +173,14 @@ const actionGroup = (negative, dialogId) => (
       icon-placement="start"
       href="https://www.sbb.ch/en/"
       negative={negative}
+      sbb-dialog-close
     >
       Link
     </sbb-link>
-    <sbb-button size="m" variant="secondary" onClick={() => closeDialog(dialogId)}>
+    <sbb-button size="m" variant="secondary" sbb-dialog-close>
       Cancel
     </sbb-button>
-    <sbb-button size="m" variant="primary" onClick={() => closeDialog(dialogId)}>
+    <sbb-button size="m" variant="primary" sbb-dialog-close>
       Button
     </sbb-button>
   </sbb-action-group>
@@ -276,7 +279,7 @@ const FormTemplate = (args) => [
   >
     <div style={'margin-bottom: var(--sbb-spacing-fixed-4x)'}>
       Submit the form below to close the dialog box using the
-      <code style={codeStyle}>close(result?: any)</code>
+      <code style={codeStyle}>close(result?: any, target?: HTMLElement)</code>
       method and returning the form values to update the details.
     </div>
     <form

--- a/src/components/sbb-dialog/sbb-dialog.tsx
+++ b/src/components/sbb-dialog/sbb-dialog.tsx
@@ -22,6 +22,7 @@ import {
 import { IS_FOCUSABLE_QUERY, FocusTrap } from '../../global/helpers/focus';
 import { i18nCloseDialog, i18nGoBack } from '../../global/i18n';
 import getDocumentLang from '../../global/helpers/get-document-lang';
+import { hostContext } from '../../global/helpers/host-context';
 
 /**
  * @slot unnamed - Use this slot to provide the dialog content.
@@ -279,8 +280,15 @@ export class SbbDialog implements AccessibilityProperties {
   // Close the dialog on click of any element that has the 'sbb-dialog-close' attribute.
   private _closeOnSbbDialogCloseClick(event: Event): void {
     const target = event.target as HTMLElement;
+
+    // Check if the target is a submit element within a form
+    const closestForm =
+      target.getAttribute('type') === 'submit'
+        ? (hostContext('form', target) as HTMLFormElement)
+        : undefined;
+
     if (target.hasAttribute('sbb-dialog-close') && !target.hasAttribute('disabled')) {
-      this.close(null, target);
+      this.close(closestForm, target);
     }
   }
 

--- a/src/components/sbb-dialog/sbb-dialog.tsx
+++ b/src/components/sbb-dialog/sbb-dialog.tsx
@@ -167,6 +167,7 @@ export class SbbDialog implements AccessibilityProperties {
   private _dialogWrapperElement: HTMLElement;
   private _dialogContentElement: HTMLElement;
   private _firstFocusable: HTMLElement;
+  private _dialogCloseElement: HTMLElement;
   private _dialogController: AbortController;
   private _windowEventsController: AbortController;
   private _focusTrap = new FocusTrap();
@@ -206,13 +207,14 @@ export class SbbDialog implements AccessibilityProperties {
    * Closes the dialog element.
    */
   @Method()
-  public async close(result?: any): Promise<any> {
+  public async close(result?: any, target?: HTMLElement): Promise<any> {
     if (this._state === 'opening') {
       return;
     }
 
     this._returnValue = result;
-    this.willClose.emit(this._returnValue);
+    this._dialogCloseElement = target;
+    this.willClose.emit({ returnValue: this._returnValue, closeTarget: this._dialogCloseElement });
     this._state = 'closing';
     this._openedByKeyboard = false;
   }
@@ -274,6 +276,14 @@ export class SbbDialog implements AccessibilityProperties {
     }
   };
 
+  // Close the dialog on click of any element that has the 'sbb-dialog-close' attribute.
+  private _closeOnSbbDialogCloseClick(event: Event): void {
+    const target = event.target as HTMLElement;
+    if (target.hasAttribute('sbb-dialog-close') && !target.hasAttribute('disabled')) {
+      this.close(null, target);
+    }
+  }
+
   // Wait for dialog transition to complete.
   private _onDialogAnimationEnd(event: AnimationEvent): void {
     if (event.animationName === 'open') {
@@ -286,7 +296,7 @@ export class SbbDialog implements AccessibilityProperties {
       this._state = 'closed';
       this._dialogWrapperElement.querySelector('.sbb-dialog__content').scrollTo(0, 0);
       this._dialog.close();
-      this.didClose.emit(this._returnValue);
+      this.didClose.emit({ returnValue: this._returnValue, closeTarget: this._dialogCloseElement });
       this._windowEventsController?.abort();
       this._focusTrap.disconnect();
       // Enable scrolling for content below the dialog
@@ -331,7 +341,7 @@ export class SbbDialog implements AccessibilityProperties {
         size="m"
         type="button"
         icon-name="cross-small"
-        onClick={() => this.close()}
+        sbb-dialog-close
       ></sbb-button>
     );
 
@@ -389,9 +399,11 @@ export class SbbDialog implements AccessibilityProperties {
           onAnimationEnd={(event: AnimationEvent) => this._onDialogAnimationEnd(event)}
           class="sbb-dialog"
         >
+          {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
           <div
-            class="sbb-dialog__wrapper"
+            onClick={(event: Event) => this._closeOnSbbDialogCloseClick(event)}
             ref={(dialogWrapperRef) => (this._dialogWrapperElement = dialogWrapperRef)}
+            class="sbb-dialog__wrapper"
           >
             {dialogHeader}
             <div

--- a/src/components/sbb-dialog/sbb-dialog.tsx
+++ b/src/components/sbb-dialog/sbb-dialog.tsx
@@ -281,13 +281,12 @@ export class SbbDialog implements AccessibilityProperties {
   private _closeOnSbbDialogCloseClick(event: Event): void {
     const target = event.target as HTMLElement;
 
-    // Check if the target is a submit element within a form
-    const closestForm =
-      target.getAttribute('type') === 'submit'
-        ? (hostContext('form', target) as HTMLFormElement)
-        : undefined;
-
     if (target.hasAttribute('sbb-dialog-close') && !target.hasAttribute('disabled')) {
+      // Check if the target is a submit element within a form
+      const closestForm =
+        target.getAttribute('type') === 'submit'
+          ? (hostContext('form', target) as HTMLFormElement)
+          : undefined;
       this.close(closestForm, target);
     }
   }

--- a/src/components/sbb-dialog/sbb-dialog.tsx
+++ b/src/components/sbb-dialog/sbb-dialog.tsx
@@ -282,7 +282,7 @@ export class SbbDialog implements AccessibilityProperties {
     const target = event.target as HTMLElement;
 
     if (target.hasAttribute('sbb-dialog-close') && !target.hasAttribute('disabled')) {
-      // Check if the target is a submit element within a form
+      // Check if the target is a submit element within a form and return the form, if present
       const closestForm =
         target.getAttribute('type') === 'submit'
           ? (hostContext('form', target) as HTMLFormElement)


### PR DESCRIPTION
Extend `sbb-dialog` with option to close dialog via `sbb-dialog-close` attribute.