### PR TITLE
feat: remove event name prefixes

### DIFF
--- a/convenience/generate-component/boilerplate/component.events.ts
+++ b/convenience/generate-component/boilerplate/component.events.ts
@@ -1,3 +1,3 @@
 export default {
-  click: '__name___click',
+  click: 'click',
 };

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -2338,15 +2338,15 @@ declare namespace LocalJSX {
         /**
           * Emits when the fade in animation ends and the button is displayed.
          */
-        "onSbb-alert_did-present"?: (event: SbbAlertCustomEvent<void>) => void;
+        "onDid-present"?: (event: SbbAlertCustomEvent<void>) => void;
         /**
           * Emits when dismissal of an alert was requested.
          */
-        "onSbb-alert_dismissal-requested"?: (event: SbbAlertCustomEvent<void>) => void;
+        "onDismissal-requested"?: (event: SbbAlertCustomEvent<void>) => void;
         /**
           * Emits when the fade in animation starts.
          */
-        "onSbb-alert_will-present"?: (event: SbbAlertCustomEvent<void>) => void;
+        "onWill-present"?: (event: SbbAlertCustomEvent<void>) => void;
         /**
           * Whether the alert is readonly. In readonly mode, there is no dismiss button offered to the user.
          */
@@ -2384,11 +2384,11 @@ declare namespace LocalJSX {
         /**
           * Emits when an alert was removed from DOM.
          */
-        "onSbb-alert-group_did-dismiss-alert"?: (event: SbbAlertGroupCustomEvent<HTMLSbbAlertElement>) => void;
+        "onDid-dismiss-alert"?: (event: SbbAlertGroupCustomEvent<HTMLSbbAlertElement>) => void;
         /**
           * Emits when `sbb-alert-group` becomes empty.
          */
-        "onSbb-alert-group_empty"?: (event: SbbAlertGroupCustomEvent<void>) => void;
+        "onEmpty"?: (event: SbbAlertGroupCustomEvent<void>) => void;
         /**
           * The role attribute defines how to announce alerts to the user.  'status': sets aria-live to polite and aria-atomic to true. 'alert': sets aria-live to assertive and aria-atomic to true.
          */
@@ -2820,23 +2820,23 @@ declare namespace LocalJSX {
         /**
           * Emits whenever the dialog is closed.
          */
-        "onSbb-dialog_did-close"?: (event: SbbDialogCustomEvent<any>) => void;
+        "onDid-close"?: (event: SbbDialogCustomEvent<any>) => void;
         /**
           * Emits whenever the dialog is opened.
          */
-        "onSbb-dialog_did-open"?: (event: SbbDialogCustomEvent<void>) => void;
+        "onDid-open"?: (event: SbbDialogCustomEvent<void>) => void;
         /**
           * Emits whenever the back button is clicked.
          */
-        "onSbb-dialog_request-back-action"?: (event: SbbDialogCustomEvent<void>) => void;
+        "onRequest-back-action"?: (event: SbbDialogCustomEvent<void>) => void;
         /**
           * Emits whenever the dialog begins the closing transition.
          */
-        "onSbb-dialog_will-close"?: (event: SbbDialogCustomEvent<any>) => void;
+        "onWill-close"?: (event: SbbDialogCustomEvent<any>) => void;
         /**
           * Emits whenever the dialog starts the opening transition.
          */
-        "onSbb-dialog_will-open"?: (event: SbbDialogCustomEvent<void>) => void;
+        "onWill-open"?: (event: SbbDialogCustomEvent<void>) => void;
         /**
           * Whether a back button is displayed next to the title.
          */
@@ -3247,19 +3247,19 @@ declare namespace LocalJSX {
         /**
           * Emits whenever the menu is closed.
          */
-        "onSbb-menu_did-close"?: (event: SbbMenuCustomEvent<void>) => void;
+        "onDid-close"?: (event: SbbMenuCustomEvent<void>) => void;
         /**
           * Emits whenever the menu is opened.
          */
-        "onSbb-menu_did-open"?: (event: SbbMenuCustomEvent<void>) => void;
+        "onDid-open"?: (event: SbbMenuCustomEvent<void>) => void;
         /**
           * Emits whenever the menu begins the closing transition.
          */
-        "onSbb-menu_will-close"?: (event: SbbMenuCustomEvent<void>) => void;
+        "onWill-close"?: (event: SbbMenuCustomEvent<void>) => void;
         /**
           * Emits whenever the menu starts the opening transition.
          */
-        "onSbb-menu_will-open"?: (event: SbbMenuCustomEvent<void>) => void;
+        "onWill-open"?: (event: SbbMenuCustomEvent<void>) => void;
         /**
           * The element that will trigger the menu dialog. Accepts both a string (id of an element) or an HTML element.
          */
@@ -3406,7 +3406,7 @@ declare namespace LocalJSX {
         /**
           * Emits whenever the radio group value changes.
          */
-        "onSbb-radio-button_did-select"?: (event: SbbRadioButtonCustomEvent<any>) => void;
+        "onDid-select"?: (event: SbbRadioButtonCustomEvent<any>) => void;
         /**
           * Id of the internal input element - default id will be set automatically.
          */
@@ -3590,7 +3590,7 @@ declare namespace LocalJSX {
         /**
           * Emits an event on selected tab change
          */
-        "onSbb-tab-group_did-change"?: (event: SbbTabGroupCustomEvent<void>) => void;
+        "onDid-change"?: (event: SbbTabGroupCustomEvent<void>) => void;
     }
     interface SbbTabTitle {
         /**
@@ -3790,7 +3790,7 @@ declare namespace LocalJSX {
         /**
           * This click event gets emitted when the user clicks on the component.
          */
-        "onSbb-timetable-row_click"?: (event: SbbTimetableRowCustomEvent<any>) => void;
+        "onClick"?: (event: SbbTimetableRowCustomEvent<any>) => void;
         /**
           * The price Prop, which consists of the data for the badge.
          */
@@ -3949,19 +3949,19 @@ declare namespace LocalJSX {
         /**
           * Emits whenever the tooltip is closed.
          */
-        "onSbb-tooltip_did-close"?: (event: SbbTooltipCustomEvent<{ closeTarget: HTMLElement }>) => void;
+        "onDid-close"?: (event: SbbTooltipCustomEvent<{ closeTarget: HTMLElement }>) => void;
         /**
           * Emits whenever the tooltip is opened.
          */
-        "onSbb-tooltip_did-open"?: (event: SbbTooltipCustomEvent<void>) => void;
+        "onDid-open"?: (event: SbbTooltipCustomEvent<void>) => void;
         /**
           * Emits whenever the tooltip begins the closing transition.
          */
-        "onSbb-tooltip_will-close"?: (event: SbbTooltipCustomEvent<{ closeTarget: HTMLElement }>) => void;
+        "onWill-close"?: (event: SbbTooltipCustomEvent<{ closeTarget: HTMLElement }>) => void;
         /**
           * Emits whenever the tooltip starts the opening transition.
          */
-        "onSbb-tooltip_will-open"?: (event: SbbTooltipCustomEvent<void>) => void;
+        "onWill-open"?: (event: SbbTooltipCustomEvent<void>) => void;
         /**
           * Open the tooltip after a certain delay.
          */

--- a/src/components/sbb-accordion-item/sbb-accordion-item.events.ts
+++ b/src/components/sbb-accordion-item/sbb-accordion-item.events.ts
@@ -1,6 +1,6 @@
 export default {
-  didClose: 'sbb-accordion-item_did-close',
-  didOpen: 'sbb-accordion-item_did-open',
-  willClose: 'sbb-accordion-item_will-close',
-  willOpen: 'sbb-accordion-item_will-open',
+  didClose: 'did-close',
+  didOpen: 'did-open',
+  willClose: 'will-close',
+  willOpen: 'will-open',
 };

--- a/src/components/sbb-alert-group/readme.md
+++ b/src/components/sbb-alert-group/readme.md
@@ -32,7 +32,7 @@ and therefore interrupts screen reader flow, to immediately read out the alert c
 in some combinations of screen readers and browsers not every part of the alert is fully read.**
 
 If all alerts are dismissed, it's recommended to completely remove the `sbb-alert-group` from DOM. 
-You can catch this moment by listening to `sbb-alert-group_empty` event and react accordingly.
+You can catch this moment by listening to `empty` event and react accordingly.
 
 
 <!-- Auto Generated Below -->
@@ -49,10 +49,10 @@ You can catch this moment by listening to `sbb-alert-group_empty` event and reac
 
 ## Events
 
-| Event                               | Description                                 | Type                               |
-| ----------------------------------- | ------------------------------------------- | ---------------------------------- |
-| `sbb-alert-group_did-dismiss-alert` | Emits when an alert was removed from DOM.   | `CustomEvent<HTMLSbbAlertElement>` |
-| `sbb-alert-group_empty`             | Emits when `sbb-alert-group` becomes empty. | `CustomEvent<void>`                |
+| Event               | Description                                 | Type                               |
+| ------------------- | ------------------------------------------- | ---------------------------------- |
+| `did-dismiss-alert` | Emits when an alert was removed from DOM.   | `CustomEvent<HTMLSbbAlertElement>` |
+| `empty`             | Emits when `sbb-alert-group` becomes empty. | `CustomEvent<void>`                |
 
 
 ## Slots

--- a/src/components/sbb-alert-group/sbb-alert-group.events.ts
+++ b/src/components/sbb-alert-group/sbb-alert-group.events.ts
@@ -3,6 +3,6 @@
  * See stencil.config.ts in the root directory.
  */
 export default {
-  didDismissAlert: 'sbb-alert-group_did-dismiss-alert',
-  empty: 'sbb-alert-group_empty',
+  didDismissAlert: 'did-dismiss-alert',
+  empty: 'empty',
 };

--- a/src/components/sbb-alert-group/sbb-alert-group.tsx
+++ b/src/components/sbb-alert-group/sbb-alert-group.tsx
@@ -46,20 +46,20 @@ export class SbbAlertGroup {
 
   /** Emits when an alert was removed from DOM. */
   @Event({
-    eventName: 'sbb-alert-group_did-dismiss-alert',
+    eventName: 'did-dismiss-alert',
   })
   public didDismissAlert: EventEmitter<HTMLSbbAlertElement>;
 
   /** Emits when `sbb-alert-group` becomes empty. */
   @Event({
-    eventName: 'sbb-alert-group_empty',
+    eventName: 'empty',
   })
   public empty: EventEmitter<void>;
 
   /**
    * @internal
    */
-  @Listen('sbb-alert_dismissal-requested')
+  @Listen('dismissal-requested')
   public removeAlert(event: Event): void {
     const target = event.target as HTMLSbbAlertElement;
     const hasFocusInsideAlertGroup = document.activeElement === target;

--- a/src/components/sbb-alert/readme.md
+++ b/src/components/sbb-alert/readme.md
@@ -81,11 +81,11 @@ Accessibility is mainly done by wrapping the alerts into the `sbb-alert-group`.
 
 ## Events
 
-| Event                           | Description                                                        | Type                |
-| ------------------------------- | ------------------------------------------------------------------ | ------------------- |
-| `sbb-alert_did-present`         | Emits when the fade in animation ends and the button is displayed. | `CustomEvent<void>` |
-| `sbb-alert_dismissal-requested` | Emits when dismissal of an alert was requested.                    | `CustomEvent<void>` |
-| `sbb-alert_will-present`        | Emits when the fade in animation starts.                           | `CustomEvent<void>` |
+| Event                 | Description                                                        | Type                |
+| --------------------- | ------------------------------------------------------------------ | ------------------- |
+| `did-present`         | Emits when the fade in animation ends and the button is displayed. | `CustomEvent<void>` |
+| `dismissal-requested` | Emits when dismissal of an alert was requested.                    | `CustomEvent<void>` |
+| `will-present`        | Emits when the fade in animation starts.                           | `CustomEvent<void>` |
 
 
 ## Methods

--- a/src/components/sbb-alert/sbb-alert.events.ts
+++ b/src/components/sbb-alert/sbb-alert.events.ts
@@ -3,7 +3,7 @@
  * See stencil.config.ts in the root directory.
  */
 export default {
-  didPresent: 'sbb-alert_did-present',
-  dismissalRequested: 'sbb-alert_dismissal-requested',
-  willPresent: 'sbb-alert_will-present',
+  didPresent: 'did-present',
+  dismissalRequested: 'dismissal-requested',
+  willPresent: 'will-present',
 };

--- a/src/components/sbb-alert/sbb-alert.tsx
+++ b/src/components/sbb-alert/sbb-alert.tsx
@@ -88,19 +88,19 @@ export class SbbAlert implements LinkProperties, ComponentInterface {
 
   /** Emits when the fade in animation starts. */
   @Event({
-    eventName: 'sbb-alert_will-present',
+    eventName: 'will-present',
   })
   public willPresent: EventEmitter<void>;
 
   /** Emits when the fade in animation ends and the button is displayed. */
   @Event({
-    eventName: 'sbb-alert_did-present',
+    eventName: 'did-present',
   })
   public didPresent: EventEmitter<void>;
 
   /** Emits when dismissal of an alert was requested. */
   @Event({
-    eventName: 'sbb-alert_dismissal-requested',
+    eventName: 'dismissal-requested',
   })
   public dismissalRequested: EventEmitter<void>;
 

--- a/src/components/sbb-autocomplete/sbb-autocomplete.events.ts
+++ b/src/components/sbb-autocomplete/sbb-autocomplete.events.ts
@@ -1,3 +1,3 @@
 export default {
-  selected: 'sbb-autocomplete_selected',
+  selected: 'selected',
 };

--- a/src/components/sbb-card-product/sbb-card-product.events.ts
+++ b/src/components/sbb-card-product/sbb-card-product.events.ts
@@ -1,3 +1,3 @@
 export default {
-  click: 'sbb-card-product_click',
+  click: 'click',
 };

--- a/src/components/sbb-card-product/sbb-card-product.stories.js
+++ b/src/components/sbb-card-product/sbb-card-product.stories.js
@@ -1,6 +1,7 @@
 import { SbbColorMilkDefault, SbbColorWhiteDefault } from '@sbb-esta/lyne-design-tokens';
 import { h } from 'jsx-dom';
 import readme from './readme.md';
+import events from './sbb-card-product.events';
 
 /* ************************************************* */
 /* Documentation platform container                  */
@@ -766,6 +767,9 @@ export default {
   parameters: {
     backgrounds: {
       disable: true,
+    },
+    actions: {
+      handles: [events.click],
     },
     docs: {
       extractComponentDescription: () => readme,

--- a/src/components/sbb-card-product/sbb-card-product.tsx
+++ b/src/components/sbb-card-product/sbb-card-product.tsx
@@ -215,7 +215,7 @@ export class SbbCardProduct implements AccessibilityProperties {
         ...additionalCardAttributes,
         'aria-haspopup': this.ariaHaspopup,
         name: this.name,
-        onClick: this._buttonClick,
+        onClick: this._buttonClick.bind(this),
         type: this.type,
         value: this.value,
       };

--- a/src/components/sbb-dialog/readme.md
+++ b/src/components/sbb-dialog/readme.md
@@ -30,12 +30,19 @@ In order to show a modal you need to call the `open(event?: PointerEvent)` metho
 </script>
 ```
 
-Note that it is necessary to pass the event object to the `open()` method to allow the dialog to detect whether it has been opened by click or keyboard, so that the focus can be better handled.
+Note that it is necessary to pass the event object to the `open()` method to allow the dialog to detect whether it has 
+been opened by click or keyboard, so that the focus can be better handled.
 
-To dismiss the dialog you need to get a reference to the `sbb-dialog` element and call the `close(result?: any, target?: HTMLElement)` method, which will close the dialog element and emit a close event with an optional result as a payload. You can also indicate that an element within the dialog content should close the dialog when clicked by marking it with the `sbb-dialog-close` attribute.
+To dismiss the dialog you need to get a reference to the `sbb-dialog` element and call 
+the `close(result?: any, target?: HTMLElement)` method, which will close the dialog element and emit a close event 
+with an optional result as a payload. You can also indicate that an element within the dialog content should close 
+the dialog when clicked by marking it with the `sbb-dialog-close` attribute.
 
 ### Usage notes
-The dialog title can be provided via the `titleContent` property and via slot `name="title"` (e.g. `<span slot="title">My dialog title</span>`). You can also set the property `titleBackButton` to display the back button in the title section (or content section, if title is omitted) which will emit the event `sbb-dialog_request-back-action` when clicked. 
+The dialog title can be provided via the `titleContent` property and via slot `name="title"` 
+(e.g. `<span slot="title">My dialog title</span>`). 
+You can also set the property `titleBackButton` to display the back button in the title section 
+(or content section, if title is omitted) which will emit the event `request-back-action` when clicked. 
 
 ```html
 // Title provided via property
@@ -52,10 +59,13 @@ The dialog title can be provided via the `titleContent` property and via slot `n
 </sbb-dialog>
 ```
 
-If the title is not provided, the dialog will be displayed in full-screen mode and the close button will be displayed in the content section along with the back button (if visible). Also note that if the title is not present, but the footer is provided, the footer will not be displayed.
+If the title is not provided, the dialog will be displayed in full-screen mode and the close button will be displayed 
+in the content section along with the back button (if visible). 
+Also note that if the title is not present, but the footer is provided, the footer will not be displayed.
 
 ## Accessibility
-The ARIA attributes `aria-labelledby` an `aria-describedby` can be set to improve accessibility. If `aria-labelledby` is empty, it will automatically be added with the `id` of the title element.
+The ARIA attributes `aria-labelledby` an `aria-describedby` can be set to improve accessibility. 
+If `aria-labelledby` is empty, it will automatically be added with the `id` of the title element.
 
 <!-- Auto Generated Below -->
 
@@ -80,13 +90,13 @@ The ARIA attributes `aria-labelledby` an `aria-describedby` can be set to improv
 
 ## Events
 
-| Event                            | Description                                              | Type                |
-| -------------------------------- | -------------------------------------------------------- | ------------------- |
-| `sbb-dialog_did-close`           | Emits whenever the dialog is closed.                     | `CustomEvent<any>`  |
-| `sbb-dialog_did-open`            | Emits whenever the dialog is opened.                     | `CustomEvent<void>` |
-| `sbb-dialog_request-back-action` | Emits whenever the back button is clicked.               | `CustomEvent<void>` |
-| `sbb-dialog_will-close`          | Emits whenever the dialog begins the closing transition. | `CustomEvent<any>`  |
-| `sbb-dialog_will-open`           | Emits whenever the dialog starts the opening transition. | `CustomEvent<void>` |
+| Event                 | Description                                              | Type                |
+| --------------------- | -------------------------------------------------------- | ------------------- |
+| `did-close`           | Emits whenever the dialog is closed.                     | `CustomEvent<any>`  |
+| `did-open`            | Emits whenever the dialog is opened.                     | `CustomEvent<void>` |
+| `request-back-action` | Emits whenever the back button is clicked.               | `CustomEvent<void>` |
+| `will-close`          | Emits whenever the dialog begins the closing transition. | `CustomEvent<any>`  |
+| `will-open`           | Emits whenever the dialog starts the opening transition. | `CustomEvent<void>` |
 
 
 ## Methods

--- a/src/components/sbb-dialog/sbb-dialog.events.ts
+++ b/src/components/sbb-dialog/sbb-dialog.events.ts
@@ -3,9 +3,9 @@
  * See stencil.config.ts in the root directory.
  */
 export default {
-  backClick: 'sbb-dialog_request-back-action',
-  didClose: 'sbb-dialog_did-close',
-  didOpen: 'sbb-dialog_did-open',
-  willClose: 'sbb-dialog_will-close',
-  willOpen: 'sbb-dialog_will-open',
+  backClick: 'request-back-action',
+  didClose: 'did-close',
+  didOpen: 'did-open',
+  willClose: 'will-close',
+  willOpen: 'will-open',
 };

--- a/src/components/sbb-dialog/sbb-dialog.stories.js
+++ b/src/components/sbb-dialog/sbb-dialog.stories.js
@@ -129,7 +129,7 @@ const openDialog = (event, id) => {
 };
 
 const onFormDialogClose = (dialog) => {
-  dialog.addEventListener('sbb-dialog_will-close', (event) => {
+  dialog.addEventListener('will-close', (event) => {
     if (event.detail) {
       document.getElementById(
         'returned-value-message'

--- a/src/components/sbb-dialog/sbb-dialog.tsx
+++ b/src/components/sbb-dialog/sbb-dialog.tsx
@@ -120,7 +120,7 @@ export class SbbDialog implements AccessibilityProperties {
   @Event({
     bubbles: true,
     composed: true,
-    eventName: 'sbb-dialog_will-open',
+    eventName: 'will-open',
   })
   public willOpen: EventEmitter<void>;
 
@@ -130,7 +130,7 @@ export class SbbDialog implements AccessibilityProperties {
   @Event({
     bubbles: true,
     composed: true,
-    eventName: 'sbb-dialog_did-open',
+    eventName: 'did-open',
   })
   public didOpen: EventEmitter<void>;
 
@@ -140,7 +140,7 @@ export class SbbDialog implements AccessibilityProperties {
   @Event({
     bubbles: true,
     composed: true,
-    eventName: 'sbb-dialog_will-close',
+    eventName: 'will-close',
   })
   public willClose: EventEmitter<any>;
 
@@ -150,7 +150,7 @@ export class SbbDialog implements AccessibilityProperties {
   @Event({
     bubbles: true,
     composed: true,
-    eventName: 'sbb-dialog_did-close',
+    eventName: 'did-close',
   })
   public didClose: EventEmitter<any>;
 
@@ -160,7 +160,7 @@ export class SbbDialog implements AccessibilityProperties {
   @Event({
     bubbles: true,
     composed: true,
-    eventName: 'sbb-dialog_request-back-action',
+    eventName: 'request-back-action',
   })
   public backClick: EventEmitter<void>;
 

--- a/src/components/sbb-menu/readme.md
+++ b/src/components/sbb-menu/readme.md
@@ -65,12 +65,12 @@ As the menu opens, the focus will automatically be set to the first focusable it
 
 ## Events
 
-| Event                 | Description                                            | Type                |
-| --------------------- | ------------------------------------------------------ | ------------------- |
-| `sbb-menu_did-close`  | Emits whenever the menu is closed.                     | `CustomEvent<void>` |
-| `sbb-menu_did-open`   | Emits whenever the menu is opened.                     | `CustomEvent<void>` |
-| `sbb-menu_will-close` | Emits whenever the menu begins the closing transition. | `CustomEvent<void>` |
-| `sbb-menu_will-open`  | Emits whenever the menu starts the opening transition. | `CustomEvent<void>` |
+| Event        | Description                                            | Type                |
+| ------------ | ------------------------------------------------------ | ------------------- |
+| `did-close`  | Emits whenever the menu is closed.                     | `CustomEvent<void>` |
+| `did-open`   | Emits whenever the menu is opened.                     | `CustomEvent<void>` |
+| `will-close` | Emits whenever the menu begins the closing transition. | `CustomEvent<void>` |
+| `will-open`  | Emits whenever the menu starts the opening transition. | `CustomEvent<void>` |
 
 
 ## Methods

--- a/src/components/sbb-menu/sbb-menu.events.ts
+++ b/src/components/sbb-menu/sbb-menu.events.ts
@@ -3,8 +3,8 @@
  * See stencil.config.ts in the root directory.
  */
 export default {
-  didClose: 'sbb-menu_did-close',
-  didOpen: 'sbb-menu_did-open',
-  willClose: 'sbb-menu_will-close',
-  willOpen: 'sbb-menu_will-open',
+  didClose: 'did-close',
+  didOpen: 'did-open',
+  willClose: 'will-close',
+  willOpen: 'will-open',
 };

--- a/src/components/sbb-menu/sbb-menu.tsx
+++ b/src/components/sbb-menu/sbb-menu.tsx
@@ -51,7 +51,7 @@ export class SbbMenu implements ComponentInterface {
   @Event({
     bubbles: true,
     composed: true,
-    eventName: 'sbb-menu_will-open',
+    eventName: 'will-open',
   })
   public willOpen: EventEmitter<void>;
 
@@ -61,7 +61,7 @@ export class SbbMenu implements ComponentInterface {
   @Event({
     bubbles: true,
     composed: true,
-    eventName: 'sbb-menu_did-open',
+    eventName: 'did-open',
   })
   public didOpen: EventEmitter<void>;
 
@@ -71,7 +71,7 @@ export class SbbMenu implements ComponentInterface {
   @Event({
     bubbles: true,
     composed: true,
-    eventName: 'sbb-menu_will-close',
+    eventName: 'will-close',
   })
   public willClose: EventEmitter<void>;
 
@@ -81,7 +81,7 @@ export class SbbMenu implements ComponentInterface {
   @Event({
     bubbles: true,
     composed: true,
-    eventName: 'sbb-menu_did-close',
+    eventName: 'did-close',
   })
   public didClose: EventEmitter<void>;
 

--- a/src/components/sbb-radio-button-group/readme.md
+++ b/src/components/sbb-radio-button-group/readme.md
@@ -1,10 +1,13 @@
 # sbb-radio-button-group
 
-Radio buttons should be used within a `sbb-radio-button-group`. Pressing a radio checks it and unchecks the previously selected radio, if any. They can also be controlled programmatically by setting the value property of the parent radio group to the value of the radio.
+Radio buttons should be used within a `sbb-radio-button-group`. 
+Pressing a radio checks it and unchecks the previously selected radio, if any. 
+They can also be controlled programmatically by setting the value property of the parent radio group to the value of the radio.
 
 ## Usage
 
-Within a group of radio buttons, only one radio button can be selected at a time. If you need to select more than one item, it is recommended to use checkboxes.
+Within a group of radio buttons, only one radio button can be selected at a time. 
+If you need to select more than one item, it is recommended to use checkboxes.
 
 ```html
 <!-- The first option will be selected by default -->
@@ -37,11 +40,12 @@ The radio group can have different states:
 
 ### Deselecting Radios
 
-In order to deselect a radio inside the group you can use the `allowEmptySelection` property on the parent radio group, which enables the radios to be deselected (by default, a selected cannot be deselected).
+In order to deselect a radio inside the group you can use the `allowEmptySelection` property on the parent radio group, 
+which enables the radios to be deselected (by default, a selected cannot be deselected).
 
 ### Accessibility
 
-In order to ensure readability for screen-readers, please provide an `aria-label` attribute for the `sbb-radio-buton-group`.
+In order to ensure readability for screen-readers, please provide an `aria-label` attribute for the `sbb-radio-button-group`.
 
 <!-- Auto Generated Below -->
 

--- a/src/components/sbb-radio-button-group/sbb-radio-button-group.tsx
+++ b/src/components/sbb-radio-button-group/sbb-radio-button-group.tsx
@@ -148,7 +148,7 @@ export class SbbRadioButtonGroup {
     this._namedSlots = queryNamedSlotState(this._element, this._namedSlots, event.detail);
   }
 
-  @Listen('sbb-radio-button_did-select', { passive: true })
+  @Listen('did-select', { passive: true })
   public onRadioButtonSelect(event: CustomEvent<string>): void {
     this.value = event.detail;
   }

--- a/src/components/sbb-radio-button/readme.md
+++ b/src/components/sbb-radio-button/readme.md
@@ -27,9 +27,9 @@ Use multiple `sbb-radio-button` components inside a `sbb-radio-button-group` com
 
 ## Events
 
-| Event                         | Description                                   | Type               |
-| ----------------------------- | --------------------------------------------- | ------------------ |
-| `sbb-radio-button_did-select` | Emits whenever the radio group value changes. | `CustomEvent<any>` |
+| Event        | Description                                   | Type               |
+| ------------ | --------------------------------------------- | ------------------ |
+| `did-select` | Emits whenever the radio group value changes. | `CustomEvent<any>` |
 
 
 ## Methods

--- a/src/components/sbb-radio-button/sbb-radio-button.events.ts
+++ b/src/components/sbb-radio-button/sbb-radio-button.events.ts
@@ -3,5 +3,5 @@
  * See stencil.config.ts in the root directory.
  */
 export default {
-  didSelect: 'sbb-radio-button_did-select',
+  didSelect: 'did-select',
 };

--- a/src/components/sbb-radio-button/sbb-radio-button.tsx
+++ b/src/components/sbb-radio-button/sbb-radio-button.tsx
@@ -82,7 +82,7 @@ export class SbbRadioButton {
   @Event({
     bubbles: true,
     composed: true,
-    eventName: 'sbb-radio-button_did-select',
+    eventName: 'did-select',
   })
   public didSelect: EventEmitter;
 

--- a/src/components/sbb-tab-group/readme.md
+++ b/src/components/sbb-tab-group/readme.md
@@ -1,18 +1,27 @@
-Tab groups are used to organize and gather tabs that the user can navigate through. Use tabs when you want to provide navigation within blocks of content, instead of showing everything in one place or requiring the user to navigate between several different views.
+Tab groups are used to organize and gather tabs that the user can navigate through. 
+Use tabs when you want to provide navigation within blocks of content, instead of showing everything 
+in one place or requiring the user to navigate between several different views.
 
 ## Usage
-In order to display a tab label within the tab bar, provide an `sbb-tab-title` right before the related tab content. The content element should be wrapped in a `div`, a `section` or an `article` and placed right after its relative tab title. Tab groups can also be nested, this means that a tab's content block can be represented by another `sbb-tab-group`, as shown in the "Nested Tab Groups" example.
+In order to display a tab label within the tab bar, provide an `sbb-tab-title` right before the related tab content. 
+The content element should be wrapped in a `div`, a `section` or an `article` and placed right after its relative tab title. 
+Tab groups can also be nested, this means that a tab's content block can be represented by another `sbb-tab-group`, 
+as shown in the "Nested Tab Groups" example.
 
-Each tab has a related content, distinct from other tabs' content. Tab panels can present different sections of content and include text, images, forms, other tab groups, etc.
+Each tab has a related content, distinct from other tabs' content. 
+Tab panels can present different sections of content and include text, images, forms, other tab groups, etc.
 
 ```html
 <sbb-tab-title>Tab Label</sbb-tab-title>
 <div>Tab content...</div>
 ```
 
-A tab can be selected, unselected, or disabled. Disable a tab to mark it as unavailable. Disabled tabs cannot be focused and may be invisible to assistive technologies such as screen readers.
+A tab can be selected, unselected, or disabled. Disable a tab to mark it as unavailable. 
+Disabled tabs cannot be focused and may be invisible to assistive technologies such as screen readers.
 
-Tab buttons can show an icon on the left side of the label; provide an `sbb-icon` component within the `sbb-tab-title` tag using the `slot="icon"` to include the icon. They can also show numbers on the right side of the label by providing an `sbb-tab-amount` within the `sbb-tab-title` tag.
+Tab buttons can show an icon on the left side of the label; provide an `sbb-icon` component 
+within the `sbb-tab-title` tag using the `slot="icon"` to include the icon. 
+They can also show numbers on the right side of the label by providing an `sbb-tab-amount` within the `sbb-tab-title` tag.
 
 ```html
 <!-- Icon - remember to use the 'small' version of the icon to make it fit correctly into the tab button -->
@@ -47,9 +56,9 @@ Tab buttons can show an icon on the left side of the label; provide an `sbb-icon
 
 ## Events
 
-| Event                      | Description                           | Type                |
-| -------------------------- | ------------------------------------- | ------------------- |
-| `sbb-tab-group_did-change` | Emits an event on selected tab change | `CustomEvent<void>` |
+| Event        | Description                           | Type                |
+| ------------ | ------------------------------------- | ------------------- |
+| `did-change` | Emits an event on selected tab change | `CustomEvent<void>` |
 
 
 ## Methods

--- a/src/components/sbb-tab-group/sbb-tab-group.e2e.ts
+++ b/src/components/sbb-tab-group/sbb-tab-group.e2e.ts
@@ -51,7 +51,7 @@ describe('sbb-tab-group', () => {
 
     it('dispatches event on tab change', async () => {
       const tab = await page.find('sbb-tab-group > sbb-tab-title#sbb-tab-1');
-      const changeSpy = await page.spyOnEvent('sbb-tab-group_did-change');
+      const changeSpy = await page.spyOnEvent('did-change');
 
       await tab.click();
       expect(changeSpy).toHaveReceivedEventTimes(1);

--- a/src/components/sbb-tab-group/sbb-tab-group.events.ts
+++ b/src/components/sbb-tab-group/sbb-tab-group.events.ts
@@ -3,5 +3,5 @@
  * See stencil.config.ts in the root directory.
  */
 export default {
-  selectedTabChanged: 'sbb-tab-group_did-change',
+  selectedTabChanged: 'did-change',
 };

--- a/src/components/sbb-tab-group/sbb-tab-group.tsx
+++ b/src/components/sbb-tab-group/sbb-tab-group.tsx
@@ -62,7 +62,7 @@ export class SbbTabGroup {
    * Emits an event on selected tab change
    */
   @Event({
-    eventName: 'sbb-tab-group_did-change',
+    eventName: 'did-change',
   })
   public selectedTabChanged: EventEmitter<void>;
 

--- a/src/components/sbb-timetable-button/sbb-timetable-button.events.ts
+++ b/src/components/sbb-timetable-button/sbb-timetable-button.events.ts
@@ -1,3 +1,3 @@
 export default {
-  click: 'sbb-timetable-button_click',
+  click: 'click',
 };

--- a/src/components/sbb-timetable-button/sbb-timetable-button.stories.js
+++ b/src/components/sbb-timetable-button/sbb-timetable-button.stories.js
@@ -2,7 +2,7 @@ import events from './sbb-timetable-button.events.ts';
 import { h } from 'jsx-dom';
 import readme from './readme.md';
 import cusHimSampleData from '../sbb-timetable-cus-him/sbb-timetable-cus-him.sample-data';
-import walkSampleData from '../sbb-timetable-transportation-walk//sbb-timetable-transportation-walk.sample-data';
+import walkSampleData from '../sbb-timetable-transportation-walk/sbb-timetable-transportation-walk.sample-data';
 
 const Template = (args) => <sbb-timetable-button {...args}></sbb-timetable-button>;
 

--- a/src/components/sbb-timetable-row/readme.md
+++ b/src/components/sbb-timetable-row/readme.md
@@ -1,5 +1,12 @@
+# sbb-timetable-row
 
-The `<sbb-timetable-row>` component displays a journey. The whole component is clickable and therefore emits a click-event. A Journey consists of various icons that display information about the means of transport, the occupancy in the first and second class, the most important warning for the trip and travel hints. Train changes are displayed in a pearl chain, which has the capability to show, if a connection is in the past, future or cancelled. In addition to that, the current position within the journey can be shown.
+The `<sbb-timetable-row>` component displays a journey. The whole component is clickable and therefore emits a click-event. 
+A Journey consists of various icons that display information about the means of transport, 
+the occupancy in the first and second class, the most important warning for the trip and travel hints. 
+Train changes are displayed in a pearl chain, which has the capability to show, 
+if a connection is in the past, future or cancelled. 
+In addition to that, the current position within the journey can be shown.
+
 ## Usage with props
 Example props:  priceProp: {price:'12', text: 'CHF', isDiscount: true} <br>
                 tripProp: {
@@ -45,9 +52,9 @@ This is helpful if you need a specific state of the component.
 
 ## Events
 
-| Event                     | Description                                                          | Type               |
-| ------------------------- | -------------------------------------------------------------------- | ------------------ |
-| `sbb-timetable-row_click` | This click event gets emitted when the user clicks on the component. | `CustomEvent<any>` |
+| Event   | Description                                                          | Type               |
+| ------- | -------------------------------------------------------------------- | ------------------ |
+| `click` | This click event gets emitted when the user clicks on the component. | `CustomEvent<any>` |
 
 
 ## Dependencies

--- a/src/components/sbb-timetable-row/sbb-timetable-row.events.ts
+++ b/src/components/sbb-timetable-row/sbb-timetable-row.events.ts
@@ -3,5 +3,5 @@
  * See stencil.config.ts in the root directory.
  */
 export default {
-  sbbClick: 'sbb-timetable-row_click',
+  click: 'click',
 };

--- a/src/components/sbb-timetable-row/sbb-timetable-row.spec.ts
+++ b/src/components/sbb-timetable-row/sbb-timetable-row.spec.ts
@@ -131,7 +131,7 @@ describe('sbb-timetable-row', () => {
       const element = page.root.shadowRoot.querySelector('sbb-card');
       const buttonSpy = jest.fn();
 
-      page.win.addEventListener('sbb-timetable-row_click', buttonSpy);
+      page.win.addEventListener('click', buttonSpy);
       element.click();
       await page.waitForChanges();
       expect(buttonSpy).toHaveBeenCalled();

--- a/src/components/sbb-timetable-row/sbb-timetable-row.stories.js
+++ b/src/components/sbb-timetable-row/sbb-timetable-row.stories.js
@@ -176,7 +176,7 @@ export default {
   ],
   parameters: {
     actions: {
-      handles: [events.sbbClick],
+      handles: [events.click],
     },
     docs: {
       extractComponentDescription: () => readme,

--- a/src/components/sbb-timetable-row/sbb-timetable-row.tsx
+++ b/src/components/sbb-timetable-row/sbb-timetable-row.tsx
@@ -47,9 +47,9 @@ export class SbbTimetableRow {
   @Event({
     bubbles: true,
     composed: true,
-    eventName: 'sbb-timetable-row_click',
+    eventName: 'click',
   })
-  public sbbClick: EventEmitter<any>;
+  public click: EventEmitter<any>;
 
   @Element() private _element: HTMLElement;
 
@@ -85,7 +85,7 @@ export class SbbTimetableRow {
   }
 
   private _clickHandler = (): void => {
-    this.sbbClick.emit({
+    this.click.emit({
       bubbles: true,
     });
   };

--- a/src/components/sbb-tooltip/readme.md
+++ b/src/components/sbb-tooltip/readme.md
@@ -82,12 +82,12 @@ As the tooltip opens, the focus will automatically be set to the first focusable
 
 ## Events
 
-| Event                    | Description                                               | Type                                         |
-| ------------------------ | --------------------------------------------------------- | -------------------------------------------- |
-| `sbb-tooltip_did-close`  | Emits whenever the tooltip is closed.                     | `CustomEvent<{ closeTarget: HTMLElement; }>` |
-| `sbb-tooltip_did-open`   | Emits whenever the tooltip is opened.                     | `CustomEvent<void>`                          |
-| `sbb-tooltip_will-close` | Emits whenever the tooltip begins the closing transition. | `CustomEvent<{ closeTarget: HTMLElement; }>` |
-| `sbb-tooltip_will-open`  | Emits whenever the tooltip starts the opening transition. | `CustomEvent<void>`                          |
+| Event        | Description                                               | Type                                         |
+| ------------ | --------------------------------------------------------- | -------------------------------------------- |
+| `did-close`  | Emits whenever the tooltip is closed.                     | `CustomEvent<{ closeTarget: HTMLElement; }>` |
+| `did-open`   | Emits whenever the tooltip is opened.                     | `CustomEvent<void>`                          |
+| `will-close` | Emits whenever the tooltip begins the closing transition. | `CustomEvent<{ closeTarget: HTMLElement; }>` |
+| `will-open`  | Emits whenever the tooltip starts the opening transition. | `CustomEvent<void>`                          |
 
 
 ## Methods

--- a/src/components/sbb-tooltip/sbb-tooltip.events.ts
+++ b/src/components/sbb-tooltip/sbb-tooltip.events.ts
@@ -3,8 +3,8 @@
  * See stencil.config.ts in the root directory.
  */
 export default {
-  didClose: 'sbb-tooltip_did-close',
-  didOpen: 'sbb-tooltip_did-open',
-  willClose: 'sbb-tooltip_will-close',
-  willOpen: 'sbb-tooltip_will-open',
+  didClose: 'did-close',
+  didOpen: 'did-open',
+  willClose: 'will-close',
+  willOpen: 'will-open',
 };

--- a/src/components/sbb-tooltip/sbb-tooltip.tsx
+++ b/src/components/sbb-tooltip/sbb-tooltip.tsx
@@ -76,7 +76,7 @@ export class SbbTooltip implements ComponentInterface {
   @Event({
     bubbles: true,
     composed: true,
-    eventName: 'sbb-tooltip_will-open',
+    eventName: 'will-open',
   })
   public willOpen: EventEmitter<void>;
 
@@ -86,7 +86,7 @@ export class SbbTooltip implements ComponentInterface {
   @Event({
     bubbles: true,
     composed: true,
-    eventName: 'sbb-tooltip_did-open',
+    eventName: 'did-open',
   })
   public didOpen: EventEmitter<void>;
 
@@ -96,7 +96,7 @@ export class SbbTooltip implements ComponentInterface {
   @Event({
     bubbles: true,
     composed: true,
-    eventName: 'sbb-tooltip_will-close',
+    eventName: 'will-close',
   })
   public willClose: EventEmitter<{ closeTarget: HTMLElement }>;
 
@@ -106,7 +106,7 @@ export class SbbTooltip implements ComponentInterface {
   @Event({
     bubbles: true,
     composed: true,
-    eventName: 'sbb-tooltip_did-close',
+    eventName: 'did-close',
   })
   public didClose: EventEmitter<{ closeTarget: HTMLElement }>;
 


### PR DESCRIPTION
## Preflight Checklist

<!-- Please ensure you've completed the following steps by replacing [ ] with [x]-->

- [x] I have read the [Contributing Guidelines](https://github.com/lyne-design-system/lyne-components/blob/master/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/lyne-design-system/lyne-components/blob/master/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [pull request tracker](https://github.com/lyne-design-system/lyne-components/pulls) for a Pull Request (PR) that matches the one I want to submit, without success.

## Issue

This PR Closes #1464 

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

See [Review Guidelines](../REVIEW.md) for more information what is checked during review process.

## Changes

Changes in this pull request:

- all the names of the custom events have been changed, removing the component prefix;
e.g. 'sbb-dialog_did-close' become 'did-close', and so on.

## Browsers

I tested the build on the following browsers:

- [ ] Firefox Desktop
- [ ] Chrome Desktop
- [ ] Edge Desktop
- [ ] Safari Desktop
- [ ] Chrome Mobile
- [ ] Safari Mobile

## Screen readers

I tested the build on the following browsers:

- [ ] JAWS Firefox Desktop
- [ ] JAWS Chrome Desktop
- [ ] NVDA Firefox Desktop
- [ ] NVDA Chrome Desktop
- [ ] VoiceOver Safari Desktop
- [ ] VoiceOver Chrome Desktop
- [ ] VoiceOver Safari Mobile
- [ ] Android Accessibility Suite Chrome Mobile

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

Consumers who use event listeners must modify them by removing the component prefix;
e.g. from 'onSbb-dialog_will-close' to 'onWill-close', from 'onSbb-radio-button_did-select' to 'onDid-select', and so on.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
