### PR TITLE
fix(sbb-navigation-section): place button always in new row

### DIFF
--- a/src/components/sbb-navigation-section/sbb-navigation-section.scss
+++ b/src/components/sbb-navigation-section/sbb-navigation-section.scss
@@ -32,6 +32,11 @@
     padding-inline-start: var(--sbb-navigation-section-content-padding-inline-start);
   }
 
+  // Always place the sbb-button on a new row
+  ::slotted(sbb-button) {
+    grid-column-start: 1;
+  }
+
   @include sbb.mq($from: large) {
     --sbb-navigation-section-column: 5 / 9;
     --sbb-navigation-section-animation-duration: var(--sbb-animation-duration-4x);

--- a/src/components/sbb-navigation-section/sbb-navigation-section.stories.js
+++ b/src/components/sbb-navigation-section/sbb-navigation-section.stories.js
@@ -135,7 +135,6 @@ const DefaultTemplate = (args) => [
 
       {navigationList('Label')}
       {navigationList('Label')}
-      {navigationList('Label')}
 
       <sbb-button size="m" variant="secondary" style="width: fit-content" sbb-navigation-close>
         Close navigation


### PR DESCRIPTION
This fix only works if there is exactly one button and if it is an "sbb-button".

Closes #1575 