### PR TITLE
refactor(sbb-toggle-check): introduce new design

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1632,7 +1632,7 @@ export namespace Components {
         /**
           * The svg name for the true state - default -> 'tick-small'
          */
-        "icon": string;
+        "iconName": string;
         /**
           * The label position relative to the toggle. Defaults to 'after'
          */
@@ -4014,7 +4014,7 @@ declare namespace LocalJSX {
         /**
           * The svg name for the true state - default -> 'tick-small'
          */
-        "icon"?: string;
+        "iconName"?: string;
         /**
           * The label position relative to the toggle. Defaults to 'after'
          */

--- a/src/components/sbb-toggle-check/readme.md
+++ b/src/components/sbb-toggle-check/readme.md
@@ -49,7 +49,7 @@ descriptive text content.
 | `accessibilityLabel` | `accessibility-label` | The aria-label prop for the hidden input.                      | `string`              | `undefined`    |
 | `checked`            | `checked`             | Whether the toggle-check is checked.                           | `boolean`             | `false`        |
 | `disabled`           | `disabled`            | The disabled prop for the disabled state.                      | `boolean`             | `false`        |
-| `icon`               | `icon`                | The svg name for the true state - default -> 'tick-small'      | `string`              | `'tick-small'` |
+| `iconName`           | `icon-name`           | The svg name for the true state - default -> 'tick-small'      | `string`              | `'tick-small'` |
 | `labelPosition`      | `label-position`      | The label position relative to the toggle. Defaults to 'after' | `"after" \| "before"` | `'after'`      |
 | `name`               | `name`                | Name of the toggle-check.                                      | `string`              | `undefined`    |
 | `required`           | `required`            | The required prop for the required state.                      | `boolean`             | `false`        |

--- a/src/components/sbb-toggle-check/sbb-toggle-check.e2e.ts
+++ b/src/components/sbb-toggle-check/sbb-toggle-check.e2e.ts
@@ -1,11 +1,11 @@
-import { newE2EPage } from '@stencil/core/testing';
+import { E2EElement, E2EPage, newE2EPage } from '@stencil/core/testing';
 
 describe('sbb-toggle-check', () => {
-  let element, page;
+  let element: E2EElement, page: E2EPage;
 
   beforeEach(async () => {
     page = await newE2EPage();
-    await page.setContent('<sbb-toggle-check></sbb-toggle-check>');
+    await page.setContent('<sbb-toggle-check id="outer-id"></sbb-toggle-check>');
     element = await page.find('sbb-toggle-check');
   });
 
@@ -22,6 +22,33 @@ describe('sbb-toggle-check', () => {
 
       await toggle.click();
       expect(changeSpy).toHaveReceivedEventTimes(1);
+    });
+
+    it('should forward host click to input element', async () => {
+      const input = await page.find('sbb-toggle-check >>> input');
+      const changeSpy = await input.spyOnEvent('click');
+
+      element.triggerEvent('click');
+      await page.waitForChanges();
+
+      expect(changeSpy).toHaveReceivedEventTimes(1);
+    });
+
+    it('should forward host focus event to the input element', async () => {
+      const input = await page.find('sbb-toggle-check >>> input');
+
+      const changeSpy = await input.spyOnEvent('focus');
+
+      await element.focus();
+      await page.waitForChanges();
+
+      expect(changeSpy).toHaveReceivedEventTimes(1);
+
+      // Although the inner native button receives the focus, the active element is the host
+      expect(await page.evaluate(() => document.activeElement.id)).toBe('outer-id');
+      expect(await page.evaluate(() => document.activeElement.shadowRoot.activeElement.id)).toBe(
+        'sbb-toggle-check-input'
+      );
     });
   });
 });

--- a/src/components/sbb-toggle-check/sbb-toggle-check.scss
+++ b/src/components/sbb-toggle-check/sbb-toggle-check.scss
@@ -33,7 +33,7 @@
   --sbb-toggle-check-circle-border-color: var(--sbb-toggle-check-background-color);
   --sbb-toggle-check-icon-opacity: 1;
 
-  // As the circle is greater than the slider below,
+  // As the circle is greater than the track below,
   // we have to subtract the difference in order to not overshoot at the right side.
   // 100% of circle (28px) - 2 * (100% (28px) - 0.5 * width (48px)) => 20px
   --sbb-toggle-check-circle-transform: translate(
@@ -108,7 +108,7 @@ input[type='checkbox'] {
   );
 }
 
