### PR TITLE
feat(sbb-icon): add pictogram namespace

### DIFF
--- a/src/components/sbb-icon/readme.md
+++ b/src/components/sbb-icon/readme.md
@@ -2,7 +2,7 @@ The `sbb-icon` component provides a solid way of rendering registered and named 
 The component will dynamically load an SVG for each icon, avoiding multiple requests to the same icon. 
 The icon components are not tied to specific icon sets; you can register a new SVG icon or a custom namespace 
 and then provide the `sbb-icon` with the `name` property in the format `name="icon-name"` or `name="namespace:icon-name"`. 
-Note that if you do not provide a namespace, the default namespace "sbb" will be used 
+Note that if you do not provide a namespace, the default namespace will be used 
 pointing to the [SBB Icons CDN](https://lyne-icons.netlify.app/). 
 
 ## Usage
@@ -10,7 +10,7 @@ pointing to the [SBB Icons CDN](https://lyne-icons.netlify.app/).
 The example below shows how to render an icon named `app-icon-medium` that points to the default SBB Icons CDN:
 
 ```html
-<!-- Will use "sbb" as the default namespace -->
+<!-- Will use the default namespace -->
 <sbb-icon name="app-icon-medium"></sbb-icon>
 ```
 

--- a/src/components/sbb-icon/request.ts
+++ b/src/components/sbb-icon/request.ts
@@ -2,7 +2,7 @@ import { validateContent } from './validate';
 
 const iconCdn = 'https://d1s1onrtynjaa8.cloudfront.net/';
 export const iconNamespaces = new Map<string, string>()
-  .set('sbb', `${iconCdn}icons/`)
+  .set('default', `${iconCdn}icons/`)
   .set('picto', `${iconCdn}pictograms/`);
 export const registeredIcons = new Map<string, string>();
 const requests = new Map<string, Promise<any>>();

--- a/src/components/sbb-icon/request.ts
+++ b/src/components/sbb-icon/request.ts
@@ -1,8 +1,9 @@
 import { validateContent } from './validate';
 
-export const iconNamespaces = new Map<string, string>([
-  ['sbb', 'https://d1s1onrtynjaa8.cloudfront.net/icons/'],
-]);
+const iconCdn = 'https://d1s1onrtynjaa8.cloudfront.net/';
+export const iconNamespaces = new Map<string, string>()
+  .set('sbb', `${iconCdn}icons/`)
+  .set('picto', `${iconCdn}pictograms/`);
 export const registeredIcons = new Map<string, string>();
 const requests = new Map<string, Promise<any>>();
 

--- a/src/components/sbb-icon/sbb-icon.tsx
+++ b/src/components/sbb-icon/sbb-icon.tsx
@@ -9,7 +9,7 @@ import { validateContent } from './validate';
 })
 export class SbbIcon {
   private _svgName: string;
-  private _svgNamespace = 'sbb';
+  private _svgNamespace = 'default';
 
   @Element() private _element!: HTMLElement;
 


### PR DESCRIPTION
This PR will allow the namespace `picto` to retrieve pictograms (e.g. `<sbb-icon name="picto:feuerloescher"></sbb-icon>`).
