### PR TITLE
refactor(sbb-menu): rename opening and closing methods

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -932,17 +932,17 @@ export namespace Components {
     }
     interface SbbMenu {
         /**
+          * Closes the menu.
+         */
+        "close": () => Promise<void>;
+        /**
           * Whether the animation is enabled.
          */
         "disableAnimation": boolean;
         /**
-          * Dismisses the menu.
-         */
-        "dismiss": () => Promise<void>;
-        /**
           * Opens the menu on trigger click.
          */
-        "present": () => Promise<void>;
+        "open": () => Promise<void>;
         /**
           * The element that will trigger the menu dialog. Accepts both a string (id of an element) or an HTML element.
          */
@@ -2935,21 +2935,21 @@ declare namespace LocalJSX {
          */
         "disableAnimation"?: boolean;
         /**
-          * Emits whenever the menu is dismissed.
+          * Emits whenever the menu is closed.
          */
-        "onSbb-menu_did-dismiss"?: (event: SbbMenuCustomEvent<void>) => void;
+        "onSbb-menu_did-close"?: (event: SbbMenuCustomEvent<void>) => void;
         /**
-          * Emits whenever the menu is presented.
+          * Emits whenever the menu is opened.
          */
-        "onSbb-menu_did-present"?: (event: SbbMenuCustomEvent<void>) => void;
+        "onSbb-menu_did-open"?: (event: SbbMenuCustomEvent<void>) => void;
         /**
           * Emits whenever the menu begins the closing transition.
          */
-        "onSbb-menu_will-dismiss"?: (event: SbbMenuCustomEvent<void>) => void;
+        "onSbb-menu_will-close"?: (event: SbbMenuCustomEvent<void>) => void;
         /**
-          * Emits whenever the menu starts the presenting transition.
+          * Emits whenever the menu starts the opening transition.
          */
-        "onSbb-menu_will-present"?: (event: SbbMenuCustomEvent<void>) => void;
+        "onSbb-menu_will-open"?: (event: SbbMenuCustomEvent<void>) => void;
         /**
           * The element that will trigger the menu dialog. Accepts both a string (id of an element) or an HTML element.
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1511,13 +1511,13 @@ export namespace Components {
          */
         "close": (target?: HTMLElement) => Promise<void>;
         /**
+          * Close the tooltip after a certain delay.
+         */
+        "closeDelay"?: number;
+        /**
           * Whether the animation is enabled.
          */
         "disableAnimation": boolean;
-        /**
-          * Close the tooltip after a certain delay.
-         */
-        "hideDelay"?: number;
         /**
           * Whether the tooltip should be triggered on hover.
          */
@@ -1529,7 +1529,7 @@ export namespace Components {
         /**
           * Open the tooltip after a certain delay.
          */
-        "showDelay"?: number;
+        "openDelay"?: number;
         /**
           * The element that will trigger the tooltip dialog. Accepts both a string (id of an element) or an HTML element.
          */
@@ -3507,13 +3507,13 @@ declare namespace LocalJSX {
          */
         "accessibilityCloseLabel"?: string | undefined;
         /**
+          * Close the tooltip after a certain delay.
+         */
+        "closeDelay"?: number;
+        /**
           * Whether the animation is enabled.
          */
         "disableAnimation"?: boolean;
-        /**
-          * Close the tooltip after a certain delay.
-         */
-        "hideDelay"?: number;
         /**
           * Whether the tooltip should be triggered on hover.
          */
@@ -3537,7 +3537,7 @@ declare namespace LocalJSX {
         /**
           * Open the tooltip after a certain delay.
          */
-        "showDelay"?: number;
+        "openDelay"?: number;
         /**
           * The element that will trigger the tooltip dialog. Accepts both a string (id of an element) or an HTML element.
          */

--- a/src/components/sbb-menu/readme.md
+++ b/src/components/sbb-menu/readme.md
@@ -9,7 +9,7 @@ by evaluating the available space with the following priority: start/below, star
 
 ## Usage
 
-The menu component allows you to present a custom menu that allows you to perform actions relevant to the current task 
+The menu component allows you to open a custom menu that allows you to perform actions relevant to the current task 
 or to navigate within or outside the application by using the `sbb-menu-action` component along with it as shown below:
 
 ```html
@@ -65,19 +65,19 @@ As the menu opens, the focus will automatically be set to the first focusable it
 
 ## Events
 
-| Event                   | Description                                               | Type                |
-| ----------------------- | --------------------------------------------------------- | ------------------- |
-| `sbb-menu_did-dismiss`  | Emits whenever the menu is dismissed.                     | `CustomEvent<void>` |
-| `sbb-menu_did-present`  | Emits whenever the menu is presented.                     | `CustomEvent<void>` |
-| `sbb-menu_will-dismiss` | Emits whenever the menu begins the closing transition.    | `CustomEvent<void>` |
-| `sbb-menu_will-present` | Emits whenever the menu starts the presenting transition. | `CustomEvent<void>` |
+| Event                 | Description                                            | Type                |
+| --------------------- | ------------------------------------------------------ | ------------------- |
+| `sbb-menu_did-close`  | Emits whenever the menu is closed.                     | `CustomEvent<void>` |
+| `sbb-menu_did-open`   | Emits whenever the menu is opened.                     | `CustomEvent<void>` |
+| `sbb-menu_will-close` | Emits whenever the menu begins the closing transition. | `CustomEvent<void>` |
+| `sbb-menu_will-open`  | Emits whenever the menu starts the opening transition. | `CustomEvent<void>` |
 
 
 ## Methods
 
-### `dismiss() => Promise<void>`
+### `close() => Promise<void>`
 
-Dismisses the menu.
+Closes the menu.
 
 #### Returns
 
@@ -85,7 +85,7 @@ Type: `Promise<void>`
 
 
 
-### `present() => Promise<void>`
+### `open() => Promise<void>`
 
 Opens the menu on trigger click.
 

--- a/src/components/sbb-menu/sbb-menu.e2e.ts
+++ b/src/components/sbb-menu/sbb-menu.e2e.ts
@@ -27,8 +27,8 @@ describe('sbb-menu', () => {
 
   it('opens on trigger click', async () => {
     const dialog = await page.find('sbb-menu >>> dialog');
-    const willOpenEventSpy = await page.spyOnEvent(events.willPresent);
-    const didOpenEventSpy = await page.spyOnEvent(events.didPresent);
+    const willOpenEventSpy = await page.spyOnEvent(events.willOpen);
+    const didOpenEventSpy = await page.spyOnEvent(events.didOpen);
 
     await trigger.click();
     await page.waitForChanges();
@@ -55,8 +55,8 @@ describe('sbb-menu', () => {
   });
 
   it('closes on menu action click', async () => {
-    const willCloseEventSpy = await page.spyOnEvent(events.willDismiss);
-    const didCloseEventSpy = await page.spyOnEvent(events.didDismiss);
+    const willCloseEventSpy = await page.spyOnEvent(events.willClose);
+    const didCloseEventSpy = await page.spyOnEvent(events.didClose);
     const dialog = await page.find('sbb-menu >>> dialog');
     const menuAction = await page.find('sbb-menu > sbb-menu-action');
 
@@ -77,8 +77,8 @@ describe('sbb-menu', () => {
   });
 
   it('closes on interactive element click', async () => {
-    const willCloseEventSpy = await page.spyOnEvent(events.willDismiss);
-    const didCloseEventSpy = await page.spyOnEvent(events.didDismiss);
+    const willCloseEventSpy = await page.spyOnEvent(events.willClose);
+    const didCloseEventSpy = await page.spyOnEvent(events.didClose);
     const dialog = await page.find('sbb-menu >>> dialog');
     const menuLink = await page.find('sbb-menu > sbb-link');
 

--- a/src/components/sbb-menu/sbb-menu.events.ts
+++ b/src/components/sbb-menu/sbb-menu.events.ts
@@ -3,8 +3,8 @@
  * See stencil.config.ts in the root directory.
  */
 export default {
-  didDismiss: 'sbb-menu_did-dismiss',
-  didPresent: 'sbb-menu_did-present',
-  willDismiss: 'sbb-menu_will-dismiss',
-  willPresent: 'sbb-menu_will-present',
+  didClose: 'sbb-menu_did-close',
+  didOpen: 'sbb-menu_did-open',
+  willClose: 'sbb-menu_will-close',
+  willOpen: 'sbb-menu_will-open',
 };

--- a/src/components/sbb-menu/sbb-menu.scss
+++ b/src/components/sbb-menu/sbb-menu.scss
@@ -46,8 +46,8 @@
   }
 }
 
-:host(.sbb-menu--presented),
-:host(.sbb-menu--presenting) {
+:host(.sbb-menu--opened),
+:host(.sbb-menu--opening) {
   --sbb-menu-backdrop-color: var(--sbb-color-black-alpha-20);
 
   @include mq($from: medium) {
@@ -108,7 +108,7 @@
     }
   }
 
-  &.sbb-menu--dismissing {
+  &.sbb-menu--closing {
     pointer-events: none;
     animation-name: hide;
   }

--- a/src/components/sbb-menu/sbb-menu.scss
+++ b/src/components/sbb-menu/sbb-menu.scss
@@ -102,7 +102,7 @@
     opacity: 1;
     pointer-events: all;
     animation: {
-      name: show;
+      name: open;
       duration: var(--sbb-menu-animation-duration);
       timing-function: var(--sbb-menu-animation-easing);
     }
@@ -110,7 +110,7 @@
 
   :host(.sbb-menu--closing) & {
     pointer-events: none;
-    animation-name: hide;
+    animation-name: close;
   }
 
   @include ifForcedColors {
@@ -163,7 +163,7 @@
   }
 }
 
-@keyframes show {
+@keyframes open {
   from {
     visibility: hidden;
     opacity: 0;
@@ -177,7 +177,7 @@
   }
 }
 
-@keyframes hide {
+@keyframes close {
   from {
     visibility: visible;
     opacity: 1;

--- a/src/components/sbb-menu/sbb-menu.scss
+++ b/src/components/sbb-menu/sbb-menu.scss
@@ -108,7 +108,7 @@
     }
   }
 
-  &.sbb-menu--closing {
+  :host(.sbb-menu--closing) & {
     pointer-events: none;
     animation-name: hide;
   }

--- a/src/components/sbb-menu/sbb-menu.stories.js
+++ b/src/components/sbb-menu/sbb-menu.stories.js
@@ -230,7 +230,7 @@ export default {
   ],
   parameters: {
     actions: {
-      handles: [events.willPresent, events.didPresent, events.didDismiss, events.willDismiss],
+      handles: [events.willOpen, events.didOpen, events.didClose, events.willClose],
     },
     backgrounds: {
       disable: true,

--- a/src/components/sbb-menu/sbb-menu.tsx
+++ b/src/components/sbb-menu/sbb-menu.tsx
@@ -251,13 +251,13 @@ export class SbbMenu implements ComponentInterface {
   // Set menu position (x, y) to '0' once the menu is closed and the transition ended to prevent the
   // viewport from overflowing. And set the focus to the first focusable element once the menu is open.
   private _onMenuAnimationEnd(event: AnimationEvent): void {
-    if (event.animationName === 'show') {
+    if (event.animationName === 'open') {
       this._state = 'opened';
       this.didOpen.emit();
       this._setDialogFocus();
       this._focusTrap.trap(this._element);
       this._attachWindowEvents();
-    } else if (event.animationName === 'hide') {
+    } else if (event.animationName === 'close') {
       this._state = 'closed';
       this._dialog.firstElementChild.scrollTo(0, 0);
       this._dialog.close();

--- a/src/components/sbb-menu/sbb-menu.tsx
+++ b/src/components/sbb-menu/sbb-menu.tsx
@@ -41,7 +41,7 @@ export class SbbMenu implements ComponentInterface {
   @Prop({ reflect: true }) public disableAnimation = false;
 
   /**
-   * The state of the tooltip.
+   * The state of the menu.
    */
   @State() private _state: 'closed' | 'opening' | 'opened' | 'closing' = 'closed';
 

--- a/src/components/sbb-tooltip/readme.md
+++ b/src/components/sbb-tooltip/readme.md
@@ -20,14 +20,14 @@ The tooltip can show a simple message and a close button (if the `hover-trigger`
 
 The tooltip can be disimissed by clicking on an interactive element within its content, by clicking on the close button or by performing another action on the page. You can also indicate that an element within the tooltip content should close the tooltip when clicked by marking it with the `sbb-tooltip-close` attribute.
 
-You can also indicate that the tooltip should be shown on hover with the property `hover-trigger` and set a custom delay for the show and hide animations (defaults to 1000ms). If hover is not supported by the current device, the component will be triggered on click/tap as default:
+You can also indicate that the tooltip should be shown on hover with the property `hover-trigger` and set a custom delay for the open and close animations (defaults to 0). If hover is not supported by the current device, the component will be triggered on click/tap as default:
 
 ```html
 <!-- Trigger element -->
 <sbb-icon id="tooltip-trigger" name="circle-information-small"/>
 
 <!-- Tooltip component with `hover-trigger` property -->
-<sbb-tooltip id="tooltip" trigger="tooltip-trigger" hover-trigger show-delay="500" hide-delay="750">
+<sbb-tooltip id="tooltip" trigger="tooltip-trigger" hover-trigger open-delay="500" close-delay="750">
   <p id="tooltip-content">
     Tooltip content. <sbb-link id="tooltip-link" variant="inline">Link</sbb-link>
   </p>
@@ -56,7 +56,7 @@ In order to make screen readers announce the tooltip content when the trigger is
 <button id="tooltip-trigger" aria-describedby="tooltip-content">Button with tooltip</button>
 
 <!-- Tooltip component with `hover-trigger` property -->
-<sbb-tooltip id="tooltip" trigger="tooltip-trigger" hover-trigger show-delay="500" hide-delay="750">
+<sbb-tooltip id="tooltip" trigger="tooltip-trigger" hover-trigger open-delay="500" close-delay="750">
   <p id="tooltip-content">
     Tooltip content. <sbb-link id="tooltip-link" variant="inline">Link</sbb-link>
   </p>
@@ -73,10 +73,10 @@ As the tooltip opens, the focus will automatically be set to the first focusable
 | Property                  | Attribute                   | Description                                                                                                    | Type                    | Default     |
 | ------------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------- | ----------- |
 | `accessibilityCloseLabel` | `accessibility-close-label` | This will be forwarded as aria-label to the close button element.                                              | `string`                | `undefined` |
+| `closeDelay`              | `close-delay`               | Close the tooltip after a certain delay.                                                                       | `number`                | `0`         |
 | `disableAnimation`        | `disable-animation`         | Whether the animation is enabled.                                                                              | `boolean`               | `false`     |
-| `hideDelay`               | `hide-delay`                | Close the tooltip after a certain delay.                                                                       | `number`                | `0`         |
 | `hoverTrigger`            | `hover-trigger`             | Whether the tooltip should be triggered on hover.                                                              | `boolean`               | `false`     |
-| `showDelay`               | `show-delay`                | Open the tooltip after a certain delay.                                                                        | `number`                | `0`         |
+| `openDelay`               | `open-delay`                | Open the tooltip after a certain delay.                                                                        | `number`                | `0`         |
 | `trigger`                 | `trigger`                   | The element that will trigger the tooltip dialog. Accepts both a string (id of an element) or an HTML element. | `HTMLElement \| string` | `undefined` |
 
 

--- a/src/components/sbb-tooltip/sbb-tooltip.scss
+++ b/src/components/sbb-tooltip/sbb-tooltip.scss
@@ -62,7 +62,7 @@
 
   &[open] {
     animation: {
-      name: show;
+      name: open;
       duration: var(--sbb-tooltip-animation-duration);
       timing-function: var(--sbb-tooltip-animation-easing);
     }
@@ -81,7 +81,7 @@
 
   :host(.sbb-tooltip--closing) & {
     pointer-events: none;
-    animation-name: hide;
+    animation-name: close;
   }
 
   :host(.sbb-tooltip--above) & {
@@ -111,7 +111,7 @@
   }
 }
 
-@keyframes show {
+@keyframes open {
   from {
     visibility: hidden;
     opacity: 0;
@@ -125,7 +125,7 @@
   }
 }
 
-@keyframes hide {
+@keyframes close {
   from {
     visibility: visible;
     opacity: 1;

--- a/src/components/sbb-tooltip/sbb-tooltip.stories.js
+++ b/src/components/sbb-tooltip/sbb-tooltip.stories.js
@@ -26,13 +26,13 @@ const hoverTrigger = {
   },
 };
 
-const showDelay = {
+const openDelay = {
   control: {
     type: 'number',
   },
 };
 
-const hideDelay = {
+const closeDelay = {
   control: {
     type: 'number',
   },
@@ -46,15 +46,15 @@ const disableAnimation = {
 
 const defaultArgTypes = {
   'hover-trigger': hoverTrigger,
-  'show-delay': showDelay,
-  'hide-delay': hideDelay,
+  'open-delay': openDelay,
+  'close-delay': closeDelay,
   'disable-animation': disableAnimation,
 };
 
 const defaultArgs = {
   'hover-trigger': false,
-  'show-delay': undefined,
-  'hide-delay': undefined,
+  'open-delay': undefined,
+  'close-delay': undefined,
   'disable-animation': isChromatic(),
 };
 
@@ -160,8 +160,8 @@ HoverTrigger.argTypes = defaultArgTypes;
 HoverTrigger.args = {
   ...defaultArgs,
   'hover-trigger': true,
-  'show-delay': 0,
-  'hide-delay': 0,
+  'open-delay': 0,
+  'close-delay': 0,
 };
 HoverTrigger.documentation = { title: 'Hover Trigger' };
 HoverTrigger.play = playStory;

--- a/src/components/sbb-tooltip/sbb-tooltip.tsx
+++ b/src/components/sbb-tooltip/sbb-tooltip.tsx
@@ -43,12 +43,12 @@ export class SbbTooltip implements ComponentInterface {
   /**
    * Open the tooltip after a certain delay.
    */
-  @Prop() public showDelay? = 0;
+  @Prop() public openDelay? = 0;
 
   /**
    * Close the tooltip after a certain delay.
    */
-  @Prop() public hideDelay? = 0;
+  @Prop() public closeDelay? = 0;
 
   /**
    * Whether the animation is enabled.
@@ -304,7 +304,7 @@ export class SbbTooltip implements ComponentInterface {
 
   private _onTriggerMouseEnter = (): void => {
     if (this._state === 'closed' || this._state === 'closing') {
-      this._openTimeout = setTimeout(() => this.open(), this.showDelay);
+      this._openTimeout = setTimeout(() => this.open(), this.openDelay);
     } else {
       clearTimeout(this._closeTimeout);
     }
@@ -312,7 +312,7 @@ export class SbbTooltip implements ComponentInterface {
 
   private _onTriggerMouseLeave = (): void => {
     if (this._state === 'opened' || this._state === 'opening') {
-      this._closeTimeout = setTimeout(() => this.close(), this.hideDelay);
+      this._closeTimeout = setTimeout(() => this.close(), this.closeDelay);
     } else {
       clearTimeout(this._openTimeout);
     }
@@ -326,20 +326,20 @@ export class SbbTooltip implements ComponentInterface {
 
   private _onDialogMouseLeave = (): void => {
     if (this._state !== 'opening') {
-      this._closeTimeout = setTimeout(() => this.close(), this.hideDelay);
+      this._closeTimeout = setTimeout(() => this.close(), this.closeDelay);
     }
   };
 
   // Set tooltip position (x, y) to '0' once the tooltip is closed and the transition ended to prevent the
   // viewport from overflowing. And set the focus to the first focusable element once the tooltip is open.
   private _onTooltipAnimationEnd(event: AnimationEvent): void {
-    if (event.animationName === 'show' && this._state === 'opening') {
+    if (event.animationName === 'open' && this._state === 'opening') {
       this._state = 'opened';
       this.didOpen.emit();
       this._setTooltipFocus();
       this._focusTrap.trap(this._element);
       this._attachWindowEvents();
-    } else if (event.animationName === 'hide' && this._state === 'closing') {
+    } else if (event.animationName === 'close' && this._state === 'closing') {
       this._state = 'closed';
       this._dialog.firstElementChild.scrollTo(0, 0);
       this._dialog.close();


### PR DESCRIPTION
**BREAKING CHANGE:** 
Use `open` for opening overlays and `close` for closing overlays. The methods `present()` and `dismiss()` become `open()` and `close()`; the tooltip properties `showDelay` and `hideDelay` become `openDelay` and `closeDelay`.