-.sbb-toggle-check__slider {
+.sbb-toggle-check__track {
   display: inline-block;
   position: relative;
   min-width: var(--sbb-toggle-check-width);

--- a/src/components/sbb-toggle-check/sbb-toggle-check.scss
+++ b/src/components/sbb-toggle-check/sbb-toggle-check.scss
@@ -100,7 +100,7 @@ input[type='checkbox'] {
 .sbb-toggle-check__label {
   flex-grow: 1;
   padding-block-start: calc(
-    (var(--sbb-toggle-check-height) - (var(--sbb-typo-line-height-body-text) * 1em)) / 2
+    (var(--sbb-toggle-check-circle-diameter) - (var(--sbb-typo-line-height-body-text) * 1em)) / 2
   );
 }
 

--- a/src/components/sbb-toggle-check/sbb-toggle-check.scss
+++ b/src/components/sbb-toggle-check/sbb-toggle-check.scss
@@ -49,7 +49,7 @@
   --sbb-toggle-check-background: var(--sbb-color-cloud-default);
   --sbb-toggle-check-fill: var(--sbb-color-smoke-default);
   --sbb-toggle-check-circle-background: var(--sbb-color-milk-default);
-  --sbb-toggle-check-cursor: not-allowed;
+  --sbb-toggle-check-cursor: default;
 
   @include sbb.if-forced-colors {
     --sbb-toggle-check-fill: GrayText;
@@ -74,6 +74,7 @@
   color: var(--sbb-toggle-check-color);
   user-select: none;
   -webkit-tap-highlight-color: transparent;
+  cursor: var(--sbb-toggle-check-cursor);
 
   input[type='checkbox']:focus-visible + & {
     @include sbb.focus-outline;
@@ -110,7 +111,6 @@ input[type='checkbox'] {
   height: var(--sbb-toggle-check-height);
   border-radius: var(--sbb-toggle-check-height);
   background-color: var(--sbb-toggle-check-background);
-  cursor: var(--sbb-toggle-check-cursor);
 
   // Reserve space of overlapping circle
   margin-block: calc(
@@ -133,7 +133,7 @@ input[type='checkbox'] {
   transition: transform ease var(--sbb-animation-duration-6x);
 }
 
-.sbb-toggle-check-icon {
+.sbb-toggle-check__icon {
   @include sbb.absolute-center-x-y;
 
   width: var(--sbb-size-icon-ui-small);

--- a/src/components/sbb-toggle-check/sbb-toggle-check.scss
+++ b/src/components/sbb-toggle-check/sbb-toggle-check.scss
@@ -11,15 +11,14 @@
   --sbb-toggle-check-background: var(--sbb-color-smoke-default);
   --sbb-toggle-check-fill: var(--sbb-color-red-default);
   --sbb-toggle-check-circle-background: var(--sbb-color-white-default);
-  --sbb-toggle-check-circle-offset: var(--sbb-border-width-2x);
-  --sbb-toggle-check-circle-diameter: var(--sbb-size-icon-ui-small);
-  --sbb-toggle-check-height: calc(
-    var(--sbb-toggle-check-circle-diameter) + 2 * var(--sbb-toggle-check-circle-offset)
-  );
-  --sbb-toggle-check-circle-transform: translate(var(--sbb-toggle-check-circle-offset), -50%);
+  --sbb-toggle-check-circle-diameter: #{sbb.px-to-rem-build(28)};
+  --sbb-toggle-check-circle-transform: translate(0, -50%);
+  --sbb-toggle-check-height: #{sbb.px-to-rem-build(24)};
+  --sbb-toggle-check-width: calc(2 * var(--sbb-toggle-check-height));
   --sbb-toggle-check-cursor: pointer;
   --sbb-toggle-check-flex-direction: row-reverse;
   --sbb-toggle-check-icon-opacity: 0;
+  --sbb-toggle-check-vertical-align: start;
 
   @include sbb.if-forced-colors {
     --sbb-toggle-check-circle-background: Canvas;
@@ -29,8 +28,12 @@
 
 :host([checked]:not([checked='false'])) {
   --sbb-toggle-check-background: var(--sbb-color-red-default);
+
+  // As the circle is greater than the slider below,
+  // we have to subtract the difference in order to not overshoot on the right side.
+  // 100% of circle (28px) - 2 * (100% (28px) - 0.5 * width (48px)) => 20px
   --sbb-toggle-check-circle-transform: translate(
-    calc(100% - var(--sbb-toggle-check-circle-offset)),
+    calc(100% - 2 * (100% - 0.5 * var(--sbb-toggle-check-width))),
     -50%
   );
   --sbb-toggle-check-icon-opacity: 1;
@@ -44,7 +47,7 @@
 :host([disabled]:not([disabled='false'])) {
   --sbb-toggle-check-color: var(--sbb-color-graphite-default);
   --sbb-toggle-check-background: var(--sbb-color-cloud-default);
-  --sbb-toggle-check-fill: var(--sbb-color-granite-default);
+  --sbb-toggle-check-fill: var(--sbb-color-smoke-default);
   --sbb-toggle-check-circle-background: var(--sbb-color-milk-default);
   --sbb-toggle-check-cursor: not-allowed;
 
@@ -52,6 +55,10 @@
     --sbb-toggle-check-fill: GrayText;
     --sbb-toggle-check-background: GrayText;
   }
+}
+
+:host([checked][disabled]) {
+  --sbb-toggle-check-circle-background: var(--sbb-color-white-default);
 }
 
 :host([label-position='before']) {
@@ -76,7 +83,7 @@
 }
 
 input[type='checkbox'] {
-  @include sbb.invisible-container-overlay;
+  @include sbb.screen-reader-only;
 }
 
 .sbb-toggle-check__container {
@@ -85,7 +92,7 @@ input[type='checkbox'] {
   display: flex;
   flex-direction: var(--sbb-toggle-check-flex-direction);
   gap: var(--sbb-spacing-fixed-3x);
-  align-items: start;
+  align-items: var(--sbb-toggle-check-vertical-align);
   width: 100%;
 }
 
@@ -99,12 +106,16 @@ input[type='checkbox'] {
 .sbb-toggle-check__slider {
   display: inline-block;
   position: relative;
-  overflow: hidden;
-  min-width: calc(2 * var(--sbb-toggle-check-circle-diameter));
+  min-width: var(--sbb-toggle-check-width);
   height: var(--sbb-toggle-check-height);
   border-radius: var(--sbb-toggle-check-height);
   background-color: var(--sbb-toggle-check-background);
   cursor: var(--sbb-toggle-check-cursor);
+
+  // Reserve space of overlapping circle
+  margin-block: calc(
+    0.5 * (var(--sbb-toggle-check-circle-diameter) - var(--sbb-toggle-check-height))
+  );
 }
 
 .sbb-toggle-check__circle {
@@ -113,7 +124,8 @@ input[type='checkbox'] {
 
   width: var(--sbb-toggle-check-circle-diameter);
   height: var(--sbb-toggle-check-circle-diameter);
-  border-radius: var(--sbb-toggle-check-height);
+  border: var(--sbb-border-width-1x) solid var(--sbb-toggle-check-background);
+  border-radius: 50%;
   background-color: var(--sbb-toggle-check-circle-background);
   color: var(--sbb-toggle-check-fill);
   will-change: transform;
@@ -121,8 +133,11 @@ input[type='checkbox'] {
   transition: transform ease var(--sbb-animation-duration-6x);
 }
 
-::slotted(sbb-icon),
-slot[name='icon'] sbb-icon {
+.sbb-toggle-check-icon {
+  @include sbb.absolute-center-x-y;
+
+  width: var(--sbb-size-icon-ui-small);
+  height: var(--sbb-size-icon-ui-small);
   opacity: var(--sbb-toggle-check-icon-opacity);
   transition: opacity ease var(--sbb-animation-duration-6x);
 }

--- a/src/components/sbb-toggle-check/sbb-toggle-check.scss
+++ b/src/components/sbb-toggle-check/sbb-toggle-check.scss
@@ -7,58 +7,62 @@
 :host {
   display: inline-block;
 
-  --sbb-toggle-check-color: var(--sbb-color-charcoal-default);
-  --sbb-toggle-check-background: var(--sbb-color-smoke-default);
-  --sbb-toggle-check-fill: var(--sbb-color-red-default);
-  --sbb-toggle-check-circle-background: var(--sbb-color-white-default);
+  --sbb-toggle-check-font-color: var(--sbb-color-charcoal-default);
+  --sbb-toggle-check-checked-color: var(--sbb-color-red-default);
+  --sbb-toggle-check-background-color: var(--sbb-color-cloud-default);
+  --sbb-toggle-check-icon-color: var(--sbb-toggle-check-checked-color);
+  --sbb-toggle-check-icon-opacity: 0;
+  --sbb-toggle-check-circle-background-color: var(--sbb-color-white-default);
+  --sbb-toggle-check-circle-border-color: var(--sbb-color-smoke-default);
   --sbb-toggle-check-circle-diameter: #{sbb.px-to-rem-build(28)};
   --sbb-toggle-check-circle-transform: translate(0, -50%);
   --sbb-toggle-check-height: #{sbb.px-to-rem-build(24)};
   --sbb-toggle-check-width: calc(2 * var(--sbb-toggle-check-height));
   --sbb-toggle-check-cursor: pointer;
   --sbb-toggle-check-flex-direction: row-reverse;
-  --sbb-toggle-check-icon-opacity: 0;
-  --sbb-toggle-check-vertical-align: start;
+  --sbb-toggle-check-gap: var(--sbb-spacing-fixed-3x);
 
   @include sbb.if-forced-colors {
-    --sbb-toggle-check-circle-background: Canvas;
-    --sbb-toggle-check-background: CanvasText;
+    --sbb-toggle-check-background-color: CanvasText;
+    --sbb-toggle-check-circle-background-color: Canvas;
   }
 }
 
 :host([checked]:not([checked='false'])) {
-  --sbb-toggle-check-background: var(--sbb-color-red-default);
+  --sbb-toggle-check-background-color: var(--sbb-toggle-check-checked-color);
+  --sbb-toggle-check-circle-border-color: var(--sbb-toggle-check-background-color);
+  --sbb-toggle-check-icon-opacity: 1;
 
   // As the circle is greater than the slider below,
-  // we have to subtract the difference in order to not overshoot on the right side.
+  // we have to subtract the difference in order to not overshoot at the right side.
   // 100% of circle (28px) - 2 * (100% (28px) - 0.5 * width (48px)) => 20px
   --sbb-toggle-check-circle-transform: translate(
     calc(100% - 2 * (100% - 0.5 * var(--sbb-toggle-check-width))),
     -50%
   );
-  --sbb-toggle-check-icon-opacity: 1;
 
   @include sbb.if-forced-colors {
-    --sbb-toggle-check-fill: Highlight;
-    --sbb-toggle-check-background: Highlight;
+    --sbb-toggle-check-icon-color: Highlight;
+    --sbb-toggle-check-background-color: Highlight;
   }
 }
 
 :host([disabled]:not([disabled='false'])) {
-  --sbb-toggle-check-color: var(--sbb-color-graphite-default);
-  --sbb-toggle-check-background: var(--sbb-color-cloud-default);
-  --sbb-toggle-check-fill: var(--sbb-color-smoke-default);
-  --sbb-toggle-check-circle-background: var(--sbb-color-milk-default);
+  --sbb-toggle-check-font-color: var(--sbb-color-graphite-default);
+  --sbb-toggle-check-background-color: var(--sbb-color-cloud-default);
+  --sbb-toggle-check-circle-border-color: var(--sbb-toggle-check-background-color);
+  --sbb-toggle-check-circle-background-color: var(--sbb-color-milk-default);
+  --sbb-toggle-check-icon-color: var(--sbb-color-smoke-default);
   --sbb-toggle-check-cursor: default;
 
   @include sbb.if-forced-colors {
-    --sbb-toggle-check-fill: GrayText;
-    --sbb-toggle-check-background: GrayText;
+    --sbb-toggle-check-icon-color: GrayText;
+    --sbb-toggle-check-background-color: GrayText;
   }
 }
 
-:host([checked][disabled]) {
-  --sbb-toggle-check-circle-background: var(--sbb-color-white-default);
+:host([checked]:not([checked='false'])[disabled]:not([disabled='false'])) {
+  --sbb-toggle-check-circle-background-color: var(--sbb-color-white-default);
 }
 
 :host([label-position='before']) {
@@ -71,7 +75,7 @@
 
   position: relative;
   display: flex;
-  color: var(--sbb-toggle-check-color);
+  color: var(--sbb-toggle-check-font-color);
   user-select: none;
   -webkit-tap-highlight-color: transparent;
   cursor: var(--sbb-toggle-check-cursor);
@@ -92,8 +96,8 @@ input[type='checkbox'] {
 
   display: flex;
   flex-direction: var(--sbb-toggle-check-flex-direction);
-  gap: var(--sbb-spacing-fixed-3x);
-  align-items: var(--sbb-toggle-check-vertical-align);
+  gap: var(--sbb-toggle-check-gap);
+  align-items: start;
   width: 100%;
 }
 
@@ -110,7 +114,7 @@ input[type='checkbox'] {
   min-width: var(--sbb-toggle-check-width);
   height: var(--sbb-toggle-check-height);
   border-radius: var(--sbb-toggle-check-height);
-  background-color: var(--sbb-toggle-check-background);
+  background-color: var(--sbb-toggle-check-background-color);
 
   // Reserve space of overlapping circle
   margin-block: calc(
@@ -124,10 +128,10 @@ input[type='checkbox'] {
 
   width: var(--sbb-toggle-check-circle-diameter);
   height: var(--sbb-toggle-check-circle-diameter);
-  border: var(--sbb-border-width-1x) solid var(--sbb-toggle-check-background);
+  border: var(--sbb-border-width-1x) solid var(--sbb-toggle-check-circle-border-color);
   border-radius: 50%;
-  background-color: var(--sbb-toggle-check-circle-background);
-  color: var(--sbb-toggle-check-fill);
+  background-color: var(--sbb-toggle-check-circle-background-color);
+  color: var(--sbb-toggle-check-icon-color);
   will-change: transform;
   transform: var(--sbb-toggle-check-circle-transform);
   transition: transform ease var(--sbb-animation-duration-6x);

--- a/src/components/sbb-toggle-check/sbb-toggle-check.scss
+++ b/src/components/sbb-toggle-check/sbb-toggle-check.scss
@@ -67,6 +67,12 @@
   color: var(--sbb-toggle-check-color);
   user-select: none;
   -webkit-tap-highlight-color: transparent;
+
+  input[type='checkbox']:focus-visible + & {
+    @include sbb.focus-outline;
+
+    border-radius: calc(var(--sbb-border-radius-4x) - var(--sbb-focus-outline-offset));
+  }
 }
 
 input[type='checkbox'] {
@@ -80,9 +86,11 @@ input[type='checkbox'] {
   flex-direction: var(--sbb-toggle-check-flex-direction);
   gap: var(--sbb-spacing-fixed-3x);
   align-items: start;
+  width: 100%;
 }
 
 .sbb-toggle-check__label {
+  flex-grow: 1;
   padding-block-start: calc(
     (var(--sbb-toggle-check-height) - (var(--sbb-typo-line-height-body-text) * 1em)) / 2
   );
@@ -97,10 +105,6 @@ input[type='checkbox'] {
   border-radius: var(--sbb-toggle-check-height);
   background-color: var(--sbb-toggle-check-background);
   cursor: var(--sbb-toggle-check-cursor);
-
-  input[type='checkbox']:focus-visible + .sbb-toggle-check__container & {
-    @include sbb.focus-outline;
-  }
 }
 
 .sbb-toggle-check__circle {

--- a/src/components/sbb-toggle-check/sbb-toggle-check.spec.ts
+++ b/src/components/sbb-toggle-check/sbb-toggle-check.spec.ts
@@ -11,18 +11,20 @@ describe('sbb-toggle-check', () => {
     expect(root).toEqualHtml(`
         <sbb-toggle-check label-position="after">
           <mock:shadow-root>
-            <label class="sbb-toggle-check">
-              <input type="checkbox"/>
-                <span class="sbb-toggle-check__container">
-                  <span class="sbb-toggle-check__label" hidden="">
-                    <slot></slot>
-                  </span>
-                  <span class="sbb-toggle-check__slider">
-                    <span class="sbb-toggle-check__circle">
+            <input type="checkbox" id="sbb-toggle-check-input"/>
+            <label class="sbb-toggle-check" htmlfor="sbb-toggle-check-input">
+              <span class="sbb-toggle-check__container">
+                <span class="sbb-toggle-check__label" hidden="">
+                  <slot></slot>
+                </span>
+                <span class="sbb-toggle-check__slider">
+                  <span class="sbb-toggle-check__circle">
+                    <span class="sbb-toggle-check__icon">
                       <slot name="icon">
                         <sbb-icon name="tick-small"></sbb-icon>
                       </slot>
                     </span>
+                  </span>
                 </span>
               </span>
             </label>
@@ -43,14 +45,15 @@ describe('sbb-toggle-check', () => {
       expect(root).toEqualHtml(`
         <sbb-toggle-check label-position="before">
           <mock:shadow-root>
-            <label class="sbb-toggle-check">
-              <input type="checkbox"/>
-                <span class="sbb-toggle-check__container">
-                  <span class="sbb-toggle-check__label">
-                    <slot></slot>
-                  </span>
-                  <span class="sbb-toggle-check__slider">
-                  <span class="sbb-toggle-check__circle">
+            <input type="checkbox" id="sbb-toggle-check-input"/>
+            <label class="sbb-toggle-check" htmlfor="sbb-toggle-check-input">
+              <span class="sbb-toggle-check__container">
+                <span class="sbb-toggle-check__label">
+                  <slot></slot>
+                </span>
+                <span class="sbb-toggle-check__slider">
+                <span class="sbb-toggle-check__circle">
+                  <span class="sbb-toggle-check__icon">
                     <slot name="icon">
                       <sbb-icon name="tick-small"></sbb-icon>
                     </slot>
@@ -76,17 +79,19 @@ describe('sbb-toggle-check', () => {
         expect(root).toEqualHtml(`
           <sbb-toggle-check checked label-position="after">
             <mock:shadow-root>
-              <label class="sbb-toggle-check">
-                <input checked="" type="checkbox"/>
+              <input checked="" type="checkbox" id="sbb-toggle-check-input"/>
+              <label class="sbb-toggle-check" htmlfor="sbb-toggle-check-input">
                 <span class="sbb-toggle-check__container">
                   <span class="sbb-toggle-check__label" hidden="">
                     <slot></slot>
                   </span>
                   <span class="sbb-toggle-check__slider">
                     <span class="sbb-toggle-check__circle">
-                      <slot name="icon">
-                        <sbb-icon name="tick-small"></sbb-icon>
-                      </slot>
+                      <span class="sbb-toggle-check__icon">
+                        <slot name="icon">
+                          <sbb-icon name="tick-small"></sbb-icon>
+                        </slot>
+                      </span>
                     </span>
                   </span>
                 </span>
@@ -107,18 +112,20 @@ describe('sbb-toggle-check', () => {
         expect(root).toEqualHtml(`
           <sbb-toggle-check disabled label-position="after">
             <mock:shadow-root>
-              <label class="sbb-toggle-check">
-                <input disabled="" aria-disabled="" type="checkbox">
-                  <span class="sbb-toggle-check__container">
+              <input disabled="" aria-disabled="" type="checkbox" id="sbb-toggle-check-input">
+              <label class="sbb-toggle-check" htmlfor="sbb-toggle-check-input">
+                <span class="sbb-toggle-check__container">
                   <span class="sbb-toggle-check__label" hidden="">
                     <slot></slot>
                   </span>
                   <span class="sbb-toggle-check__slider">
                     <span class="sbb-toggle-check__circle">
-                     <slot name="icon">
-                       <sbb-icon name="tick-small"></sbb-icon>
-                     </slot>
-                   </span>
+                      <span class="sbb-toggle-check__icon">
+                        <slot name="icon">
+                          <sbb-icon name="tick-small"></sbb-icon>
+                        </slot>
+                      </span>
+                    </span>
                   </span>
                 </span>
               </label>
@@ -138,17 +145,19 @@ describe('sbb-toggle-check', () => {
         expect(root).toEqualHtml(`
           <sbb-toggle-check checked disabled label-position="after">
             <mock:shadow-root>
-              <label class="sbb-toggle-check">
-                <input checked="" type="checkbox" disabled aria-disabled=""/>
+              <input checked="" type="checkbox" disabled aria-disabled="" id="sbb-toggle-check-input"/>
+              <label class="sbb-toggle-check" htmlfor="sbb-toggle-check-input">
                 <span class="sbb-toggle-check__container">
                   <span class="sbb-toggle-check__label" hidden="">
                     <slot></slot>
                   </span>
                   <span class="sbb-toggle-check__slider">
                     <span class="sbb-toggle-check__circle">
-                      <slot name="icon">
-                        <sbb-icon name="tick-small"></sbb-icon>
-                      </slot>
+                      <span class="sbb-toggle-check__icon">
+                        <slot name="icon">
+                          <sbb-icon name="tick-small"></sbb-icon>
+                        </slot>
+                      </span>
                     </span>
                   </span>
                 </span>

--- a/src/components/sbb-toggle-check/sbb-toggle-check.spec.ts
+++ b/src/components/sbb-toggle-check/sbb-toggle-check.spec.ts
@@ -17,7 +17,7 @@ describe('sbb-toggle-check', () => {
                 <span class="sbb-toggle-check__label" hidden="">
                   <slot></slot>
                 </span>
-                <span class="sbb-toggle-check__slider">
+                <span class="sbb-toggle-check__track">
                   <span class="sbb-toggle-check__circle">
                     <span class="sbb-toggle-check__icon">
                       <slot name="icon">
@@ -51,7 +51,7 @@ describe('sbb-toggle-check', () => {
                 <span class="sbb-toggle-check__label">
                   <slot></slot>
                 </span>
-                <span class="sbb-toggle-check__slider">
+                <span class="sbb-toggle-check__track">
                 <span class="sbb-toggle-check__circle">
                   <span class="sbb-toggle-check__icon">
                     <slot name="icon">
@@ -85,7 +85,7 @@ describe('sbb-toggle-check', () => {
                   <span class="sbb-toggle-check__label" hidden="">
                     <slot></slot>
                   </span>
-                  <span class="sbb-toggle-check__slider">
+                  <span class="sbb-toggle-check__track">
                     <span class="sbb-toggle-check__circle">
                       <span class="sbb-toggle-check__icon">
                         <slot name="icon">
@@ -118,7 +118,7 @@ describe('sbb-toggle-check', () => {
                   <span class="sbb-toggle-check__label" hidden="">
                     <slot></slot>
                   </span>
-                  <span class="sbb-toggle-check__slider">
+                  <span class="sbb-toggle-check__track">
                     <span class="sbb-toggle-check__circle">
                       <span class="sbb-toggle-check__icon">
                         <slot name="icon">
@@ -151,7 +151,7 @@ describe('sbb-toggle-check', () => {
                   <span class="sbb-toggle-check__label" hidden="">
                     <slot></slot>
                   </span>
-                  <span class="sbb-toggle-check__slider">
+                  <span class="sbb-toggle-check__track">
                     <span class="sbb-toggle-check__circle">
                       <span class="sbb-toggle-check__icon">
                         <slot name="icon">

--- a/src/components/sbb-toggle-check/sbb-toggle-check.stories.js
+++ b/src/components/sbb-toggle-check/sbb-toggle-check.stories.js
@@ -65,64 +65,83 @@ const ToggleCheckCustomIconTemplate = (args) => (
   </sbb-toggle-check>
 );
 
-export const sbbToggleCheckDefault = ToggleCheckDefaultTemplate.bind({});
-export const sbbToggleCheckDefaultChecked = ToggleCheckDefaultTemplate.bind({});
-export const sbbToggleCheckDefaultLongLabel = ToggleCheckDefaultTemplate.bind({});
-export const sbbToggleCheckLabelBefore = ToggleCheckDefaultTemplate.bind({});
-export const sbbToggleCheckWithoutLabel = ToggleCheckWithoutLabelTemplate.bind({});
-export const sbbToggleCheckDisabled = ToggleCheckDefaultTemplate.bind({});
-export const sbbToggleCheckDisabledChecked = ToggleCheckDefaultTemplate.bind({});
-export const sbbToggleCheckCustomIcon = ToggleCheckCustomIconTemplate.bind({});
+const ToggleCheckBlockVariantTemplate = (args) => (
+  <div>
+    <sbb-toggle-check {...args} style="display:block">
+      <sbb-title level="5" style="margin: 0">
+        Accessible Connection.
+      </sbb-title>
+      <span class="sbb-text-s" style="color: var(--sbb-color-iron-default);">
+        Show connections for accessible journeys.
+      </span>
+    </sbb-toggle-check>
+    <p class="sbb-text-xs">
+      In this example <code>&lt;sbb-toggle-check&gt;</code> is converted to a block element by
+      setting <code>display: block</code>.
+    </p>
+  </div>
+);
 
-sbbToggleCheckDefault.argTypes = defaultArgTypes;
-sbbToggleCheckDefault.args = {
+export const SbbToggleCheckDefault = ToggleCheckDefaultTemplate.bind({});
+SbbToggleCheckDefault.argTypes = defaultArgTypes;
+SbbToggleCheckDefault.args = {
   ...defaultArgs,
 };
 
-sbbToggleCheckDefaultChecked.argTypes = defaultArgTypes;
-sbbToggleCheckDefaultChecked.args = {
+export const SbbToggleCheckDefaultChecked = ToggleCheckDefaultTemplate.bind({});
+SbbToggleCheckDefaultChecked.argTypes = defaultArgTypes;
+SbbToggleCheckDefaultChecked.args = {
   ...defaultArgs,
   checked: true,
 };
 
-sbbToggleCheckDefaultLongLabel.argTypes = defaultArgTypes;
-sbbToggleCheckDefaultLongLabel.args = {
+export const SbbToggleCheckDefaultLongLabel = ToggleCheckDefaultTemplate.bind({});
+SbbToggleCheckDefaultLongLabel.argTypes = defaultArgTypes;
+SbbToggleCheckDefaultLongLabel.args = {
   ...defaultArgs,
   label: longLabel,
 };
 
-sbbToggleCheckLabelBefore.argTypes = defaultArgTypes;
-sbbToggleCheckLabelBefore.args = {
+export const SbbToggleCheckLabelBefore = ToggleCheckDefaultTemplate.bind({});
+SbbToggleCheckLabelBefore.argTypes = defaultArgTypes;
+SbbToggleCheckLabelBefore.args = {
   ...defaultArgs,
   'label-position': 'before',
 };
 
-sbbToggleCheckWithoutLabel.argTypes = defaultArgTypes;
-sbbToggleCheckWithoutLabel.args = {
+export const SbbToggleCheckWithoutLabel = ToggleCheckWithoutLabelTemplate.bind({});
+SbbToggleCheckWithoutLabel.argTypes = defaultArgTypes;
+SbbToggleCheckWithoutLabel.args = {
   ...defaultArgs,
 };
 
-sbbToggleCheckDisabled.argTypes = defaultArgTypes;
-sbbToggleCheckDisabled.args = {
+export const SbbToggleCheckDisabled = ToggleCheckDefaultTemplate.bind({});
+SbbToggleCheckDisabled.argTypes = defaultArgTypes;
+SbbToggleCheckDisabled.args = {
   ...defaultArgs,
   disabled: true,
 };
 
-sbbToggleCheckDisabledChecked.argTypes = defaultArgTypes;
-sbbToggleCheckDisabledChecked.args = {
+export const SbbToggleCheckDisabledChecked = ToggleCheckDefaultTemplate.bind({});
+SbbToggleCheckDisabledChecked.argTypes = defaultArgTypes;
+SbbToggleCheckDisabledChecked.args = {
   ...defaultArgs,
   disabled: true,
   checked: true,
 };
 
-sbbToggleCheckCustomIcon.argTypes = defaultArgTypes;
-sbbToggleCheckCustomIcon.args = {
+export const SbbToggleCheckCustomIcon = ToggleCheckCustomIconTemplate.bind({});
+SbbToggleCheckCustomIcon.argTypes = defaultArgTypes;
+SbbToggleCheckCustomIcon.args = {
   ...defaultArgs,
   checked: true,
 };
 
-sbbToggleCheckDefault.documentation = {
-  title: 'Default',
+export const SbbToggleCheckBlockVariant = ToggleCheckBlockVariantTemplate.bind({});
+SbbToggleCheckBlockVariant.argTypes = defaultArgTypes;
+SbbToggleCheckBlockVariant.args = {
+  ...defaultArgs,
+  'label-position': 'before',
 };
 
 export default {

--- a/src/components/sbb-toggle-check/sbb-toggle-check.stories.js
+++ b/src/components/sbb-toggle-check/sbb-toggle-check.stories.js
@@ -26,6 +26,12 @@ const label = {
   },
 };
 
+const iconName = {
+  control: {
+    type: 'text',
+  },
+};
+
 const labelPosition = {
   control: {
     type: 'inline-radio',
@@ -38,30 +44,31 @@ const defaultArgTypes = {
   disabled,
   'label-position': labelPosition,
   label,
+  'icon-name': iconName,
 };
 
 const defaultArgs = {
   checked: false,
   disabled: false,
   'label-position': labelPosition.options[1],
-  label: 'Title',
-  name: 'toggle',
+  label: 'Label',
+  'icon-name': undefined,
 };
 
 /* ************************************************* */
 /* Storybook templates                               */
 /* ************************************************* */
 
-const ToggleCheckDefaultTemplate = (args) => (
-  <sbb-toggle-check {...args}>{args.label}</sbb-toggle-check>
+const ToggleCheckDefaultTemplate = ({ label, ...args }) => (
+  <sbb-toggle-check {...args}>{label}</sbb-toggle-check>
 );
 
 const ToggleCheckWithoutLabelTemplate = (args) => <sbb-toggle-check {...args}></sbb-toggle-check>;
 
-const ToggleCheckCustomIconTemplate = (args) => (
+const ToggleCheckCustomIconTemplate = ({ label, ...args }) => (
   <sbb-toggle-check {...args}>
     <sbb-icon slot="icon" name="eye-small"></sbb-icon>
-    {args.label}
+    {label}
   </sbb-toggle-check>
 );
 
@@ -130,11 +137,20 @@ SbbToggleCheckDisabledChecked.args = {
   checked: true,
 };
 
-export const SbbToggleCheckCustomIcon = ToggleCheckCustomIconTemplate.bind({});
+export const SbbToggleCheckCustomIcon = ToggleCheckDefaultTemplate.bind({});
 SbbToggleCheckCustomIcon.argTypes = defaultArgTypes;
 SbbToggleCheckCustomIcon.args = {
   ...defaultArgs,
   checked: true,
+  'icon-name': 'face-smiling-small',
+};
+
+export const SbbToggleCheckCustomIconSlotted = ToggleCheckCustomIconTemplate.bind({});
+SbbToggleCheckCustomIconSlotted.argTypes = defaultArgTypes;
+SbbToggleCheckCustomIconSlotted.args = {
+  ...defaultArgs,
+  checked: true,
+  iconName: undefined,
 };
 
 export const SbbToggleCheckBlockVariant = ToggleCheckBlockVariantTemplate.bind({});
@@ -142,6 +158,7 @@ SbbToggleCheckBlockVariant.argTypes = defaultArgTypes;
 SbbToggleCheckBlockVariant.args = {
   ...defaultArgs,
   'label-position': 'before',
+  label: undefined,
 };
 
 export default {

--- a/src/components/sbb-toggle-check/sbb-toggle-check.tsx
+++ b/src/components/sbb-toggle-check/sbb-toggle-check.tsx
@@ -98,9 +98,11 @@ export class SbbToggleCheck implements ComponentInterface, AccessibilityProperti
             </span>
             <span class="sbb-toggle-check__slider">
               <span class="sbb-toggle-check__circle">
-                <slot name="icon">
-                  <sbb-icon name={this.icon}></sbb-icon>
-                </slot>
+                <span class="sbb-toggle-check-icon">
+                  <slot name="icon">
+                    <sbb-icon name={this.icon}></sbb-icon>
+                  </slot>
+                </span>
               </span>
             </span>
           </span>

--- a/src/components/sbb-toggle-check/sbb-toggle-check.tsx
+++ b/src/components/sbb-toggle-check/sbb-toggle-check.tsx
@@ -9,10 +9,12 @@ import {
   Prop,
   State,
   Host,
+  Listen,
 } from '@stencil/core';
 import { forwardEventToHost } from '../../global/helpers/forward-event';
 import { InterfaceToggleCheckAttributes } from './sbb-toggle-check.custom';
 import { AccessibilityProperties } from '../../global/interfaces/accessibility-properties';
+import { forwardHostEvent } from '../../global/interfaces/link-button-properties';
 
 @Component({
   shadow: true,
@@ -32,7 +34,7 @@ export class SbbToggleCheck implements ComponentInterface, AccessibilityProperti
   @Prop() public name?: string;
 
   /** The svg name for the true state - default -> 'tick-small' */
-  @Prop() public icon = 'tick-small';
+  @Prop() public iconName = 'tick-small';
 
   /** The disabled prop for the disabled state. */
   @Prop({ reflect: true }) public disabled = false;
@@ -64,9 +66,17 @@ export class SbbToggleCheck implements ComponentInterface, AccessibilityProperti
   }
 
   public connectedCallback(): void {
+    // Forward focus call to checkbox
+    this._element.focus = (options: FocusOptions) => this._checkbox?.focus(options);
+
     this._hasLabelText = Array.from(this._element.childNodes).some(
       (n: ChildNode) => !(n as Element).slot && n.textContent
     );
+  }
+
+  @Listen('click')
+  public handleClick(event: Event): void {
+    forwardHostEvent(event, this._element, this._checkbox);
   }
 
   private _onLabelSlotChange(event: Event): void {
@@ -100,7 +110,7 @@ export class SbbToggleCheck implements ComponentInterface, AccessibilityProperti
               <span class="sbb-toggle-check__circle">
                 <span class="sbb-toggle-check__icon">
                   <slot name="icon">
-                    <sbb-icon name={this.icon}></sbb-icon>
+                    {this.iconName && <sbb-icon name={this.iconName}></sbb-icon>}
                   </slot>
                 </span>
               </span>

--- a/src/components/sbb-toggle-check/sbb-toggle-check.tsx
+++ b/src/components/sbb-toggle-check/sbb-toggle-check.tsx
@@ -8,6 +8,7 @@ import {
   JSX,
   Prop,
   State,
+  Host,
 } from '@stencil/core';
 import { forwardEventToHost } from '../../global/helpers/forward-event';
 import { InterfaceToggleCheckAttributes } from './sbb-toggle-check.custom';
@@ -76,8 +77,9 @@ export class SbbToggleCheck implements ComponentInterface, AccessibilityProperti
 
   public render(): JSX.Element {
     return (
-      <label class="sbb-toggle-check">
+      <Host>
         <input
+          id="sbb-toggle-check-input"
           ref={(checkbox: HTMLInputElement): HTMLInputElement => (this._checkbox = checkbox)}
           type="checkbox"
           name={this.name}
@@ -89,19 +91,21 @@ export class SbbToggleCheck implements ComponentInterface, AccessibilityProperti
           onChange={(event: Event): void => this.checkedChanged(event)}
           aria-label={this.accessibilityLabel}
         />
-        <span class="sbb-toggle-check__container">
-          <span class="sbb-toggle-check__label" hidden={!this._hasLabelText}>
-            <slot onSlotchange={(event): void => this._onLabelSlotChange(event)} />
-          </span>
-          <span class="sbb-toggle-check__slider">
-            <span class="sbb-toggle-check__circle">
-              <slot name="icon">
-                <sbb-icon name={this.icon}></sbb-icon>
-              </slot>
+        <label class="sbb-toggle-check" htmlFor="sbb-toggle-check-input">
+          <span class="sbb-toggle-check__container">
+            <span class="sbb-toggle-check__label" hidden={!this._hasLabelText}>
+              <slot onSlotchange={(event): void => this._onLabelSlotChange(event)} />
+            </span>
+            <span class="sbb-toggle-check__slider">
+              <span class="sbb-toggle-check__circle">
+                <slot name="icon">
+                  <sbb-icon name={this.icon}></sbb-icon>
+                </slot>
+              </span>
             </span>
           </span>
-        </span>
-      </label>
+        </label>
+      </Host>
     );
   }
 }

--- a/src/components/sbb-toggle-check/sbb-toggle-check.tsx
+++ b/src/components/sbb-toggle-check/sbb-toggle-check.tsx
@@ -98,7 +98,7 @@ export class SbbToggleCheck implements ComponentInterface, AccessibilityProperti
             </span>
             <span class="sbb-toggle-check__slider">
               <span class="sbb-toggle-check__circle">
-                <span class="sbb-toggle-check-icon">
+                <span class="sbb-toggle-check__icon">
                   <slot name="icon">
                     <sbb-icon name={this.icon}></sbb-icon>
                   </slot>

--- a/src/components/sbb-toggle-check/sbb-toggle-check.tsx
+++ b/src/components/sbb-toggle-check/sbb-toggle-check.tsx
@@ -96,7 +96,7 @@ export class SbbToggleCheck implements ComponentInterface, AccessibilityProperti
             <span class="sbb-toggle-check__label" hidden={!this._hasLabelText}>
               <slot onSlotchange={(event): void => this._onLabelSlotChange(event)} />
             </span>
-            <span class="sbb-toggle-check__slider">
+            <span class="sbb-toggle-check__track">
               <span class="sbb-toggle-check__circle">
                 <span class="sbb-toggle-check__icon">
                   <slot name="icon">


### PR DESCRIPTION
BREAKING CHANGE:
Rename property `icon` to `icon-name` to be consistent with all other components.

This PR Closes #1532 

## Browsers

I tested the build on the following browsers:

- [x] Firefox Desktop
- [x] Chrome Desktop
- [ ] Edge Desktop
- [x] Safari Desktop
- [ ] Chrome Mobile
- [x] Safari Mobile