### PR TITLE
fix(typography): fix name of `sbb-text--bold` CSS class

### DIFF
--- a/src/global/styles/typography.scss
+++ b/src/global/styles/typography.scss
@@ -40,7 +40,7 @@ html {
   @include typo.text-xl--regular;
 }
 
-.sbb-text-bold {
+.sbb-text--bold {
   @include typo.text--bold;
 }
 

--- a/src/storybook/styles/typography/readme.md
+++ b/src/storybook/styles/typography/readme.md
@@ -6,14 +6,14 @@ It also includes line-height, letter-spacing and font-family.
 The native browser margins (1em) between paragraph elements `<p>` correctly corresponds
 to the defined paragraph spacing. Due to this there are no additional rules for paragraph spacing.
 
-| css class      | css class bold               | sass mixin          | sass mixin bold  |
-| -------------- | ---------------------------- | ------------------- | ---------------- |
-| `sbb-text-xxs` | `sbb-text-xxs sbb-text-bold` | `text-xxs--regular` | `text-xxs--bold` |
-| `sbb-text-xs`  | `sbb-text-xs sbb-text-bold`  | `text-xs--regular`  | `text-xs--bold`  |
-| `sbb-text-s`   | `sbb-text-s sbb-text-bold`   | `text-s--regular`   | `text-s--bold`   |
-| `sbb-text-m`   | `sbb-text-m sbb-text-bold`   | `text-m--regular`   | `text-m--bold`   |
-| `sbb-text-l`   | `sbb-text-l sbb-text-bold`   | `text-l--regular`   | `text-l--bold`   |
-| `sbb-text-xl`  | `sbb-text-xl sbb-text-bold`  | `text-xl--regular`  | `text-xl--bold`  |
+| css class      | css class bold                | sass mixin          | sass mixin bold  |
+| -------------- | ----------------------------- | ------------------- | ---------------- |
+| `sbb-text-xxs` | `sbb-text-xxs sbb-text--bold` | `text-xxs--regular` | `text-xxs--bold` |
+| `sbb-text-xs`  | `sbb-text-xs sbb-text--bold`  | `text-xs--regular`  | `text-xs--bold`  |
+| `sbb-text-s`   | `sbb-text-s sbb-text--bold`   | `text-s--regular`   | `text-s--bold`   |
+| `sbb-text-m`   | `sbb-text-m sbb-text--bold`   | `text-m--regular`   | `text-m--bold`   |
+| `sbb-text-l`   | `sbb-text-l sbb-text--bold`   | `text-l--regular`   | `text-l--bold`   |
+| `sbb-text-xl`  | `sbb-text-xl sbb-text--bold`  | `text-xl--regular`  | `text-xl--bold`  |
 
 ### Usage
 

--- a/src/storybook/styles/typography/typography.stories.js
+++ b/src/storybook/styles/typography/typography.stories.js
@@ -18,7 +18,7 @@ const TextBoldTemplate = () =>
     <sbb-title level={sizes.length - index}>
       Titel Level {sizes.length - index} / Text size {textSize}
     </sbb-title>,
-    <p class={`sbb-text-${textSize} sbb-text-bold`}>{text}</p>,
+    <p class={`sbb-text-${textSize} sbb-text--bold`}>{text}</p>,
   ]);
 
 const LegendSubSupTemplate = () => [


### PR DESCRIPTION
BREAKING CHANGE:
Renamed CSS class `sbb-text-bold` to `sbb-text--bold` to match BEM naming.