### PR TITLE
feat: add title margins

### DIFF
--- a/src/components/sbb-alert/sbb-alert.scss
+++ b/src/components/sbb-alert/sbb-alert.scss
@@ -77,7 +77,8 @@
 }
 
 .sbb-alert__title {
-  margin: 0; // Overwrite sbb-title default margin
+  // Overwrite sbb-title default margin
+  margin: 0;
 }
 
 .sbb-alert__close-button-wrapper {

--- a/src/components/sbb-alert/sbb-alert.scss
+++ b/src/components/sbb-alert/sbb-alert.scss
@@ -76,6 +76,10 @@
   flex: 1;
 }
 
+.sbb-alert__title {
+  margin: 0; // Overwrite sbb-title default margin
+}
+
 .sbb-alert__close-button-wrapper {
   display: flex;
   justify-content: flex-end;

--- a/src/components/sbb-alert/sbb-alert.spec.ts
+++ b/src/components/sbb-alert/sbb-alert.spec.ts
@@ -19,7 +19,7 @@ describe('sbb-alert', () => {
                   </slot>
                 </span>
                 <span class="sbb-alert__content">
-                  <sbb-title level="3" negative visual-level="5">
+                  <sbb-title class="sbb-alert__title" level="3" negative visual-level="5">
                     <slot name="title">Interruption</slot>
                   </sbb-title>
                   <slot></slot>
@@ -52,7 +52,7 @@ describe('sbb-alert', () => {
                   </slot>
                 </span>
                 <span class="sbb-alert__content">
-                  <sbb-title level="2" negative visual-level="3">
+                  <sbb-title class="sbb-alert__title" level="2" negative visual-level="3">
                     <slot name="title">Interruption</slot>
                   </sbb-title>
                   <slot></slot>

--- a/src/components/sbb-alert/sbb-alert.tsx
+++ b/src/components/sbb-alert/sbb-alert.tsx
@@ -191,6 +191,7 @@ export class SbbAlert implements ComponentInterface, LinkProperties {
           </span>
           <span class="sbb-alert__content">
             <sbb-title
+              class="sbb-alert__title"
               level={this.titleLevel}
               visual-level={this.size === 'l' ? '3' : '5'}
               negative

--- a/src/components/sbb-card-product/sbb-card-product.scss
+++ b/src/components/sbb-card-product/sbb-card-product.scss
@@ -145,5 +145,6 @@
 }
 
 ::slotted(sbb-title) {
-  margin: 0; // Overwrite sbb-title default margin
+  // Overwrite sbb-title default margin
+  margin: 0;
 }

--- a/src/components/sbb-card-product/sbb-card-product.scss
+++ b/src/components/sbb-card-product/sbb-card-product.scss
@@ -133,7 +133,7 @@
 }
 
 .card-product__lead {
-  @include sbb.title-6(true);
+  @include sbb.title-6($exclude-spacing: true);
 }
 
 .card-product__category,

--- a/src/components/sbb-card-product/sbb-card-product.scss
+++ b/src/components/sbb-card-product/sbb-card-product.scss
@@ -133,7 +133,7 @@
 }
 
 .card-product__lead {
-  @include sbb.title-6;
+  @include sbb.title-6(true);
 }
 
 .card-product__category,
@@ -142,4 +142,8 @@
 
   margin: 0;
   color: var(--sbb-color-granite-default);
+}
+
+::slotted(sbb-title) {
+  margin: 0; // Overwrite sbb-title default margin
 }

--- a/src/components/sbb-card-product/sbb-card-product.stories.js
+++ b/src/components/sbb-card-product/sbb-card-product.stories.js
@@ -228,7 +228,11 @@ const sbbTitleTravelCardHalfFareArgs = {
   'visual-level': 1,
 };
 
-const SlotSbbTitleTemplate = (args) => <sbb-title {...args}>{args.text}</sbb-title>;
+const SlotSbbTitleTemplate = (args) => (
+  <sbb-title {...args} style="margin: 0">
+    {args.text}
+  </sbb-title>
+);
 
 const sbbJourneyHeaderArgs = {
   destination: 'Loèche-les-Bains',
@@ -514,10 +518,7 @@ const TemplateTheWholeShabang = (args) => (
     <div slot="category">
       <SlotSbbCategoryTemplate {...sbbCategoryArgs} />
     </div>
-    <div
-      slot="title"
-      style="--sbb-title-margin-block-start-override: 0; --sbb-title-margin-block-end-override: 0;"
-    >
+    <div slot="title">
       <SlotSbbTitleTemplate {...sbbTitleTravelCardGAArgs} />
       <SlotSbbJourneyHeaderTemplate {...sbbJourneyHeaderArgs} />
     </div>

--- a/src/components/sbb-card-product/sbb-card-product.stories.js
+++ b/src/components/sbb-card-product/sbb-card-product.stories.js
@@ -382,9 +382,7 @@ const SlotActionTemplate = ({ label, ...args }) => <sbb-button {...args}>{label}
 const TemplateTopProductDayPass = (args) => (
   <sbb-card-product {...args}>
     <SlotIconTemplate {...iconArgs} />
-    <div slot="title">
-      <SlotSbbTitleTemplate {...sbbTitleDayPassArgs} />
-    </div>
+    <SlotSbbTitleTemplate slot="title" {...sbbTitleDayPassArgs} />
     <div slot="text">
       <SlotSbbTextTemplate {...sbbTextValidTodayArgs} />
     </div>
@@ -397,9 +395,7 @@ const TemplateTopProductDayPass = (args) => (
 const TemplateTopProductDayPassBicycle = (args) => (
   <sbb-card-product {...args}>
     <SlotIconTemplate {...iconBicycleArgs} />
-    <div slot="title">
-      <SlotSbbTitleTemplate {...sbbTitleDayPassBicycleArgs} />
-    </div>
+    <SlotSbbTitleTemplate slot="title" {...sbbTitleDayPassBicycleArgs} />
     <div slot="text">
       <SlotSbbTextTemplate {...sbbTextValidTodayArgs} />
     </div>
@@ -412,9 +408,7 @@ const TemplateTopProductDayPassBicycle = (args) => (
 const TemplateTopProductTravelCardPointToPoint = (args) => (
   <sbb-card-product {...args}>
     <SlotIconTemplate {...iconArgs} />
-    <div slot="title">
-      <SlotSbbTitleTemplate {...sbbTitleTravelCardPointToPointArgs} />
-    </div>
+    <SlotSbbTitleTemplate slot="title" {...sbbTitleTravelCardPointToPointArgs} />
     <div slot="text">
       <SlotSbbTextTemplate {...sbbTextTravelCardPointToPointArgs} />
     </div>
@@ -427,9 +421,7 @@ const TemplateTopProductTravelCardPointToPoint = (args) => (
 const TemplateYourProductPointToPointPersonalized = (args) => (
   <sbb-card-product {...args}>
     <SlotIconTemplate {...iconArgs} />
-    <div slot="title">
-      <SlotSbbJourneyHeaderTemplate {...sbbJourneyHeaderArgs} />
-    </div>
+    <SlotSbbJourneyHeaderTemplate {...sbbJourneyHeaderArgs} />
     <div slot="text">
       <SlotSbbTextTemplate {...sbbTextValidTodayArgs} />
     </div>
@@ -445,9 +437,7 @@ const TemplateYourProductTravelCardPersonalized = (args) => (
     <div slot="category">
       <SlotSbbCategoryTemplate {...sbbCategoryArgs} />
     </div>
-    <div slot="title">
-      <SlotSbbTitleTemplate {...sbbTitleTravelCardLiberoArgs} />
-    </div>
+    <SlotSbbTitleTemplate slot="title" {...sbbTitleTravelCardLiberoArgs} />
     <div slot="text">
       <SlotSbbTextTemplate {...sbbTextValidTodayLongArgs} />
     </div>
@@ -459,9 +449,7 @@ const TemplateYourProductTravelCardPersonalized = (args) => (
 
 const TemplateYourProductTicketPersonalized = (args) => (
   <sbb-card-product {...args}>
-    <div slot="title">
-      <SlotSbbJourneyHeaderTemplate {...sbbJourneyHeaderArgs} />
-    </div>
+    <SlotSbbJourneyHeaderTemplate {...sbbJourneyHeaderArgs} />
     <div slot="text">
       <SlotSbbTextTemplate {...sbbTextConnectionDetailsArgs} />
     </div>
@@ -476,9 +464,7 @@ const TemplateYourProductTicketPersonalized = (args) => (
 
 const TemplateTravelCardGA = (args) => (
   <sbb-card-product {...args}>
-    <div slot="title">
-      <SlotSbbTitleTemplate {...sbbTitleTravelCardGAArgs} />
-    </div>
+    <SlotSbbTitleTemplate slot="title" {...sbbTitleTravelCardGAArgs} />
     <div slot="lead">
       <SlotSbbLeadTemplate {...sbbLeadGALongArgs} />
     </div>
@@ -490,9 +476,7 @@ const TemplateTravelCardGA = (args) => (
 
 const TemplateTravelCardGAPersonalized = (args) => (
   <sbb-card-product {...args}>
-    <div slot="title">
-      <SlotSbbTitleTemplate {...sbbTitleTravelCardGAArgs} />
-    </div>
+    <SlotSbbTitleTemplate slot="title" {...sbbTitleTravelCardGAArgs} />
     <div slot="lead">
       <SlotSbbLeadTemplate {...sbbLeadGAArgs} />
     </div>
@@ -507,9 +491,7 @@ const TemplateTravelCardGAPersonalized = (args) => (
 
 const TemplateTravelCardHalfFarePersonalized = (args) => (
   <sbb-card-product {...args}>
-    <div slot="title">
-      <SlotSbbTitleTemplate {...sbbTitleTravelCardHalfFareArgs} />
-    </div>
+    <SlotSbbTitleTemplate slot="title" {...sbbTitleTravelCardHalfFareArgs} />
     <div slot="lead">
       <SlotSbbLeadTemplate {...sbbLeadHalfFareArgs} />
     </div>
@@ -524,9 +506,7 @@ const TemplateTravelCardHalfFarePersonalized = (args) => (
 
 const TemplateTravelCardHalfFare = (args) => (
   <sbb-card-product {...args}>
-    <div slot="title">
-      <SlotSbbTitleTemplate {...sbbTitleTravelCardHalfFareArgs} />
-    </div>
+    <SlotSbbTitleTemplate slot="title" {...sbbTitleTravelCardHalfFareArgs} />
     <div slot="lead">
       <SlotSbbLeadTemplate {...sbbLeadHalfFareLongArgs} />
     </div>
@@ -542,10 +522,8 @@ const TemplateTheWholeShabang = (args) => (
     <div slot="category">
       <SlotSbbCategoryTemplate {...sbbCategoryArgs} />
     </div>
-    <div slot="title">
-      <SlotSbbTitleTemplate {...sbbTitleTravelCardGAArgs} />
-      <SlotSbbJourneyHeaderTemplate {...sbbJourneyHeaderArgs} />
-    </div>
+    <SlotSbbTitleTemplate slot="title" {...sbbTitleTravelCardGAArgs} />
+    <SlotSbbJourneyHeaderTemplate {...sbbJourneyHeaderArgs} />
     <div slot="lead">
       <SlotSbbLeadTemplate {...sbbLeadGAArgs} />
     </div>

--- a/src/components/sbb-card-product/sbb-card-product.stories.js
+++ b/src/components/sbb-card-product/sbb-card-product.stories.js
@@ -421,7 +421,7 @@ const TemplateTopProductTravelCardPointToPoint = (args) => (
 const TemplateYourProductPointToPointPersonalized = (args) => (
   <sbb-card-product {...args}>
     <SlotIconTemplate {...iconArgs} />
-    <SlotSbbJourneyHeaderTemplate {...sbbJourneyHeaderArgs} />
+    <SlotSbbJourneyHeaderTemplate slot="title" {...sbbJourneyHeaderArgs} />
     <div slot="text">
       <SlotSbbTextTemplate {...sbbTextValidTodayArgs} />
     </div>
@@ -449,7 +449,7 @@ const TemplateYourProductTravelCardPersonalized = (args) => (
 
 const TemplateYourProductTicketPersonalized = (args) => (
   <sbb-card-product {...args}>
-    <SlotSbbJourneyHeaderTemplate {...sbbJourneyHeaderArgs} />
+    <SlotSbbJourneyHeaderTemplate slot="title" {...sbbJourneyHeaderArgs} />
     <div slot="text">
       <SlotSbbTextTemplate {...sbbTextConnectionDetailsArgs} />
     </div>
@@ -465,9 +465,7 @@ const TemplateYourProductTicketPersonalized = (args) => (
 const TemplateTravelCardGA = (args) => (
   <sbb-card-product {...args}>
     <SlotSbbTitleTemplate slot="title" {...sbbTitleTravelCardGAArgs} />
-    <div slot="lead">
-      <SlotSbbLeadTemplate {...sbbLeadGALongArgs} />
-    </div>
+    <SlotSbbLeadTemplate slot="lead" {...sbbLeadGALongArgs} />
     <div slot="action">
       <SlotActionTemplate {...actionGAArgs} />
     </div>
@@ -477,9 +475,7 @@ const TemplateTravelCardGA = (args) => (
 const TemplateTravelCardGAPersonalized = (args) => (
   <sbb-card-product {...args}>
     <SlotSbbTitleTemplate slot="title" {...sbbTitleTravelCardGAArgs} />
-    <div slot="lead">
-      <SlotSbbLeadTemplate {...sbbLeadGAArgs} />
-    </div>
+    <SlotSbbLeadTemplate slot="lead" {...sbbLeadGAArgs} />
     <div slot="text">
       <SlotSbbTextTemplate {...sbbTextTravelCardValidityArgs} />
     </div>
@@ -492,9 +488,7 @@ const TemplateTravelCardGAPersonalized = (args) => (
 const TemplateTravelCardHalfFarePersonalized = (args) => (
   <sbb-card-product {...args}>
     <SlotSbbTitleTemplate slot="title" {...sbbTitleTravelCardHalfFareArgs} />
-    <div slot="lead">
-      <SlotSbbLeadTemplate {...sbbLeadHalfFareArgs} />
-    </div>
+    <SlotSbbLeadTemplate slot="lead" {...sbbLeadHalfFareArgs} />
     <div slot="text">
       <SlotSbbTextTemplate {...sbbTextTravelCardValidityArgs} />
     </div>
@@ -507,9 +501,7 @@ const TemplateTravelCardHalfFarePersonalized = (args) => (
 const TemplateTravelCardHalfFare = (args) => (
   <sbb-card-product {...args}>
     <SlotSbbTitleTemplate slot="title" {...sbbTitleTravelCardHalfFareArgs} />
-    <div slot="lead">
-      <SlotSbbLeadTemplate {...sbbLeadHalfFareLongArgs} />
-    </div>
+    <SlotSbbLeadTemplate slot="lead" {...sbbLeadHalfFareLongArgs} />
     <div slot="action">
       <SlotActionTemplate {...actionHalfFareArgs} />
     </div>
@@ -522,11 +514,14 @@ const TemplateTheWholeShabang = (args) => (
     <div slot="category">
       <SlotSbbCategoryTemplate {...sbbCategoryArgs} />
     </div>
-    <SlotSbbTitleTemplate slot="title" {...sbbTitleTravelCardGAArgs} />
-    <SlotSbbJourneyHeaderTemplate {...sbbJourneyHeaderArgs} />
-    <div slot="lead">
-      <SlotSbbLeadTemplate {...sbbLeadGAArgs} />
+    <div
+      slot="title"
+      style="--sbb-title-margin-block-start-override: 0; --sbb-title-margin-block-end-override: 0;"
+    >
+      <SlotSbbTitleTemplate {...sbbTitleTravelCardGAArgs} />
+      <SlotSbbJourneyHeaderTemplate {...sbbJourneyHeaderArgs} />
     </div>
+    <SlotSbbLeadTemplate slot="lead" {...sbbLeadGAArgs} />
     <div slot="text">
       <SlotSbbTextTemplate {...sbbTextTravelCardValidityArgs} />
     </div>

--- a/src/components/sbb-card/sbb-card.scss
+++ b/src/components/sbb-card/sbb-card.scss
@@ -127,6 +127,8 @@
   @include sbb.screen-reader-only;
 }
 
-::slotted(sbb-title:first-child) {
+// We remove upper margin from all titles
+// as we do not expect multiple titles to be used inside a card.
+.sbb-card__content ::slotted(sbb-title) {
   margin-block-start: 0;
 }

--- a/src/components/sbb-card/sbb-card.scss
+++ b/src/components/sbb-card/sbb-card.scss
@@ -126,3 +126,7 @@
 .sbb-card__opens-in-new-window {
   @include sbb.screen-reader-only;
 }
+
+::slotted(sbb-title:first-child) {
+  margin-block-start: 0;
+}

--- a/src/components/sbb-dialog/sbb-dialog.scss
+++ b/src/components/sbb-dialog/sbb-dialog.scss
@@ -190,7 +190,9 @@
   flex: 1;
   overflow: hidden;
   align-self: center;
-  margin: 0; // Overwrite sbb-title default margin
+
+  // Overwrite sbb-title default margin
+  margin: 0;
 }
 
 .sbb-dialog__content {

--- a/src/components/sbb-dialog/sbb-dialog.scss
+++ b/src/components/sbb-dialog/sbb-dialog.scss
@@ -190,6 +190,7 @@
   flex: 1;
   overflow: hidden;
   align-self: center;
+  margin: 0; // Overwrite sbb-title default margin
 }
 
 .sbb-dialog__content {

--- a/src/components/sbb-dialog/sbb-dialog.stories.js
+++ b/src/components/sbb-dialog/sbb-dialog.stories.js
@@ -249,7 +249,7 @@ const FormTemplate = (args) => [
     {...args}
     ref={(dialog) => onFormDialogClose(dialog)}
   >
-    <div style={'margin-bottom: var(--sbb-spacing-fixed-4x)'}>
+    <div style={'margin-block-end: var(--sbb-spacing-fixed-4x)'}>
       Submit the form below to close the dialog box using the
       <code style={codeStyle}>close(result?: any, target?: HTMLElement)</code>
       method and returning the form values to update the details.
@@ -288,7 +288,7 @@ const NoFooterTemplate = (args) => [
 const FullScreenTemplate = (args) => [
   triggerButton('my-dialog-6'),
   <sbb-dialog data-testid="dialog" id="my-dialog-6" {...args}>
-    <sbb-title visual-level="2" negative={args.negative}>
+    <sbb-title visual-level="2" negative={args.negative} style="margin-block-start:0">
       Many Meetings
     </sbb-title>
     Frodo halted for a moment, looking back. Elrond was in his chair and the fire was on his face

--- a/src/components/sbb-dialog/sbb-dialog.stories.js
+++ b/src/components/sbb-dialog/sbb-dialog.stories.js
@@ -288,7 +288,7 @@ const NoFooterTemplate = (args) => [
 const FullScreenTemplate = (args) => [
   triggerButton('my-dialog-6'),
   <sbb-dialog data-testid="dialog" id="my-dialog-6" {...args}>
-    <sbb-title visual-level="2" style={'margin-bottom: 1rem'} negative={args.negative}>
+    <sbb-title visual-level="2" negative={args.negative}>
       Many Meetings
     </sbb-title>
     Frodo halted for a moment, looking back. Elrond was in his chair and the fire was on his face

--- a/src/components/sbb-grid/sbb-grid.stories.js
+++ b/src/components/sbb-grid/sbb-grid.stories.js
@@ -91,11 +91,9 @@ const TemplateGridTopProducts = (args) => (
           ></path>
         </svg>
       </div>
-      <div slot="title">
-        <sbb-title level="2" visual-level="6">
-          Tageskarte
-        </sbb-title>
-      </div>
+      <sbb-title slot="title" level="2" visual-level="6">
+        Tageskarte
+      </sbb-title>
       <div slot="text">
         <span>Gültig heute</span>
       </div>
@@ -122,11 +120,9 @@ const TemplateGridTopProducts = (args) => (
           ></path>
         </svg>
       </div>
-      <div slot="title">
-        <sbb-title level="2" visual-level="6">
-          Velo Tageskarte
-        </sbb-title>
-      </div>
+      <sbb-title slot="title" level="2" visual-level="6">
+        Velo Tageskarte
+      </sbb-title>
       <div slot="text">
         <span>Gültig heute</span>
       </div>
@@ -153,11 +149,9 @@ const TemplateGridTopProducts = (args) => (
           ></path>
         </svg>
       </div>
-      <div slot="title">
-        <sbb-title level="2" visual-level="6">
-          Libero Kurzstrecke
-        </sbb-title>
-      </div>
+      <sbb-title slot="title" level="2" visual-level="6">
+        Libero Kurzstrecke
+      </sbb-title>
       <div slot="text">
         <span>Gültig heute</span>
       </div>
@@ -184,11 +178,9 @@ const TemplateGridTopProducts = (args) => (
           ></path>
         </svg>
       </div>
-      <div slot="title">
-        <sbb-title level="2" visual-level="6">
-          Streckenkarte
-        </sbb-title>
-      </div>
+      <sbb-title slot="title" level="2" visual-level="6">
+        Streckenkarte
+      </sbb-title>
       <div slot="text">
         <span>Für regelmässige Streckenfahrten</span>
       </div>
@@ -206,11 +198,9 @@ const TemplateGridTopProducts = (args) => (
       layout="loose"
       href-value="https://github.com/lyne-design-system/lyne-components"
     >
-      <div slot="title">
-        <sbb-title level="2" visual-level="1">
-          GA
-        </sbb-title>
-      </div>
+      <sbb-title slot="title" level="2" visual-level="1">
+        GA
+      </sbb-title>
       <div slot="lead">
         <sbb-title level="3" visual-level="6">
           Mit dem Generalabonnement geniessen Sie freie Fahrt.
@@ -230,11 +220,9 @@ const TemplateGridTopProducts = (args) => (
       layout="loose"
       href-value="https://github.com/lyne-design-system/lyne-components"
     >
-      <div slot="title">
-        <sbb-title level="2" visual-level="1">
-          1/2
-        </sbb-title>
-      </div>
+      <sbb-title slot="title" level="2" visual-level="1">
+        1/2
+      </sbb-title>
       <div slot="lead">
         <sbb-title level="3" visual-level="6">
           Mit dem Halbtax zum halben Preis fahren.
@@ -270,11 +258,9 @@ const TemplateTickets = (args) => (
       <div slot="category">
         <span>Sparbillett</span>
       </div>
-      <div slot="title">
-        <sbb-title level="2" visual-level="6">
-          Libero Tageskarte: Alle Zonen
-        </sbb-title>
-      </div>
+      <sbb-title slot="title" level="2" visual-level="6">
+        Libero Tageskarte: Alle Zonen
+      </sbb-title>
       <div slot="text">
         <span>Heute, Gültig 24 Stunden</span>
       </div>

--- a/src/components/sbb-journey-header/sbb-journey-header.scss
+++ b/src/components/sbb-journey-header/sbb-journey-header.scss
@@ -36,11 +36,11 @@
 }
 
 .journey-header--size-4 {
-  @include sbb.title-4;
+  @include sbb.title-4($exclude-spacing: true);
 }
 
 .journey-header--size-5 {
-  @include sbb.title-5;
+  @include sbb.title-5($exclude-spacing: true);
 }
 
 .connection--visually-hidden {

--- a/src/components/sbb-link-list/sbb-link-list.scss
+++ b/src/components/sbb-link-list/sbb-link-list.scss
@@ -28,7 +28,7 @@ $breakpoints: 'zero', 'micro', 'small', 'medium', 'large', 'wide', 'ultra';
   gap: var(--sbb-spacing-fixed-3x);
 }
 
-.sbb-link-list__title {
+.sbb-link-list-title {
   // Overwrite sbb-title default margin
   margin: 0;
 }

--- a/src/components/sbb-link-list/sbb-link-list.scss
+++ b/src/components/sbb-link-list/sbb-link-list.scss
@@ -29,7 +29,8 @@ $breakpoints: 'zero', 'micro', 'small', 'medium', 'large', 'wide', 'ultra';
 }
 
 .sbb-link-list__title {
-  margin: 0; // Overwrite sbb-title default margin
+  // Overwrite sbb-title default margin
+  margin: 0;
 }
 
 .sbb-link-list {

--- a/src/components/sbb-link-list/sbb-link-list.scss
+++ b/src/components/sbb-link-list/sbb-link-list.scss
@@ -28,6 +28,10 @@ $breakpoints: 'zero', 'micro', 'small', 'medium', 'large', 'wide', 'ultra';
   gap: var(--sbb-spacing-fixed-3x);
 }
 
+.sbb-link-list__title {
+  margin: 0; // Overwrite sbb-title default margin
+}
+
 .sbb-link-list {
   @include sbb.list-reset;
 

--- a/src/components/sbb-link-list/sbb-link-list.tsx
+++ b/src/components/sbb-link-list/sbb-link-list.tsx
@@ -72,6 +72,7 @@ export class SbbLinkList implements ComponentInterface {
       <div class="sbb-link-list-wrapper">
         {(this._namedSlots.title || this.titleContent) && (
           <sbb-title
+            class="sbb-link-list__title"
             level={this.titleLevel}
             visual-level="5"
             negative={this.negative}

--- a/src/components/sbb-link-list/sbb-link-list.tsx
+++ b/src/components/sbb-link-list/sbb-link-list.tsx
@@ -72,12 +72,11 @@ export class SbbLinkList implements ComponentInterface {
       <div class="sbb-link-list-wrapper">
         {(this._namedSlots.title || this.titleContent) && (
           <sbb-title
-            class="sbb-link-list__title"
+            class="sbb-link-list-title"
             level={this.titleLevel}
             visual-level="5"
             negative={this.negative}
             id="sbb-link-list-title-id"
-            class="sbb-link-list-title"
           >
             <slot name="title">{this.titleContent}</slot>
           </sbb-title>

--- a/src/components/sbb-teaser/sbb-teaser.scss
+++ b/src/components/sbb-teaser/sbb-teaser.scss
@@ -70,7 +70,8 @@
 .sbb-teaser__lead {
   @include sbb.clamp-lines($lines: 2);
 
-  margin: 0; // Overwrite sbb-title default margin
+  // Overwrite sbb-title default margin
+  margin: 0;
 }
 
 .sbb-teaser__description {

--- a/src/components/sbb-teaser/sbb-teaser.scss
+++ b/src/components/sbb-teaser/sbb-teaser.scss
@@ -69,6 +69,8 @@
 
 .sbb-teaser__lead {
   @include sbb.clamp-lines($lines: 2);
+
+  margin: 0; // Overwrite sbb-title default margin
 }
 
 .sbb-teaser__description {

--- a/src/components/sbb-title/readme.md
+++ b/src/components/sbb-title/readme.md
@@ -5,6 +5,11 @@ Internally this is represented by the heading elements: h1, h2, h3, h4, h5 and h
 In scenarios where the visual representation needs to be different from the semantic meaning of the title level,
 it is possible to use the `visual-level`.
 
+As a default the `<sbb-title>` contains spacing on top and bottom. To achieve a custom spacing, 
+set margin on `<sbb-title style='margin:0'>`.
+As an alternative you can also set the following 
+css vars: `--sbb-title-margin-block-start-override` and `--sbb-title-margin-block-end-override` to a specific value.
+
 <!-- Auto Generated Below -->
 
 

--- a/src/components/sbb-title/readme.md
+++ b/src/components/sbb-title/readme.md
@@ -5,10 +5,8 @@ Internally this is represented by the heading elements: h1, h2, h3, h4, h5 and h
 In scenarios where the visual representation needs to be different from the semantic meaning of the title level,
 it is possible to use the `visual-level`.
 
-As a default the `<sbb-title>` contains spacing on top and bottom. To achieve a custom spacing, 
-set margin on `<sbb-title style='margin:0'>`.
-As an alternative you can also set the following 
-css vars: `--sbb-title-margin-block-start-override` and `--sbb-title-margin-block-end-override` to a specific value.
+As a default the `<sbb-title>` contains spacing on top and bottom on the host. This can be removed or customized
+via simple CSS rules.
 
 <!-- Auto Generated Below -->
 

--- a/src/components/sbb-title/sbb-title.scss
+++ b/src/components/sbb-title/sbb-title.scss
@@ -40,8 +40,9 @@
 }
 
 .sbb-title {
-  color: var(--sbb-title-text-color-normal);
   @include sbb.font-smoothing;
+
+  color: var(--sbb-title-text-color-normal);
 
   :host([visually-hidden]) & {
     @include sbb.screen-reader-only;

--- a/src/components/sbb-title/sbb-title.scss
+++ b/src/components/sbb-title/sbb-title.scss
@@ -12,11 +12,8 @@
   --sbb-title-margin-block-start: 0;
   --sbb-title-margin-block-end: 0;
 
-  margin-block-start: var(
-    --sbb-title-margin-block-start-override,
-    var(--sbb-title-margin-block-start)
-  );
-  margin-block-end: var(--sbb-title-margin-block-start-override, var(--sbb-title-margin-block-end));
+  margin-block-start: var(--sbb-title-margin-block-start);
+  margin-block-end: var(--sbb-title-margin-block-end);
 }
 
 // stylelint-disable plugin/stylelint-bem-namics

--- a/src/components/sbb-title/sbb-title.scss
+++ b/src/components/sbb-title/sbb-title.scss
@@ -23,6 +23,11 @@
 }
 
 // Due to using :where, order does matter
+:host(:where([level='1']:not([visual-level]), [visual-level='1']):where(:not([visually-hidden]))) {
+  --sbb-title-margin-block-start: var(--sbb-spacing-responsive-l);
+}
+
+// Due to using :where, order does matter
 :host(:where([level='2']:not([visual-level]), [visual-level='2']):where(:not([visually-hidden]))),
 :host(:where([level='3']:not([visual-level]), [visual-level='3']):where(:not([visually-hidden]))) {
   --sbb-title-margin-block-end: var(--sbb-spacing-responsive-xxxs);

--- a/src/components/sbb-title/sbb-title.scss
+++ b/src/components/sbb-title/sbb-title.scss
@@ -19,17 +19,28 @@
 // stylelint-disable plugin/stylelint-bem-namics
 :host(:where(:not([visually-hidden]))) {
   --sbb-title-margin-block-start: var(--sbb-spacing-responsive-m);
-  --sbb-title-margin-block-end: var(--sbb-spacing-responsive-xs);
+  --sbb-title-margin-block-end: var(--sbb-spacing-responsive-s);
+}
+
+// Due to using :where, order does matter
+:host(:where([level='2']:not([visual-level]), [visual-level='2']):where(:not([visually-hidden]))),
+:host(:where([level='3']:not([visual-level]), [visual-level='3']):where(:not([visually-hidden]))) {
+  --sbb-title-margin-block-end: var(--sbb-spacing-responsive-xxxs);
+}
+
+// Due to using :where, order does matter
+:host(:where([level='4']:not([visual-level]), [visual-level='4']):where(:not([visually-hidden]))) {
+  --sbb-title-margin-block-end: var(--sbb-spacing-fixed-3x);
 }
 
 // Due to using :where, order does matter
 :host(:where([level='5']:not([visual-level]), [visual-level='5']):where(:not([visually-hidden]))) {
-  --sbb-title-margin-block-end: var(--sbb-spacing-fixed-5x);
+  --sbb-title-margin-block-end: var(--sbb-spacing-fixed-2x);
 }
 
 // Due to using :where, order does matter
 :host(:where([level='6']:not([visual-level]), [visual-level='6']):where(:not([visually-hidden]))) {
-  --sbb-title-margin-block-end: var(--sbb-spacing-fixed-4x);
+  --sbb-title-margin-block-end: var(--sbb-spacing-fixed-1x);
 }
 
 :host([negative]) {

--- a/src/components/sbb-title/sbb-title.scss
+++ b/src/components/sbb-title/sbb-title.scss
@@ -9,6 +9,27 @@
     --sbb-title-text-color-normal-override,
     var(--sbb-color-charcoal-default)
   );
+  --sbb-title-margin-block-start: 0;
+  --sbb-title-margin-block-end: 0;
+
+  margin-block-start: var(--sbb-title-margin-block-start);
+  margin-block-end: var(--sbb-title-margin-block-end);
+}
+
+// stylelint-disable plugin/stylelint-bem-namics
+:host(:where(:not([visually-hidden]))) {
+  --sbb-title-margin-block-start: var(--sbb-spacing-responsive-m);
+  --sbb-title-margin-block-end: var(--sbb-spacing-responsive-xs);
+}
+
+// Due to using :where, order does matter
+:host(:where([level='5']:not([visual-level]), [visual-level='5']):where(:not([visually-hidden]))) {
+  --sbb-title-margin-block-end: var(--sbb-spacing-fixed-5x);
+}
+
+// Due to using :where, order does matter
+:host(:where([level='6']:not([visual-level]), [visual-level='6']):where(:not([visually-hidden]))) {
+  --sbb-title-margin-block-end: var(--sbb-spacing-fixed-4x);
 }
 
 :host([negative]) {
@@ -27,29 +48,28 @@
     @include sbb.scroll-margin-block-start;
   }
 
-  // stylelint-disable plugin/stylelint-bem-namics
   :host(:is([level='1']:not([visual-level]), [visual-level='1'])) & {
-    @include sbb.title-1;
+    @include sbb.title-1($exclude-spacing: true);
   }
 
   :host(:is([level='2']:not([visual-level]), [visual-level='2'])) & {
-    @include sbb.title-2;
+    @include sbb.title-2($exclude-spacing: true);
   }
 
   :host(:is([level='3']:not([visual-level]), [visual-level='3'])) & {
-    @include sbb.title-3;
+    @include sbb.title-3($exclude-spacing: true);
   }
 
   :host(:is([level='4']:not([visual-level]), [visual-level='4'])) & {
-    @include sbb.title-4;
+    @include sbb.title-4($exclude-spacing: true);
   }
 
   :host(:is([level='5']:not([visual-level]), [visual-level='5'])) & {
-    @include sbb.title-5;
+    @include sbb.title-5($exclude-spacing: true);
   }
 
   :host(:is([level='6']:not([visual-level]), [visual-level='6'])) & {
-    @include sbb.title-6;
+    @include sbb.title-6($exclude-spacing: true);
   }
   // stylelint-enable plugin/stylelint-bem-namics
 }

--- a/src/components/sbb-title/sbb-title.scss
+++ b/src/components/sbb-title/sbb-title.scss
@@ -12,8 +12,11 @@
   --sbb-title-margin-block-start: 0;
   --sbb-title-margin-block-end: 0;
 
-  margin-block-start: var(--sbb-title-margin-block-start);
-  margin-block-end: var(--sbb-title-margin-block-end);
+  margin-block-start: var(
+    --sbb-title-margin-block-start-override,
+    var(--sbb-title-margin-block-start)
+  );
+  margin-block-end: var(--sbb-title-margin-block-start-override, var(--sbb-title-margin-block-end));
 }
 
 // stylelint-disable plugin/stylelint-bem-namics

--- a/src/components/sbb-wagon/sbb-wagon.scss
+++ b/src/components/sbb-wagon/sbb-wagon.scss
@@ -62,7 +62,7 @@
 }
 
 .sbb-wagon__class {
-  @include sbb.title-6;
+  @include sbb.title-6($exclude-spacing: true);
 
   margin-inline-start: auto;
 }

--- a/src/global/helpers/chromatic.js
+++ b/src/global/helpers/chromatic.js
@@ -8,8 +8,11 @@ export function combineStories(config, stories) {
   const decorators = (name, story) =>
     [
       (Story) => (
-        <div style="margin-bottom: 2rem;">
-          <sbb-title level="5" style="margin-bottom: 1rem;text-transform: capitalize;">
+        <div style="margin-block-end: 2rem;">
+          <sbb-title
+            level="5"
+            style="margin-block-end: 1rem;margin-block-start:0;text-transform: capitalize;"
+          >
             {unCamelCase(name)}
           </sbb-title>
           <div style="outline: 1px solid #ad00ff;">

--- a/src/global/styles/mixins/typo.scss
+++ b/src/global/styles/mixins/typo.scss
@@ -9,7 +9,7 @@
 
   @if not($exclude-spacing) {
     --sbb-title-margin-block-start: var(--sbb-spacing-responsive-m);
-    --sbb-title-margin-block-end: var(--sbb-spacing-responsive-xs);
+    --sbb-title-margin-block-end: var(--sbb-spacing-responsive-s);
   }
 
   margin: 0;
@@ -32,18 +32,30 @@
   @include title($exclude-spacing);
 
   --sbb-title-font-size: var(--sbb-font-size-title-2);
+
+  @if not($exclude-spacing) {
+    --sbb-title-margin-block-end: var(--sbb-spacing-responsive-xxxs);
+  }
 }
 
 @mixin title-3($exclude-spacing: false) {
   @include title($exclude-spacing);
 
   --sbb-title-font-size: var(--sbb-font-size-title-3);
+
+  @if not($exclude-spacing) {
+    --sbb-title-margin-block-end: var(--sbb-spacing-responsive-xxxs);
+  }
 }
 
 @mixin title-4($exclude-spacing: false) {
   @include title($exclude-spacing);
 
   --sbb-title-font-size: var(--sbb-font-size-title-4);
+
+  @if not($exclude-spacing) {
+    --sbb-title-margin-block-end: var(--sbb-spacing-fixed-3x);
+  }
 }
 
 @mixin title-5($exclude-spacing: false) {
@@ -53,7 +65,7 @@
   --sbb-title-line-height: var(--sbb-typo-line-height-body-text);
 
   @if not($exclude-spacing) {
-    --sbb-title-margin-block-end: var(--sbb-spacing-fixed-5x);
+    --sbb-title-margin-block-end: var(--sbb-spacing-fixed-2x);
   }
 }
 
@@ -64,7 +76,7 @@
   --sbb-title-line-height: var(--sbb-typo-line-height-body-text);
 
   @if not($exclude-spacing) {
-    --sbb-title-margin-block-end: var(--sbb-spacing-fixed-4x);
+    --sbb-title-margin-block-end: var(--sbb-spacing-fixed-1x);
   }
 }
 

--- a/src/global/styles/mixins/typo.scss
+++ b/src/global/styles/mixins/typo.scss
@@ -2,10 +2,19 @@
 // Typo: Title Style Mixins
 // ----------------------------------------------------------------------------------------------------
 
-@mixin title {
+@mixin title($exclude-spacing: false) {
   --sbb-title-line-height: var(--sbb-typo-line-height-titles);
+  --sbb-title-margin-block-start: 0;
+  --sbb-title-margin-block-end: 0;
+
+  @if not($exclude-spacing) {
+    --sbb-title-margin-block-start: var(--sbb-spacing-responsive-m);
+    --sbb-title-margin-block-end: var(--sbb-spacing-responsive-xs);
+  }
 
   margin: 0;
+  margin-block-start: var(--sbb-title-margin-block-start);
+  margin-block-end: var(--sbb-title-margin-block-end);
   font-family: var(--sbb-typo-type-face-sbb-bold);
   font-weight: normal;
   line-height: var(--sbb-title-line-height);
@@ -13,42 +22,50 @@
   font-size: var(--sbb-title-font-size);
 }
 
-@mixin title-1 {
-  @include title;
+@mixin title-1($exclude-spacing: false) {
+  @include title($exclude-spacing);
 
   --sbb-title-font-size: var(--sbb-font-size-title-1);
 }
 
-@mixin title-2 {
-  @include title;
+@mixin title-2($exclude-spacing: false) {
+  @include title($exclude-spacing);
 
   --sbb-title-font-size: var(--sbb-font-size-title-2);
 }
 
-@mixin title-3 {
-  @include title;
+@mixin title-3($exclude-spacing: false) {
+  @include title($exclude-spacing);
 
   --sbb-title-font-size: var(--sbb-font-size-title-3);
 }
 
-@mixin title-4 {
-  @include title;
+@mixin title-4($exclude-spacing: false) {
+  @include title($exclude-spacing);
 
   --sbb-title-font-size: var(--sbb-font-size-title-4);
 }
 
-@mixin title-5 {
-  @include title;
+@mixin title-5($exclude-spacing: false) {
+  @include title($exclude-spacing);
 
   --sbb-title-font-size: var(--sbb-font-size-title-5);
   --sbb-title-line-height: var(--sbb-typo-line-height-body-text);
+
+  @if not($exclude-spacing) {
+    --sbb-title-margin-block-end: var(--sbb-spacing-fixed-5x);
+  }
 }
 
-@mixin title-6 {
-  @include title;
+@mixin title-6($exclude-spacing: false) {
+  @include title($exclude-spacing);
 
   --sbb-title-font-size: var(--sbb-font-size-title-6);
   --sbb-title-line-height: var(--sbb-typo-line-height-body-text);
+
+  @if not($exclude-spacing) {
+    --sbb-title-margin-block-end: var(--sbb-spacing-fixed-4x);
+  }
 }
 
 @mixin title--negative {

--- a/src/storybook/pages/home/home--logged-in.stories.js
+++ b/src/storybook/pages/home/home--logged-in.stories.js
@@ -168,7 +168,10 @@ const Template = (args) => (
                   <div slot="category">
                     <span>Saver ticket</span>
                   </div>
-                  <div slot="title">
+                  <div
+                    slot="title"
+                    style="--sbb-title-margin-block-start-override: 0; --sbb-title-margin-block-end-override: 0;"
+                  >
                     <sbb-title level="2" visual-level="1">
                       GA
                     </sbb-title>
@@ -180,11 +183,9 @@ const Template = (args) => (
                       size="5"
                     ></sbb-journey-header>
                   </div>
-                  <div slot="lead">
-                    <sbb-title level="3" visual-level="6">
-                      Generalabonnement
-                    </sbb-title>
-                  </div>
+                  <sbb-title slot="lead" level="3" visual-level="6">
+                    Generalabonnement
+                  </sbb-title>
                   <div slot="text">
                     <span>2nd class, valid until 30.11.2022</span>
                   </div>
@@ -260,15 +261,14 @@ const Template = (args) => (
                   layout="standard"
                   href-value="https://github.com/lyne-design-system/lyne-components"
                 >
-                  <div slot="title">
-                    <sbb-journey-header
-                      destination="Loèche-les-Bains"
-                      is-round-trip=""
-                      markup="h2"
-                      origin="La Chaux de Fonds"
-                      size="5"
-                    ></sbb-journey-header>
-                  </div>
+                  <sbb-journey-header
+                    destination="Loèche-les-Bains"
+                    is-round-trip=""
+                    markup="h2"
+                    origin="La Chaux de Fonds"
+                    size="5"
+                    slot="title"
+                  ></sbb-journey-header>
                   <div slot="text">
                     <span>Saturday, 21.02.2021, 1 h 26 min</span>
                   </div>
@@ -411,11 +411,9 @@ const Template = (args) => (
             <sbb-title slot="title" level="2" visual-level="1">
               GA
             </sbb-title>
-            <div slot="lead">
-              <sbb-title level="3" visual-level="6">
-                Generalabonnement
-              </sbb-title>
-            </div>
+            <sbb-title slot="lead" level="3" visual-level="6">
+              Generalabonnement
+            </sbb-title>
             <div slot="text">
               <span>2nd class, valid until 30.11.2022</span>
             </div>

--- a/src/storybook/pages/home/home--logged-in.stories.js
+++ b/src/storybook/pages/home/home--logged-in.stories.js
@@ -240,11 +240,9 @@ const Template = (args) => (
                   <div slot="category">
                     <span>Saver ticket</span>
                   </div>
-                  <div slot="title">
-                    <sbb-title level="2" visual-level="6">
-                      Libero day ticket: All zones
-                    </sbb-title>
-                  </div>
+                  <sbb-title slot="title" level="2" visual-level="6">
+                    Libero day ticket: All zones
+                  </sbb-title>
                   <div slot="text">
                     <span>Today, Valid 24 hours</span>
                   </div>
@@ -332,11 +330,9 @@ const Template = (args) => (
                 ></path>
               </svg>
             </div>
-            <div slot="title">
-              <sbb-title level="2" visual-level="6">
-                <span>Daily ticket</span>
-              </sbb-title>
-            </div>
+            <sbb-title slot="title" level="2" visual-level="6">
+              <span>Daily ticket</span>
+            </sbb-title>
             <div slot="text">
               <span>Valid today</span>
             </div>
@@ -363,11 +359,9 @@ const Template = (args) => (
                 ></path>
               </svg>
             </div>
-            <div slot="title">
-              <sbb-title level="2" visual-level="6">
-                Bike day pass
-              </sbb-title>
-            </div>
+            <sbb-title slot="title" level="2" visual-level="6">
+              Bike day pass
+            </sbb-title>
             <div slot="text">
               <span>Valid today</span>
             </div>
@@ -394,11 +388,9 @@ const Template = (args) => (
                 ></path>
               </svg>
             </div>
-            <div slot="title">
-              <sbb-title level="2" visual-level="6">
-                Libero short distance ticket
-              </sbb-title>
-            </div>
+            <sbb-title slot="title" level="2" visual-level="6">
+              Libero short distance ticket
+            </sbb-title>
             <div slot="text">
               <span>Valid today</span>
             </div>
@@ -416,11 +408,9 @@ const Template = (args) => (
             layout="loose"
             href-value="https://github.com/lyne-design-system/lyne-components"
           >
-            <div slot="title">
-              <sbb-title level="2" visual-level="1">
-                GA
-              </sbb-title>
-            </div>
+            <sbb-title slot="title" level="2" visual-level="1">
+              GA
+            </sbb-title>
             <div slot="lead">
               <sbb-title level="3" visual-level="6">
                 Generalabonnement

--- a/src/storybook/pages/home/home--logged-in.stories.js
+++ b/src/storybook/pages/home/home--logged-in.stories.js
@@ -168,11 +168,8 @@ const Template = (args) => (
                   <div slot="category">
                     <span>Saver ticket</span>
                   </div>
-                  <div
-                    slot="title"
-                    style="--sbb-title-margin-block-start-override: 0; --sbb-title-margin-block-end-override: 0;"
-                  >
-                    <sbb-title level="2" visual-level="1">
+                  <div slot="title">
+                    <sbb-title level="2" visual-level="1" style="margin-block:0;">
                       GA
                     </sbb-title>
                     <sbb-journey-header

--- a/src/storybook/pages/home/home.stories.js
+++ b/src/storybook/pages/home/home.stories.js
@@ -256,11 +256,9 @@ const Template = (args) => (
             <sbb-title slot="title" level="2" visual-level="1">
               GA
             </sbb-title>
-            <div slot="lead">
-              <sbb-title level="3" visual-level="6">
-                Enjoy unlimited travel with the GA travelcard.
-              </sbb-title>
-            </div>
+            <sbb-title slot="lead" level="3" visual-level="6">
+              Enjoy unlimited travel with the GA travelcard.
+            </sbb-title>
             <div slot="action">
               <sbb-button variant="secondary" static>
                 All GAs at a glance
@@ -278,11 +276,9 @@ const Template = (args) => (
             <sbb-title slot="title" level="2" visual-level="1">
               1/2
             </sbb-title>
-            <div slot="lead">
-              <sbb-title level="3" visual-level="6">
-                Travel at half price with the Halbtax travelcard.
-              </sbb-title>
-            </div>
+            <sbb-title slot="lead" level="3" visual-level="6">
+              Travel at half price with the Halbtax travelcard.
+            </sbb-title>
             <div slot="action">
               <sbb-button variant="secondary" static>
                 Ride at half price

--- a/src/storybook/pages/home/home.stories.js
+++ b/src/storybook/pages/home/home.stories.js
@@ -146,11 +146,9 @@ const Template = (args) => (
                 ></path>
               </svg>
             </div>
-            <div slot="title">
-              <sbb-title level="2" visual-level="6">
-                Daily ticket
-              </sbb-title>
-            </div>
+            <sbb-title slot="title" level="2" visual-level="6">
+              Daily ticket
+            </sbb-title>
             <div slot="text">
               <span>Valid today</span>
             </div>
@@ -177,11 +175,9 @@ const Template = (args) => (
                 ></path>
               </svg>
             </div>
-            <div slot="title">
-              <sbb-title level="2" visual-level="6">
-                Bike day pass
-              </sbb-title>
-            </div>
+            <sbb-title slot="title" level="2" visual-level="6">
+              Bike day pass
+            </sbb-title>
             <div slot="text">
               <span>Valid today</span>
             </div>
@@ -208,11 +204,9 @@ const Template = (args) => (
                 ></path>
               </svg>
             </div>
-            <div slot="title">
-              <sbb-title level="2" visual-level="6">
-                Libero short distance ticket
-              </sbb-title>
-            </div>
+            <sbb-title slot="title" level="2" visual-level="6">
+              Libero short distance ticket
+            </sbb-title>
             <div slot="text">
               <span>Valid today</span>
             </div>
@@ -239,11 +233,9 @@ const Template = (args) => (
                 ></path>
               </svg>
             </div>
-            <div slot="title">
-              <sbb-title level="2" visual-level="6">
-                Route map
-              </sbb-title>
-            </div>
+            <sbb-title slot="title" level="2" visual-level="6">
+              Route map
+            </sbb-title>
             <div slot="text">
               <span>For regular trips</span>
             </div>
@@ -261,11 +253,9 @@ const Template = (args) => (
             layout="loose"
             href-value="https://github.com/lyne-design-system/lyne-components"
           >
-            <div slot="title">
-              <sbb-title level="2" visual-level="1">
-                GA
-              </sbb-title>
-            </div>
+            <sbb-title slot="title" level="2" visual-level="1">
+              GA
+            </sbb-title>
             <div slot="lead">
               <sbb-title level="3" visual-level="6">
                 Enjoy unlimited travel with the GA travelcard.
@@ -285,11 +275,9 @@ const Template = (args) => (
             layout="loose"
             href-value="https://github.com/lyne-design-system/lyne-components"
           >
-            <div slot="title">
-              <sbb-title level="2" visual-level="1">
-                1/2
-              </sbb-title>
-            </div>
+            <sbb-title slot="title" level="2" visual-level="1">
+              1/2
+            </sbb-title>
             <div slot="lead">
               <sbb-title level="3" visual-level="6">
                 Travel at half price with the Halbtax travelcard.

--- a/src/storybook/styles/typography/readme.md
+++ b/src/storybook/styles/typography/readme.md
@@ -3,6 +3,9 @@
 Every text size (xxs, xs, s, m, l and xl) is available as sass mixin or css class.
 It also includes line-height, letter-spacing and font-family.
 
+The native browser margins (1em) between paragraph elements `<p>` correctly corresponds
+to the defined paragraph spacing. Due to this there are no additional rules for paragraph spacing.
+
 | css class      | css class bold               | sass mixin          | sass mixin bold  |
 | -------------- | ---------------------------- | ------------------- | ---------------- |
 | `sbb-text-xxs` | `sbb-text-xxs sbb-text-bold` | `text-xxs--regular` | `text-xxs--bold` |

--- a/src/storybook/styles/typography/typography.stories.js
+++ b/src/storybook/styles/typography/typography.stories.js
@@ -8,7 +8,9 @@ const TextTemplate = () =>
     <sbb-title level={sizes.length - index}>
       Titel Level {sizes.length - index} / Text size {textSize}
     </sbb-title>,
-    <p class={`sbb-text-${textSize}`}>{text}</p>,
+    <p class={`sbb-text-${textSize}`} style="margin-block-start:0">
+      {text}
+    </p>,
   ]);
 
 const TextBoldTemplate = () =>
@@ -16,7 +18,9 @@ const TextBoldTemplate = () =>
     <sbb-title level={sizes.length - index}>
       Titel Level {sizes.length - index} / Text size {textSize}
     </sbb-title>,
-    <p class={`sbb-text-${textSize} sbb-text-bold`}>{text}</p>,
+    <p class={`sbb-text-${textSize} sbb-text-bold`} style="margin-block-start:0">
+      {text}
+    </p>,
   ]);
 
 export const Text = TextTemplate.bind({});

--- a/src/storybook/styles/typography/typography.stories.js
+++ b/src/storybook/styles/typography/typography.stories.js
@@ -4,14 +4,18 @@ import readme from './readme.md';
 const text = `Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.`;
 
 const TextTemplate = () =>
-  ['xxs', 'xs', 's', 'm', 'l', 'xl'].map((textSize) => [
-    <sbb-title level="3">Text size {textSize}</sbb-title>,
+  ['xxs', 'xs', 's', 'm', 'l', 'xl'].map((textSize, index, sizes) => [
+    <sbb-title level={sizes.length - index}>
+      Titel Level {sizes.length - index} / Text size {textSize}
+    </sbb-title>,
     <p class={`sbb-text-${textSize}`}>{text}</p>,
   ]);
 
 const TextBoldTemplate = () =>
-  ['xxs', 'xs', 's', 'm', 'l', 'xl'].map((textSize) => [
-    <sbb-title level="3">Text size {textSize}</sbb-title>,
+  ['xxs', 'xs', 's', 'm', 'l', 'xl'].map((textSize, index, sizes) => [
+    <sbb-title level={sizes.length - index}>
+      Titel Level {sizes.length - index} / Text size {textSize}
+    </sbb-title>,
     <p class={`sbb-text-${textSize} sbb-text-bold`}>{text}</p>,
   ]);
 


### PR DESCRIPTION
BREAKING CHANGE:
Title mixins and `<sbb-title>`-component now have a default margin block to meet design specs. In the mixin you can opt out by passing the flag $exclude-spacing with true (e.g. `@include text-1($exclude-spacing: true)`).
In the `sbb-title` component you can just set any margin from outside on the `<sbb-title>` itself, e.g. `<sbb-title style='margin:0'>`.