### PR TITLE
refactor: rename all mixins to kebab-case

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -598,7 +598,7 @@ This is a low-effort task that makes a big difference for low-vision users. Exam
 ```scss
 @use '../../global/styles' as sbb;
 
-@include sbb.ifForcedColors {
+@include sbb.if-forced-colors {
   .unicorn-motocycle {
     border: 1px solid #fff !important;
   }

--- a/src/components/sbb-accordion-item/sbb-accordion-item.scss
+++ b/src/components/sbb-accordion-item/sbb-accordion-item.scss
@@ -55,7 +55,7 @@
 }
 
 .accordion-item__button {
-  @include sbb.buttonReset;
+  @include sbb.button-reset;
   @include sbb.text-m--regular;
 
   width: 100%;
@@ -161,7 +161,7 @@
 }
 
 // Forced Colors
-@include sbb.ifForcedColors {
+@include sbb.if-forced-colors {
   .accordion-item--open .accordion-item__button,
   .accordion-item:not(.accordion-item--disabled):hover,
   .accordion-item:not(.accordion-item--disabled):focus-within {

--- a/src/components/sbb-accordion/sbb-accordion.scss
+++ b/src/components/sbb-accordion/sbb-accordion.scss
@@ -19,7 +19,7 @@
   --border-radius-end-end: 0;
   --color-background-hover: var(--sbb-color-white-default);
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     --item-margin-block: var(--sbb-spacing-fixed-1x);
     --body-padding-inline: var(--sbb-spacing-fixed-6x);
     --header-padding-inline: var(--sbb-spacing-fixed-6x);

--- a/src/components/sbb-alert-group/sbb-alert-group.scss
+++ b/src/components/sbb-alert-group/sbb-alert-group.scss
@@ -17,11 +17,11 @@
 
 /* stylelint-disable-next-line plugin/stylelint-bem-namics */
 :host(:focus-visible:not(.sbb-alert-group-empty)) {
-  @include sbb.focusOutline;
+  @include sbb.focus-outline;
 
   border-radius: var(--sbb-alert-group-border-radius);
 }
 
 .sbb-alert-group__title {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }

--- a/src/components/sbb-alert/sbb-alert.scss
+++ b/src/components/sbb-alert/sbb-alert.scss
@@ -21,7 +21,7 @@
     --sbb-alert-close-button-wrapper-width: var(--sbb-spacing-fixed-12x);
   }
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     // Use outline here to not influence content position.
     // Due to overflow hidden of inner elements it's placed on host.
     outline: var(--sbb-border-width-1x) solid CanvasText;

--- a/src/components/sbb-autocomplete-item/sbb-autocomplete-item.scss
+++ b/src/components/sbb-autocomplete-item/sbb-autocomplete-item.scss
@@ -33,7 +33,7 @@
 .autocomplete-item:focus {
   background-color: var(--sbb-color-milk-default);
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     background-color: Highlight;
     color: HighlightText;
 

--- a/src/components/sbb-autocomplete/sbb-autocomplete.scss
+++ b/src/components/sbb-autocomplete/sbb-autocomplete.scss
@@ -48,7 +48,7 @@
     padding-inline-end: var(--sbb-spacing-responsive-xxxs-medium);
   }
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     background-color: Canvas;
     border: #{sbb.px-to-rem-build(1)} solid Highlight;
     border-block-start: none;
@@ -62,5 +62,5 @@
 }
 
 .autocomplete__accessibility-hint {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }

--- a/src/components/sbb-button/sbb-button.scss
+++ b/src/components/sbb-button/sbb-button.scss
@@ -162,10 +162,10 @@
 }
 
 .sbb-button {
-  @include sbb.buttonReset;
+  @include sbb.button-reset;
   @include sbb.stretch(width);
   @include sbb.text-xs--bold;
-  @include sbb.fontSmoothing;
+  @include sbb.font-smoothing;
 
   // Reset for link variant
   text-decoration: none;
@@ -201,13 +201,13 @@
     transition-timing-function: var(--sbb-button-transition-easing-function);
     transition-property: inset, background-color, border-color, box-shadow;
 
-    @include sbb.ifForcedColors {
+    @include sbb.if-forced-colors {
       border: #{sbb.px-to-rem-build(1)} solid windowText;
     }
   }
 
   &:focus-visible::before {
-    @include sbb.focusOutline;
+    @include sbb.focus-outline;
   }
 
   // If the the device can hover over elements with ease
@@ -228,7 +228,7 @@
         background-color: var(--sbb-button-color-hover-background);
         border-color: var(--sbb-button-color-hover-border);
 
-        @include sbb.ifForcedColors {
+        @include sbb.if-forced-colors {
           border-color: Highlight;
         }
       }
@@ -249,18 +249,18 @@
     // Line through content
     &::after {
       content: '';
-      @include sbb.absoluteCenterY;
+      @include sbb.absolute-center-y;
 
       background-color: var(--sbb-button-color-disabled-text);
       height: var(--sbb-button-disabled-line-through-height);
       inset-inline: var(--sbb-button-padding-inline);
 
-      @include sbb.ifForcedColors {
+      @include sbb.if-forced-colors {
         background-color: GrayText;
       }
     }
 
-    @include sbb.ifForcedColors {
+    @include sbb.if-forced-colors {
       color: GrayText;
     }
   }
@@ -288,7 +288,7 @@
   }
   // stylelint-enable plugin/stylelint-bem-namics
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     color: ButtonText;
   }
 }
@@ -333,5 +333,5 @@
 }
 
 .sbb-button__opens-in-new-window {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }

--- a/src/components/sbb-card-badge/sbb-card-badge.scss
+++ b/src/components/sbb-card-badge/sbb-card-badge.scss
@@ -11,7 +11,7 @@
   --card-badge-background-color-primary-negative: var(--sbb-color-white-default);
   --card-badge-border-color-primary-negative: var(--sbb-color-aluminium-default);
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     border-inline-start: #{sbb.px-to-rem-build(1)} solid CanvasText;
     border-block-end: #{sbb.px-to-rem-build(1)} solid CanvasText;
   }

--- a/src/components/sbb-card/sbb-card.scss
+++ b/src/components/sbb-card/sbb-card.scss
@@ -79,7 +79,7 @@
   }
 
   &:focus-visible {
-    @include sbb.focusOutline;
+    @include sbb.focus-outline;
   }
 
   :host([href]) & {
@@ -93,7 +93,7 @@
 
     cursor: pointer;
 
-    // can't use @include sbb.buttonReset because overrides paddings, backgrounds..., only basic rules added
+    // can't use @include sbb.button-reset because overrides paddings, backgrounds..., only basic rules added
     border: none;
     -webkit-appearance: none;
     -moz-appearance: none;
@@ -124,5 +124,5 @@
 }
 
 .sbb-card__opens-in-new-window {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }

--- a/src/components/sbb-checkbox/sbb-checkbox.scss
+++ b/src/components/sbb-checkbox/sbb-checkbox.scss
@@ -12,7 +12,7 @@
   --sbb-checkbox-label-color: var(--sbb-color-charcoal-default);
   --sbb-checkbox-cursor: pointer;
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     --sbb-checkbox-selection-color: CanvasText;
   }
 
@@ -27,7 +27,7 @@
   --sbb-checkbox-label-color: var(--sbb-color-smoke-default);
   --sbb-checkbox-cursor: default;
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     --sbb-checkbox-color: GrayText;
     --sbb-checkbox-label-color: GrayText;
     --sbb-checkbox-selection-color: GrayText;
@@ -37,7 +37,7 @@
 .sbb-checkbox-wrapper {
   display: flex;
 
-  @include sbb.zeroWidthSpace;
+  @include sbb.zero-width-space;
 }
 
 .sbb-checkbox {
@@ -63,7 +63,7 @@
 }
 
 input[type='checkbox'] {
-  @include sbb.invisibleContainerOverlay;
+  @include sbb.invisible-container-overlay;
 }
 
 .sbb-checkbox__aligner,
@@ -123,7 +123,7 @@ input[type='checkbox'] {
 }
 
 input[type='checkbox']:focus-visible + .sbb-checkbox__inner {
-  @include sbb.focusOutline;
+  @include sbb.focus-outline;
 
   border-radius: calc(var(--sbb-border-radius-4x) - var(--sbb-focus-outline-offset));
 }

--- a/src/components/sbb-dialog/sbb-dialog.scss
+++ b/src/components/sbb-dialog/sbb-dialog.scss
@@ -140,7 +140,7 @@
     border-radius: 0;
   }
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     outline: var(--sbb-border-width-1x) solid CanvasText;
   }
 

--- a/src/components/sbb-footer/sbb-footer.scss
+++ b/src/components/sbb-footer/sbb-footer.scss
@@ -29,7 +29,7 @@
 }
 
 .sbb-footer__title {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }
 
 ::slotted(.sbb-link-list-button-group) {

--- a/src/components/sbb-form-error/sbb-form-error.scss
+++ b/src/components/sbb-form-error/sbb-form-error.scss
@@ -12,7 +12,7 @@
   --sbb-icon-svg-width: var(--sbb-size-icon-form-error);
   --sbb-icon-svg-height: var(--sbb-size-icon-form-error);
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     --form-error-color: LinkText;
   }
 

--- a/src/components/sbb-form-field/sbb-form-field.scss
+++ b/src/components/sbb-form-field/sbb-form-field.scss
@@ -55,7 +55,7 @@
   --sbb-form-field-prefix-color: var(--sbb-color-graphite-default);
   --sbb-form-field-text-color: var(--sbb-color-graphite-default);
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     --sbb-form-field-label-color: GrayText;
     --sbb-form-field-prefix-color: GrayText;
     --sbb-form-field-text-color: GrayText;
@@ -76,7 +76,7 @@
   --sbb-form-field-border-color: var(--sbb-color-red125-default);
   --sbb-form-field-text-color: var(--sbb-color-red125-default);
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     --sbb-form-field-border-color: LinkText;
     --sbb-form-field-text-color: LinkText;
   }
@@ -102,7 +102,7 @@
 .sbb-form-field__space-wrapper {
   display: flex;
   flex-direction: column;
-  @include sbb.zeroWidthSpace;
+  @include sbb.zero-width-space;
 }
 
 .sbb-form-field__wrapper {
@@ -124,7 +124,7 @@
 }
 
 .sbb-form-field__select-input-icon {
-  @include sbb.absoluteCenterY;
+  @include sbb.absolute-center-y;
 
   inset-inline-end: 0;
   position: absolute;

--- a/src/components/sbb-header-action/sbb-header-action.scss
+++ b/src/components/sbb-header-action/sbb-header-action.scss
@@ -54,7 +54,7 @@ $breakpoints: 'zero', 'micro', 'small', 'medium', 'large', 'wide', 'ultra';
 }
 
 .sbb-header-action {
-  @include sbb.buttonReset;
+  @include sbb.button-reset;
   @include sbb.text-inherit;
 
   text-decoration: none;
@@ -74,7 +74,7 @@ $breakpoints: 'zero', 'micro', 'small', 'medium', 'large', 'wide', 'ultra';
   gap: var(--sbb-spacing-fixed-2x);
 
   &:focus-visible {
-    @include sbb.focusOutline;
+    @include sbb.focus-outline;
   }
 }
 
@@ -97,5 +97,5 @@ $breakpoints: 'zero', 'micro', 'small', 'medium', 'large', 'wide', 'ultra';
 }
 
 .sbb-header-action__opens-in-new-window {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }

--- a/src/components/sbb-journey-header/sbb-journey-header.scss
+++ b/src/components/sbb-journey-header/sbb-journey-header.scss
@@ -10,11 +10,11 @@
 }
 
 .journey-header[id] {
-  @include sbb.scrollMarginBlockStart;
+  @include sbb.scroll-margin-block-start;
 }
 
 .journey-header {
-  @include sbb.fontSmoothing;
+  @include sbb.font-smoothing;
 
   display: flex;
   flex-wrap: wrap;
@@ -44,7 +44,7 @@
 }
 
 .connection--visually-hidden {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }
 
 .icon {
@@ -55,7 +55,7 @@
   svg {
     fill: currentcolor;
 
-    @include sbb.ifForcedColors {
+    @include sbb.if-forced-colors {
       fill: ButtonText;
     }
   }

--- a/src/components/sbb-link-list/sbb-link-list.scss
+++ b/src/components/sbb-link-list/sbb-link-list.scss
@@ -8,7 +8,7 @@
   --sbb-link-list-flex-flow: row wrap;
 
   .sbb-link-list-title {
-    @include sbb.screenReaderOnly;
+    @include sbb.screen-reader-only;
   }
 }
 

--- a/src/components/sbb-link/sbb-link.scss
+++ b/src/components/sbb-link/sbb-link.scss
@@ -65,7 +65,7 @@
   }
 
   &:focus-visible {
-    @include sbb.focusOutline;
+    @include sbb.focus-outline;
 
     border-radius: calc(var(--sbb-border-radius-4x) - var(--sbb-focus-outline-offset));
   }
@@ -89,7 +89,7 @@
     }
   }
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     text-decoration: underline;
     text-decoration-skip-ink: auto; // -> read more about here https://bit.ly/3BHdTsE
   }
@@ -97,7 +97,7 @@
 // stylelint-enable plugin/stylelint-bem-namics
 
 button:where(.sbb-link) {
-  @include sbb.buttonReset;
+  @include sbb.button-reset;
 }
 
 .sbb-link__icon {
@@ -113,10 +113,10 @@ button:where(.sbb-link) {
 
   ::slotted([slot='icon']),
   sbb-icon {
-    @include sbb.absoluteCenterY;
+    @include sbb.absolute-center-y;
   }
 }
 
 .sbb-link__opens-in-new-window {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }

--- a/src/components/sbb-logo/sbb-logo.scss
+++ b/src/components/sbb-logo/sbb-logo.scss
@@ -14,7 +14,7 @@
   --sbb-logo-svg-container-height: auto;
   --sbb-logo-background-color: none;
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     --sbb-logo-panel-color: ButtonText !important;
     --sbb-logo-panel-stroke-color: ButtonText !important;
     --sbb-logo-signet-color: Canvas !important;

--- a/src/components/sbb-menu-action/sbb-menu-action.scss
+++ b/src/components/sbb-menu-action/sbb-menu-action.scss
@@ -15,7 +15,7 @@
 }
 
 .sbb-menu-action {
-  @include sbb.buttonReset;
+  @include sbb.button-reset;
 
   text-decoration: none;
   display: block;
@@ -48,7 +48,7 @@
   .sbb-menu-action:focus-visible & {
     --sbb-focus-outline-color: var(--sbb-focus-outline-color-dark);
 
-    @include sbb.focusOutline;
+    @include sbb.focus-outline;
   }
 
   @include sbb.hover-mq($hover: true) {

--- a/src/components/sbb-menu/sbb-menu.scss
+++ b/src/components/sbb-menu/sbb-menu.scss
@@ -115,7 +115,7 @@
     animation-name: close;
   }
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     outline: var(--sbb-border-width-1x) solid CanvasText;
   }
 

--- a/src/components/sbb-pearl-chain-time/sbb-pearl-chain-time.scss
+++ b/src/components/sbb-pearl-chain-time/sbb-pearl-chain-time.scss
@@ -36,5 +36,5 @@
 }
 
 .sbb-screenreaderonly {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }

--- a/src/components/sbb-pearl-chain-vertical-item/sbb-pearl-chain-vertical-item.scss
+++ b/src/components/sbb-pearl-chain-vertical-item/sbb-pearl-chain-vertical-item.scss
@@ -19,7 +19,7 @@
   background-color: transparent;
   z-index: 2;
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     .pearl-chain--past & {
       border-color: GrayText;
     }

--- a/src/components/sbb-pearl-chain/sbb-pearl-chain.scss
+++ b/src/components/sbb-pearl-chain/sbb-pearl-chain.scss
@@ -50,7 +50,7 @@
   inset-block-start: 0;
   z-index: 3;
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     background-color: CanvasText;
   }
 }
@@ -65,7 +65,7 @@
 
 .sbb-pearl-chain.sbb-pearl-chain--past::before,
 .sbb-pearl-chain.sbb-pearl-chain--past::after {
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     background-color: GrayText;
   }
 }
@@ -74,7 +74,7 @@
 .sbb-pearl-chain--arrival-cancellation::after {
   color: var(--color-cancellation);
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     background-color: ActiveText;
   }
 }
@@ -83,7 +83,7 @@
 .sbb-pearl-chain--arrival-cancellation.pearl-chain--past::after {
   color: var(--color-past);
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     color: GrayText;
   }
 }
@@ -91,7 +91,7 @@
 .sbb-pearl-chain--past {
   position: relative;
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     color: GrayText;
   }
 }
@@ -105,7 +105,7 @@
   background-color: currentcolor;
   width: var(--leg-width);
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     color: CanvasText;
   }
 }
@@ -133,7 +133,7 @@
     border: var(--sbb-pearl-chain-height) solid currentcolor;
     z-index: 2;
 
-    @include sbb.ifForcedColors {
+    @include sbb.if-forced-colors {
       .sbb-pearl-chain--past & {
         border-color: GrayText;
       }
@@ -152,7 +152,7 @@
   border-radius: var(--sbb-pearl-chain-height);
   z-index: 1;
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     background-color: CanvasText;
 
     .sbb-pearl-chain--past & {
@@ -173,7 +173,7 @@
 .sbb-pearl-chain__leg--cancellation {
   color: var(--color-cancellation);
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     color: ActiveText;
   }
 }
@@ -188,7 +188,7 @@
 
 .sbb-pearl-chain__leg--cancellation::after,
 .sbb-pearl-chain--past .sbb-pearl-chain__leg--cancellation::after {
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     background: none;
     border-block-start: #{sbb.px-to-rem-build(1)} dashed currentcolor;
     transform: translateY(#{sbb.px-to-rem-build(1)});
@@ -209,7 +209,7 @@
   inset-inline-start: var(--status-position);
   animation: pulse 3s infinite;
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     background-color: ActiveText;
   }
 }

--- a/src/components/sbb-radio-button/sbb-radio-button.scss
+++ b/src/components/sbb-radio-button/sbb-radio-button.scss
@@ -18,7 +18,7 @@
 }
 
 :host(:focus-visible) {
-  @include sbb.focusOutline;
+  @include sbb.focus-outline;
 
   border-radius: calc(var(--sbb-border-radius-4x) - var(--sbb-focus-outline-offset));
 }
@@ -29,7 +29,7 @@
 }
 
 .sbb-radio-button__input {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }
 
 // One radio button per line
@@ -80,7 +80,7 @@
 
     :host([data-group-disabled]) &,
     :host([disabled]) & {
-      @include sbb.ifForcedColors {
+      @include sbb.if-forced-colors {
         border-color: GrayText;
       }
     }

--- a/src/components/sbb-signet/sbb-signet.scss
+++ b/src/components/sbb-signet/sbb-signet.scss
@@ -10,7 +10,7 @@
   --sbb-signet-aspect-ratio: 2 / 1;
   --sbb-signet-svg-container-height: auto;
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     --sbb-signet-background-color: ButtonText !important;
     --sbb-signet-icon-color: Canvas !important;
   }

--- a/src/components/sbb-slider/sbb-slider.scss
+++ b/src/components/sbb-slider/sbb-slider.scss
@@ -17,7 +17,7 @@
   --sbb-slider-line-color: var(--sbb-color-smoke-default);
   --sbb-slider-line-disabled-color: var(--sbb-color-graphite-default);
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     --sbb-slider-selected-line-color: Highlight;
     --sbb-slider-line-color: CanvasText;
   }
@@ -40,7 +40,7 @@
 
 :host([disabled]),
 :host([readonly]) {
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     --sbb-slider-icon-color: GrayText;
     --sbb-slider-selected-line-disabled-color: GrayText;
     --sbb-slider-line-disabled-color: GrayText;
@@ -51,7 +51,7 @@
 }
 
 .sbb-slider__height-container {
-  @include sbb.zeroWidthSpace;
+  @include sbb.zero-width-space;
 
   display: flex;
   flex-direction: column;
@@ -79,7 +79,7 @@
 }
 
 .sbb-slider__line {
-  @include sbb.absoluteCenterY;
+  @include sbb.absolute-center-y;
 
   height: var(--sbb-slider-line-height);
   width: 100%;
@@ -97,7 +97,7 @@
 }
 
 .sbb-slider__knob {
-  @include sbb.absoluteCenterY;
+  @include sbb.absolute-center-y;
   @include sbb.shadow-level-5-hard;
 
   width: var(--sbb-slider-knob-size);
@@ -124,7 +124,7 @@
   }
 
   .sbb-slider__range-input:focus-visible ~ .sbb-slider__knob {
-    @include sbb.focusOutline;
+    @include sbb.focus-outline;
   }
 }
 /* stylelint-enable plugin/stylelint-bem-namics */

--- a/src/components/sbb-tab-amount/sbb-tab-amount.scss
+++ b/src/components/sbb-tab-amount/sbb-tab-amount.scss
@@ -6,7 +6,7 @@
 
 :host {
   @include sbb.text-xs--regular;
-  @include sbb.fontSmoothing;
+  @include sbb.font-smoothing;
 
   display: inline-block;
 }

--- a/src/components/sbb-tab-title/sbb-tab-title.scss
+++ b/src/components/sbb-tab-title/sbb-tab-title.scss
@@ -40,7 +40,7 @@
 
   .sbb-tab-title__text {
     @include sbb.text-xs--bold;
-    @include sbb.fontSmoothing;
+    @include sbb.font-smoothing;
     @include sbb.ellipsis;
   }
 
@@ -63,7 +63,7 @@
     &::before {
       inset: calc(var(--sbb-border-width-2x) * -1);
 
-      @include sbb.ifForcedColors {
+      @include sbb.if-forced-colors {
         border-color: Highlight;
       }
     }
@@ -103,7 +103,7 @@
   ::slotted(sbb-tab-amount) {
     --sbb-amount-color-override: var(--sbb-color-platinum-default);
 
-    @include sbb.ifForcedColors {
+    @include sbb.if-forced-colors {
       --sbb-amount-color-override: GrayText;
     }
   }
@@ -112,7 +112,7 @@
     border-color: var(--sbb-color-milk-default);
     background-color: var(--sbb-color-milk-default);
 
-    @include sbb.ifForcedColors {
+    @include sbb.if-forced-colors {
       border-color: GrayText;
     }
   }
@@ -122,13 +122,13 @@
     content: '';
     inset: 50% var(--sbb-spacing-fixed-5x);
     border-block-end: var(--sbb-border-width-2x) solid var(--sbb-color-platinum-default);
-    @include sbb.absoluteCenterY;
-    @include sbb.ifForcedColors {
+    @include sbb.absolute-center-y;
+    @include sbb.if-forced-colors {
       border-color: GrayText;
     }
   }
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     color: GrayText;
   }
 }
@@ -138,7 +138,7 @@
 
   .sbb-tab-title {
     &::before {
-      @include sbb.focusOutline;
+      @include sbb.focus-outline;
     }
   }
 }

--- a/src/components/sbb-teaser-hero/sbb-teaser-hero.scss
+++ b/src/components/sbb-teaser-hero/sbb-teaser-hero.scss
@@ -15,7 +15,7 @@
   display: block;
 
   &:focus-visible {
-    @include sbb.focusOutline;
+    @include sbb.focus-outline;
   }
 
   @include sbb.hover-mq($hover: true) {
@@ -28,7 +28,7 @@
 
 .sbb-teaser-hero__panel {
   @include sbb.panel;
-  @include sbb.absoluteCenterY;
+  @include sbb.absolute-center-y;
 
   z-index: 1;
 }
@@ -38,11 +38,11 @@
 }
 
 .sbb-teaser-hero__panel-link {
-  @include sbb.fontSmoothing;
+  @include sbb.font-smoothing;
 }
 
 .sbb-teaser-hero__opens-in-new-window {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }
 
 ::slotted([slot='image']),

--- a/src/components/sbb-teaser/sbb-teaser.scss
+++ b/src/components/sbb-teaser/sbb-teaser.scss
@@ -23,13 +23,13 @@
 }
 
 .sbb-teaser {
-  @include sbb.zeroWidthSpace;
+  @include sbb.zero-width-space;
 
   display: flex;
   text-decoration: none;
 
   &:focus-visible {
-    @include sbb.focusOutline;
+    @include sbb.focus-outline;
   }
 }
 
@@ -68,12 +68,12 @@
 }
 
 .sbb-teaser__lead {
-  @include sbb.clampLines($lines: 2);
+  @include sbb.clamp-lines($lines: 2);
 }
 
 .sbb-teaser__description {
   @include sbb.text-s--regular;
-  @include sbb.clampLines($lines: 2);
+  @include sbb.clamp-lines($lines: 2);
 
   color: var(--sbb-teaser-description-color);
 }
@@ -83,5 +83,5 @@
 }
 
 .sbb-teaser__opens-in-new-window {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }

--- a/src/components/sbb-timetable-barrier-free/sbb-timetable-barrier-free.scss
+++ b/src/components/sbb-timetable-barrier-free/sbb-timetable-barrier-free.scss
@@ -35,5 +35,5 @@
 }
 
 .barrier-free__text--visually-hidden {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }

--- a/src/components/sbb-timetable-button/sbb-timetable-button.scss
+++ b/src/components/sbb-timetable-button/sbb-timetable-button.scss
@@ -54,7 +54,7 @@ button[dir='rtl'] .button__chevron {
   margin-inline-end: var(--sbb-spacing-fixed-1x);
 
   @include sbb.mq($to: micro) {
-    @include sbb.screenReaderOnly;
+    @include sbb.screen-reader-only;
   }
 }
 

--- a/src/components/sbb-timetable-cus-him/sbb-timetable-cus-him.scss
+++ b/src/components/sbb-timetable-cus-him/sbb-timetable-cus-him.scss
@@ -109,5 +109,5 @@
 }
 
 .cus-him__text--visually-hidden {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }

--- a/src/components/sbb-timetable-duration/sbb-timetable-duration.scss
+++ b/src/components/sbb-timetable-duration/sbb-timetable-duration.scss
@@ -8,5 +8,5 @@
 }
 
 .duration__text--visually-hidden {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }

--- a/src/components/sbb-timetable-occupancy/sbb-timetable-occupancy.scss
+++ b/src/components/sbb-timetable-occupancy/sbb-timetable-occupancy.scss
@@ -31,7 +31,7 @@
 }
 
 .occupancy__class--visually-hidden {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }
 
 .occupancy__icon {

--- a/src/components/sbb-timetable-park-and-rail/sbb-timetable-park-and-rail.scss
+++ b/src/components/sbb-timetable-park-and-rail/sbb-timetable-park-and-rail.scss
@@ -15,7 +15,7 @@
   height: var(--park-and-rail-icon-height);
   width: var(--park-and-rail-icon-width);
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     fill: CanvasText;
   }
 }

--- a/src/components/sbb-timetable-row-column-headers/sbb-timetable-row-column-headers.scss
+++ b/src/components/sbb-timetable-row-column-headers/sbb-timetable-row-column-headers.scss
@@ -1,5 +1,5 @@
 @use '../../global/styles' as sbb;
 
 .column-headers {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }

--- a/src/components/sbb-timetable-row-day-change/sbb-timetable-row-day-change.scss
+++ b/src/components/sbb-timetable-row-day-change/sbb-timetable-row-day-change.scss
@@ -14,5 +14,5 @@
 
 .day-change--visually-hidden,
 .day-change__text--visually-hidden {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }

--- a/src/components/sbb-timetable-row-header/sbb-timetable-row-header.scss
+++ b/src/components/sbb-timetable-row-header/sbb-timetable-row-header.scss
@@ -1,5 +1,5 @@
 @use '../../global/styles' as sbb;
 
 .row-header {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }

--- a/src/components/sbb-timetable-row/sbb-timetable-row.scss
+++ b/src/components/sbb-timetable-row/sbb-timetable-row.scss
@@ -30,7 +30,7 @@
 }
 
 .sbb-screenreaderonly {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }
 
 .sbb-timetable__row--quay {

--- a/src/components/sbb-timetable-transportation-number/sbb-timetable-transportation-number.scss
+++ b/src/components/sbb-timetable-transportation-number/sbb-timetable-transportation-number.scss
@@ -89,7 +89,7 @@
 }
 
 .transportation-number--visually-hidden {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }
 
 svg {

--- a/src/components/sbb-timetable-transportation-time/sbb-timetable-transportation-time.scss
+++ b/src/components/sbb-timetable-transportation-time/sbb-timetable-transportation-time.scss
@@ -43,5 +43,5 @@
 }
 
 .time__text--visually-hidden {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }

--- a/src/components/sbb-timetable-transportation-walk/sbb-timetable-transportation-walk.scss
+++ b/src/components/sbb-timetable-transportation-walk/sbb-timetable-transportation-walk.scss
@@ -24,7 +24,7 @@
 }
 
 .walk__text--visually-hidden {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }
 
 .walk__icon {
@@ -54,7 +54,7 @@
   width: var(--walk-icon-width);
   transform: translateX(#{sbb.px-to-rem-build(-7)});
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     fill: CanvasText;
   }
 }

--- a/src/components/sbb-timetable-travel-hints/sbb-timetable-travel-hints.scss
+++ b/src/components/sbb-timetable-travel-hints/sbb-timetable-travel-hints.scss
@@ -40,10 +40,10 @@
 }
 
 .travel-hints__text--visually-hidden {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }
 
-@mixin widthWithScalingFactor($width) {
+@mixin width-with-scaling-factor($width) {
   width: calc(var(--travel-hint-icon-scaling-factor) * #{sbb.px-to-rem-build($width)});
 }
 
@@ -55,29 +55,29 @@
 // great an absolutely equal spacing.
 
 .travel-hints__icon--sa-mi svg {
-  @include widthWithScalingFactor(8);
+  @include width-with-scaling-factor(8);
 }
 
 .travel-hints__icon--sa-r svg {
-  @include widthWithScalingFactor(9);
+  @include width-with-scaling-factor(9);
 }
 
 .travel-hints__icon--sa-s svg {
-  @include widthWithScalingFactor(10);
+  @include width-with-scaling-factor(10);
 }
 
 .travel-hints__icon--sa-1,
 .travel-hints__icon--sa-2,
 .travel-hints__icon--sa-p {
   svg {
-    @include widthWithScalingFactor(11);
+    @include width-with-scaling-factor(11);
   }
 }
 
 .travel-hints__icon--sa-y,
 .travel-hints__icon--sa-z {
   svg {
-    @include widthWithScalingFactor(12);
+    @include width-with-scaling-factor(12);
   }
 }
 
@@ -85,28 +85,28 @@
 .travel-hints__icon--sa-gn,
 .travel-hints__icon--sa-rr {
   svg {
-    @include widthWithScalingFactor(13);
+    @include width-with-scaling-factor(13);
   }
 }
 
 .travel-hints__icon--sa-wr svg {
-  @include widthWithScalingFactor(14);
+  @include width-with-scaling-factor(14);
 }
 
 .travel-hints__icon--sa-x svg {
-  @include widthWithScalingFactor(15);
+  @include width-with-scaling-factor(15);
 }
 
 .travel-hints__icon--sa-pa svg {
-  @include widthWithScalingFactor(16);
+  @include width-with-scaling-factor(16);
 }
 
 .travel-hints__icon--sa-vi svg {
-  @include widthWithScalingFactor(17);
+  @include width-with-scaling-factor(17);
 }
 
 .travel-hints__icon--sa-fl svg {
-  @include widthWithScalingFactor(18);
+  @include width-with-scaling-factor(18);
 }
 
 .travel-hints__icon--sa-b,
@@ -116,7 +116,7 @@
 .travel-hints__icon--sa-vl,
 .travel-hints__icon--sa-vr {
   svg {
-    @include widthWithScalingFactor(19);
+    @include width-with-scaling-factor(19);
   }
 }
 
@@ -126,7 +126,7 @@
 .travel-hints__icon--sa-tf,
 .travel-hints__icon--sa-ts {
   svg {
-    @include widthWithScalingFactor(20);
+    @include width-with-scaling-factor(20);
   }
 }
 
@@ -141,7 +141,7 @@
 .travel-hints__icon--sa-tt,
 .travel-hints__icon--sa-wl {
   svg {
-    @include widthWithScalingFactor(21);
+    @include width-with-scaling-factor(21);
   }
 }
 
@@ -156,7 +156,7 @@
 .travel-hints__icon--sa-vp,
 .travel-hints__icon--sa-yb {
   svg {
-    @include widthWithScalingFactor(22);
+    @include width-with-scaling-factor(22);
   }
 }
 
@@ -174,7 +174,7 @@
 .travel-hints__icon--sa-ws,
 .travel-hints__icon--sa-yt {
   svg {
-    @include widthWithScalingFactor(23);
+    @include width-with-scaling-factor(23);
   }
 }
 
@@ -182,7 +182,7 @@
 .travel-hints__icon--sa-sh,
 .travel-hints__icon--sa-sv {
   svg {
-    @include widthWithScalingFactor(24);
+    @include width-with-scaling-factor(24);
   }
 }
 
@@ -195,7 +195,7 @@
 .travel-hints__icon--sa-xp,
 .travel-hints__icon--sa-xr {
   svg {
-    @include widthWithScalingFactor(25);
+    @include width-with-scaling-factor(25);
   }
 }
 
@@ -203,14 +203,14 @@
 .travel-hints__icon--sa-uk,
 .travel-hints__icon--sa-xt {
   svg {
-    @include widthWithScalingFactor(26);
+    @include width-with-scaling-factor(26);
   }
 }
 
 .travel-hints__icon--sa-hk,
 .travel-hints__icon--sa-hn {
   svg {
-    @include widthWithScalingFactor(27);
+    @include width-with-scaling-factor(27);
   }
 }
 
@@ -218,7 +218,7 @@
 .travel-hints__icon--sa-mp,
 .travel-hints__icon--sa-sm {
   svg {
-    @include widthWithScalingFactor(28);
+    @include width-with-scaling-factor(28);
   }
 }
 
@@ -226,22 +226,22 @@
 .travel-hints__icon--sa-ym,
 .travel-hints__icon--sa-zm {
   svg {
-    @include widthWithScalingFactor(29);
+    @include width-with-scaling-factor(29);
   }
 }
 
 .travel-hints__icon--sa-wv {
-  @include widthWithScalingFactor(31);
+  @include width-with-scaling-factor(31);
 }
 
 .travel-hints__icon--sa-vb {
-  @include widthWithScalingFactor(32);
+  @include width-with-scaling-factor(32);
 }
 
 .travel-hints__icon--sa-kw {
-  @include widthWithScalingFactor(33);
+  @include width-with-scaling-factor(33);
 }
 
 .travel-hints__icon--sa-aw {
-  @include widthWithScalingFactor(34);
+  @include width-with-scaling-factor(34);
 }

--- a/src/components/sbb-timetable/sbb-timetable.scss
+++ b/src/components/sbb-timetable/sbb-timetable.scss
@@ -18,5 +18,5 @@
 
 .timetable > svg,
 .timetable__column-headers {
-  @include sbb.screenReaderOnly;
+  @include sbb.screen-reader-only;
 }

--- a/src/components/sbb-title/sbb-title.scss
+++ b/src/components/sbb-title/sbb-title.scss
@@ -17,14 +17,14 @@
 
 .sbb-title {
   color: var(--sbb-title-text-color-normal);
-  @include sbb.fontSmoothing;
+  @include sbb.font-smoothing;
 
   :host([visually-hidden]) & {
-    @include sbb.screenReaderOnly;
+    @include sbb.screen-reader-only;
   }
 
   &[id] {
-    @include sbb.scrollMarginBlockStart;
+    @include sbb.scroll-margin-block-start;
   }
 
   // stylelint-disable plugin/stylelint-bem-namics

--- a/src/components/sbb-toggle-check/sbb-toggle-check.scss
+++ b/src/components/sbb-toggle-check/sbb-toggle-check.scss
@@ -21,7 +21,7 @@
   --sbb-toggle-check-flex-direction: row-reverse;
   --sbb-toggle-check-icon-opacity: 0;
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     --sbb-toggle-check-circle-background: Canvas;
     --sbb-toggle-check-background: CanvasText;
   }
@@ -35,7 +35,7 @@
   );
   --sbb-toggle-check-icon-opacity: 1;
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     --sbb-toggle-check-fill: Highlight;
     --sbb-toggle-check-background: Highlight;
   }
@@ -48,7 +48,7 @@
   --sbb-toggle-check-circle-background: var(--sbb-color-milk-default);
   --sbb-toggle-check-cursor: not-allowed;
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     --sbb-toggle-check-fill: GrayText;
     --sbb-toggle-check-background: GrayText;
   }
@@ -60,7 +60,7 @@
 
 .sbb-toggle-check {
   // Avoids unwanted space displayed if no label text is set.
-  @include sbb.zeroWidthSpace;
+  @include sbb.zero-width-space;
 
   position: relative;
   display: flex;
@@ -70,7 +70,7 @@
 }
 
 input[type='checkbox'] {
-  @include sbb.invisibleContainerOverlay;
+  @include sbb.invisible-container-overlay;
 }
 
 .sbb-toggle-check__container {
@@ -99,13 +99,13 @@ input[type='checkbox'] {
   cursor: var(--sbb-toggle-check-cursor);
 
   input[type='checkbox']:focus-visible + .toggle-check__container & {
-    @include sbb.focusOutline;
+    @include sbb.focus-outline;
   }
 }
 
 .sbb-toggle-check__circle {
   @include sbb.shadow-level-5-hard;
-  @include sbb.absoluteCenterY;
+  @include sbb.absolute-center-y;
 
   width: var(--sbb-toggle-check-circle-diameter);
   height: var(--sbb-toggle-check-circle-diameter);

--- a/src/components/sbb-tooltip/sbb-tooltip.scss
+++ b/src/components/sbb-tooltip/sbb-tooltip.scss
@@ -74,7 +74,7 @@
   &::after {
     @include sbb.shadow-level-5-hard;
 
-    @include sbb.ifForcedColors {
+    @include sbb.if-forced-colors {
       outline: var(--sbb-border-width-1x) solid CanvasText;
     }
 
@@ -92,7 +92,7 @@
     }
   }
 
-  @include sbb.ifForcedColors {
+  @include sbb.if-forced-colors {
     outline: var(--sbb-border-width-1x) solid CanvasText;
   }
 }

--- a/src/global/styles/mixins/a11y.scss
+++ b/src/global/styles/mixins/a11y.scss
@@ -1,22 +1,22 @@
 // ----------------------------------------------------------------------------------------------------
 // A11y: MediaQueries & Other things
 // ----------------------------------------------------------------------------------------------------
-@mixin ifForcedColors {
+@mixin if-forced-colors {
   @media (forced-colors: active) {
     @content;
   }
 }
 
-@mixin focusOutline {
+@mixin focus-outline {
   outline-offset: var(--sbb-focus-outline-offset);
   outline: var(--sbb-focus-outline-color) solid var(--sbb-focus-outline-width);
 
-  @include ifForcedColors {
+  @include if-forced-colors {
     outline-color: Highlight;
   }
 }
 
-@mixin screenReaderOnly {
+@mixin screen-reader-only {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;
@@ -28,6 +28,6 @@
   width: 1px;
 }
 
-@mixin scrollMarginBlockStart() {
+@mixin scroll-margin-block-start() {
   scroll-margin-block-start: var(--sbb-spacing-fixed-10x);
 }

--- a/src/global/styles/mixins/buttons.scss
+++ b/src/global/styles/mixins/buttons.scss
@@ -2,7 +2,7 @@
 // Buttons Mixins
 // ----------------------------------------------------------------------------------------------------
 
-@mixin buttonReset {
+@mixin button-reset {
   -webkit-appearance: none;
   -moz-appearance: none;
   box-sizing: border-box;

--- a/src/global/styles/mixins/card.scss
+++ b/src/global/styles/mixins/card.scss
@@ -42,7 +42,7 @@
   &:focus {
     @include card--shadow;
 
-    @include a11y.focusOutline;
+    @include a11y.focus-outline;
   }
 
   // If the the device can hover over elements with ease
@@ -52,7 +52,7 @@
     }
   }
 
-  @include a11y.ifForcedColors {
+  @include a11y.if-forced-colors {
     border: #{functions.px-to-rem-build(1)} solid ButtonText;
 
     &:disabled {

--- a/src/global/styles/mixins/helpers.scss
+++ b/src/global/styles/mixins/helpers.scss
@@ -9,27 +9,27 @@
   #{$property}: stretch;
 }
 
-@mixin absoluteCenterXY() {
+@mixin absolute-center-x-y() {
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
 }
 
-@mixin absoluteCenterX() {
+@mixin absolute-center-x() {
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
 }
 
-@mixin absoluteCenterY() {
+@mixin absolute-center-y() {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
 }
 
 /** This mixin can be used to avoid spacing problems by inserting an invisible space as pseudo element. */
-@mixin zeroWidthSpace() {
+@mixin zero-width-space() {
   &::before {
     content: '\200B';
     user-select: none;
@@ -38,7 +38,7 @@
   }
 }
 
-@mixin invisibleContainerOverlay {
+@mixin invisible-container-overlay {
   position: absolute;
   opacity: 0;
   inset: 0;

--- a/src/global/styles/mixins/panel.scss
+++ b/src/global/styles/mixins/panel.scss
@@ -65,7 +65,7 @@
 }
 
 @mixin panel-text {
-  @include typo.fontSmoothing;
+  @include typo.font-smoothing;
 
   font-family: var(--panel-font-family);
   font-size: var(--panel-font-size);

--- a/src/global/styles/mixins/typo.scss
+++ b/src/global/styles/mixins/typo.scss
@@ -150,19 +150,19 @@
  * Usage:
  *
  * .var_dark_on_light {
- * 	@include fontSmoothing;
+ * 	@include font-smoothing;
  * }
  * .var_light_on_dark {
- * 	@include fontSmoothingReset;
+ * 	@include font-smoothing-reset;
  * }
  */
 
-@mixin fontSmoothing() {
+@mixin font-smoothing() {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-@mixin fontSmoothingReset() {
+@mixin font-smoothing-reset() {
   -webkit-font-smoothing: subpixel-antialiased;
   -moz-osx-font-smoothing: auto;
 }
@@ -173,7 +173,7 @@
   }
 }
 
-@mixin clampLines($lines) {
+@mixin clamp-lines($lines) {
   overflow: hidden;
   display: -webkit-box;
   -webkit-box-orient: vertical;


### PR DESCRIPTION
BREAKING CHANGE:
In order to standardize mixin names, all mixin names were renamed to kebab-case style. E.g. `ifForcedColors` became `if-forced-colors`.

