### PR TITLE
refactor(sbb-toggle): optimize event handling

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -42,6 +42,7 @@ import { InterfaceTimetableTransportationTimeAttributes } from "./components/sbb
 import { InterfaceTimetableTravelHintsAttributes } from "./components/sbb-timetable-travel-hints/sbb-timetable-travel-hints.custom";
 import { InterfaceSbbToggleAttributes } from "./components/sbb-toggle/sbb-toggle.custom";
 import { InterfaceToggleCheckAttributes } from "./components/sbb-toggle-check/sbb-toggle-check.custom";
+import { StateChange } from "./components/sbb-toggle-option/sbb-toggle-option.custom";
 import { InterfaceSbbTrainAttributes } from "./components/sbb-train/sbb-train.custom.d";
 import { InterfaceSbbWagonAttributes } from "./components/sbb-wagon/sbb-wagon.custom.d";
 export { InterfaceAccordionItemAttributes } from "./components/sbb-accordion-item/sbb-accordion-item.custom";
@@ -81,6 +82,7 @@ export { InterfaceTimetableTransportationTimeAttributes } from "./components/sbb
 export { InterfaceTimetableTravelHintsAttributes } from "./components/sbb-timetable-travel-hints/sbb-timetable-travel-hints.custom";
 export { InterfaceSbbToggleAttributes } from "./components/sbb-toggle/sbb-toggle.custom";
 export { InterfaceToggleCheckAttributes } from "./components/sbb-toggle-check/sbb-toggle-check.custom";
+export { StateChange } from "./components/sbb-toggle-option/sbb-toggle-option.custom";
 export { InterfaceSbbTrainAttributes } from "./components/sbb-train/sbb-train.custom.d";
 export { InterfaceSbbWagonAttributes } from "./components/sbb-wagon/sbb-wagon.custom.d";
 export namespace Components {
@@ -1570,7 +1572,6 @@ export namespace Components {
           * Name of the icon for `<sbb-icon>`.
          */
         "iconName"?: string;
-        "select": () => Promise<void>;
         /**
           * Value of toggle-option.
          */
@@ -3810,6 +3811,10 @@ declare namespace LocalJSX {
           * Emits whenever the toggle-option value changes.
          */
         "onDid-select"?: (event: SbbToggleOptionCustomEvent<any>) => void;
+        /**
+          * Internal event that emits whenever the state of the toggle option in relation to the parent toggle changes.
+         */
+        "onState-change"?: (event: SbbToggleOptionCustomEvent<StateChange>) => void;
         /**
           * Value of toggle-option.
          */

--- a/src/components/sbb-toggle-option/readme.md
+++ b/src/components/sbb-toggle-option/readme.md
@@ -28,22 +28,10 @@ The `<sbb-toggle-option>` component is used inside the `<sbb-toggle>` in order t
 
 ## Events
 
-| Event        | Description                                     | Type               |
-| ------------ | ----------------------------------------------- | ------------------ |
-| `did-select` | Emits whenever the toggle-option value changes. | `CustomEvent<any>` |
-
-
-## Methods
-
-### `select() => Promise<void>`
-
-
-
-#### Returns
-
-Type: `Promise<void>`
-
-
+| Event          | Description                                                                                                 | Type                                                  |
+| -------------- | ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `did-select`   | Emits whenever the toggle-option value changes.                                                             | `CustomEvent<any>`                                    |
+| `state-change` | Internal event that emits whenever the state of the toggle option in relation to the parent toggle changes. | `CustomEvent<StateChangeChecked \| StateChangeValue>` |
 
 
 ## Slots

--- a/src/components/sbb-toggle-option/sbb-toggle-option.custom.d.ts
+++ b/src/components/sbb-toggle-option/sbb-toggle-option.custom.d.ts
@@ -1,11 +1,11 @@
 export type StateChange = StateChangeChecked | StateChangeValue;
 
-interface StateChangeValue {
+export interface StateChangeValue {
   type: 'value';
   value: string;
 }
 
-interface StateChangeChecked {
+export interface StateChangeChecked {
   type: 'checked';
   checked: boolean;
 }

--- a/src/components/sbb-toggle-option/sbb-toggle-option.custom.d.ts
+++ b/src/components/sbb-toggle-option/sbb-toggle-option.custom.d.ts
@@ -1,0 +1,11 @@
+export type StateChange = StateChangeChecked | StateChangeValue;
+
+interface StateChangeValue {
+  type: 'value';
+  value: string;
+}
+
+interface StateChangeChecked {
+  type: 'checked';
+  checked: boolean;
+}

--- a/src/components/sbb-toggle-option/sbb-toggle-option.e2e.ts
+++ b/src/components/sbb-toggle-option/sbb-toggle-option.e2e.ts
@@ -38,6 +38,6 @@ describe('sbb-toggle-option', () => {
     await page.waitForChanges();
 
     expect(element).toHaveAttribute('checked');
-    expect(didSelect).toHaveReceivedEventTimes(2);
+    expect(didSelect).toHaveReceivedEventTimes(1);
   });
 });

--- a/src/components/sbb-toggle-option/sbb-toggle-option.events.ts
+++ b/src/components/sbb-toggle-option/sbb-toggle-option.events.ts
@@ -4,4 +4,5 @@
  */
 export default {
   didSelect: 'did-select',
+  stateChange: 'state-change',
 };

--- a/src/components/sbb-toggle-option/sbb-toggle-option.spec.ts
+++ b/src/components/sbb-toggle-option/sbb-toggle-option.spec.ts
@@ -9,7 +9,7 @@ describe('sbb-toggle-option', () => {
     });
 
     expect(root).toEqualHtml(`
-      <sbb-toggle-option aria-checked="true" checked="" role="radio" value="Option 1">
+      <sbb-toggle-option aria-checked="true" checked="" role="radio" tabindex="0" value="Option 1">
         <mock:shadow-root>
           <input aria-hidden="true" checked id="sbb-toggle-option-id" tabindex="-1" type="radio" value="Option 1">
           <label class="sbb-toggle-option" htmlfor="sbb-toggle-option-id">
@@ -29,7 +29,7 @@ describe('sbb-toggle-option', () => {
     });
 
     expect(root).toEqualHtml(`
-      <sbb-toggle-option aria-checked="true" checked="" icon-name="arrow-right-small" role="radio">
+      <sbb-toggle-option aria-checked="true" checked="" icon-name="arrow-right-small" role="radio" tabindex="0">
         <mock:shadow-root>
           <input aria-hidden="true" checked id="sbb-toggle-option-id" tabindex="-1" type="radio">
           <label class="sbb-toggle-option sbb-toggle-option--icon-only" htmlfor="sbb-toggle-option-id">

--- a/src/components/sbb-toggle-option/sbb-toggle-option.tsx
+++ b/src/components/sbb-toggle-option/sbb-toggle-option.tsx
@@ -39,7 +39,7 @@ export class SbbToggleOption implements ComponentInterface, AccessibilityPropert
   /**
    * Whether the toggle option is disabled.
    */
-  @Prop({ reflect: true }) public disabled = false;
+  @Prop({ mutable: true, reflect: true }) public disabled = false;
 
   /**
    * Name of the icon for `<sbb-icon>`.
@@ -94,6 +94,7 @@ export class SbbToggleOption implements ComponentInterface, AccessibilityPropert
   public handleCheckedChange(currentValue: boolean, previousValue: boolean): void {
     if (currentValue !== previousValue) {
       this.stateChange.emit({ type: 'checked', checked: currentValue });
+      this._verifyTabindex();
     }
   }
 
@@ -108,13 +109,14 @@ export class SbbToggleOption implements ComponentInterface, AccessibilityPropert
   public handleDisabledChange(currentValue: boolean): void {
     // Enforce disabled state from parent.
     if (!this._toggle) {
-      // Ignore illegal state. Our expecation is that a sbb-toggle-option
+      // Ignore illegal state. Our expectation  is that a sbb-toggle-option
       // always has a parent sbb-toggle.
     } else if (this._toggle.disabled && !currentValue) {
       this.disabled = true;
     } else if (!this._toggle.disabled && currentValue) {
       this.disabled = false;
     }
+    this._verifyTabindex();
   }
 
   @Listen('click')
@@ -136,6 +138,11 @@ export class SbbToggleOption implements ComponentInterface, AccessibilityPropert
     // We can use closest here, as we expect the parent sbb-toggle to be in light DOM.
     this._toggle = this._element.closest('sbb-toggle');
     this._namedSlots = queryAndObserveNamedSlotState(this._element, this._namedSlots);
+    this._verifyTabindex();
+  }
+
+  private _verifyTabindex(): void {
+    this._element.tabIndex = this.checked && !this.disabled ? 0 : -1;
   }
 
   public render(): JSX.Element {

--- a/src/components/sbb-toggle/sbb-toggle.spec.ts
+++ b/src/components/sbb-toggle/sbb-toggle.spec.ts
@@ -34,7 +34,7 @@ describe('sbb-toggle', () => {
     });
     option = page.doc.querySelector('#sbb-toggle-option-2');
 
-    await option.select();
+    option.checked = true;
     await page.waitForChanges();
 
     expect(option).toHaveAttribute('checked');

--- a/src/components/sbb-toggle/sbb-toggle.spec.ts
+++ b/src/components/sbb-toggle/sbb-toggle.spec.ts
@@ -4,6 +4,13 @@ import { SbbToggleOption } from '../sbb-toggle-option/sbb-toggle-option';
 
 describe('sbb-toggle', () => {
   let option: HTMLSbbToggleOptionElement, page: SpecPage;
+  const toggleComponents = [SbbToggle, SbbToggleOption];
+  const simpleToggleTemplate = `
+      <sbb-toggle>
+        <sbb-toggle-option value="Value one">Value one</sbb-toggle-option>
+        <sbb-toggle-option value="Value two">Value two</sbb-toggle-option>
+      </sbb-toggle>
+    `;
 
   it('renders', async () => {
     const { root } = await newSpecPage({
@@ -22,21 +29,184 @@ describe('sbb-toggle', () => {
       `);
   });
 
-  it('selects the corect option', async () => {
-    page = await newSpecPage({
-      components: [SbbToggle, SbbToggleOption],
-      html: `
-        <sbb-toggle value="Value one">
-          <sbb-toggle-option id="sbb-toggle-option-1" value="Value one">Value one</sbb-toggle-option>
-          <sbb-toggle-option id="sbb-toggle-option-2" value="Value two">Value two</sbb-toggle-option>
+  describe('value', () => {
+    it('should select the correct option by setting value via attribute', async () => {
+      page = await newSpecPage({
+        components: toggleComponents,
+        html: `
+          <sbb-toggle value="Value two">
+            <sbb-toggle-option value="Value one">Value one</sbb-toggle-option>
+            <sbb-toggle-option value="Value two">Value two</sbb-toggle-option>
+          </sbb-toggle>
+        `,
+      });
+      option = page.doc.querySelectorAll('sbb-toggle-option')[1];
+
+      await page.waitForChanges();
+
+      expect(option).toHaveAttribute('checked');
+    });
+
+    it('should select the correct option by setting value programmatically', async () => {
+      page = await newSpecPage({
+        components: toggleComponents,
+        html: simpleToggleTemplate,
+      });
+      option = page.doc.querySelectorAll('sbb-toggle-option')[1];
+      const toggle = page.doc.querySelector('sbb-toggle');
+      toggle.value = 'Value two';
+
+      await page.waitForChanges();
+
+      expect(option).toHaveAttribute('checked');
+    });
+
+    it('should update the value of the sbb-toggle when the value of a checked option changes', async () => {
+      page = await newSpecPage({
+        components: toggleComponents,
+        html: simpleToggleTemplate,
+      });
+      option = page.doc.querySelectorAll('sbb-toggle-option')[0];
+      option.value = 'Changed';
+      const toggle = page.doc.querySelector('sbb-toggle');
+
+      await page.waitForChanges();
+
+      expect(toggle.value).toBe(option.value);
+    });
+
+    it('should not update the value of the sbb-toggle when the value of a unchecked option changes', async () => {
+      page = await newSpecPage({
+        components: toggleComponents,
+        html: simpleToggleTemplate,
+      });
+      option = page.doc.querySelectorAll('sbb-toggle-option')[1];
+      option.value = 'Changed';
+      const toggle = page.doc.querySelector('sbb-toggle');
+
+      await page.waitForChanges();
+
+      expect(toggle.value).not.toBe(option.value);
+    });
+  });
+
+  describe('checked', () => {
+    it('should initially have the checked attributes on the first option by default', async () => {
+      page = await newSpecPage({
+        components: toggleComponents,
+        html: simpleToggleTemplate,
+      });
+      option = page.doc.querySelectorAll('sbb-toggle-option')[0];
+
+      await page.waitForChanges();
+
+      expect(option).toHaveAttribute('checked');
+    });
+
+    it('should initially have the checked property set to true on the first option by default', async () => {
+      page = await newSpecPage({
+        components: toggleComponents,
+        html: simpleToggleTemplate,
+      });
+      option = page.doc.querySelectorAll('sbb-toggle-option')[0];
+
+      await page.waitForChanges();
+
+      expect(option.checked).toBe(true);
+    });
+
+    it('should select the correct option by setting checked on the option', async () => {
+      page = await newSpecPage({
+        components: toggleComponents,
+        html: simpleToggleTemplate,
+      });
+      option = page.doc.querySelectorAll('sbb-toggle-option')[1];
+      option.checked = true;
+
+      await page.waitForChanges();
+
+      expect(option).toHaveAttribute('checked');
+    });
+
+    it('should select the correct option by setting the checked attribute on the option', async () => {
+      page = await newSpecPage({
+        components: toggleComponents,
+        html: `
+        <sbb-toggle>
+          <sbb-toggle-option value="Value one">Value one</sbb-toggle-option>
+          <sbb-toggle-option value="Value two" checked>Value two</sbb-toggle-option>
         </sbb-toggle>
       `,
+      });
+      option = page.doc.querySelectorAll('sbb-toggle-option')[1];
+      option.checked = true;
+
+      await page.waitForChanges();
+
+      expect(option).toHaveAttribute('checked');
     });
-    option = page.doc.querySelector('#sbb-toggle-option-2');
 
-    option.checked = true;
-    await page.waitForChanges();
+    it('should check first option when unchecking all options', async () => {
+      page = await newSpecPage({
+        components: toggleComponents,
+        html: simpleToggleTemplate,
+      });
+      option = page.doc.querySelectorAll('sbb-toggle-option')[0];
+      option.checked = false;
 
-    expect(option).toHaveAttribute('checked');
+      await page.waitForChanges();
+
+      expect(option.checked).toBe(true);
+    });
+  });
+
+  describe('disabled', () => {
+    it('should sync disabled state with options', async () => {
+      page = await newSpecPage({
+        components: toggleComponents,
+        html: `
+          <sbb-toggle disabled>
+            <sbb-toggle-option value="Value one">Value one</sbb-toggle-option>
+            <sbb-toggle-option value="Value two">Value two</sbb-toggle-option>
+          </sbb-toggle>
+        `,
+      });
+      const options = Array.from(page.doc.querySelectorAll('sbb-toggle-option'));
+
+      await page.waitForChanges();
+
+      options.forEach((option) => expect(option).toHaveAttribute('disabled'));
+    });
+
+    it('should prevent disabled option from unsetting disabled', async () => {
+      page = await newSpecPage({
+        components: toggleComponents,
+        html: `
+          <sbb-toggle disabled>
+            <sbb-toggle-option value="Value one">Value one</sbb-toggle-option>
+            <sbb-toggle-option value="Value two">Value two</sbb-toggle-option>
+          </sbb-toggle>
+        `,
+      });
+      option = page.doc.querySelectorAll('sbb-toggle-option')[0];
+      option.disabled = false;
+
+      await page.waitForChanges();
+
+      expect(option).toHaveAttribute('disabled');
+    });
+
+    it('should prevent enabled option from setting disabled', async () => {
+      page = await newSpecPage({
+        components: toggleComponents,
+        html: simpleToggleTemplate,
+      });
+      option = page.doc.querySelectorAll('sbb-toggle-option')[0];
+      option.disabled = true;
+
+      await page.waitForChanges();
+
+      expect(option).not.toHaveAttribute('disabled');
+    });
   });
 });

--- a/src/components/sbb-toggle/sbb-toggle.stories.js
+++ b/src/components/sbb-toggle/sbb-toggle.stories.js
@@ -231,7 +231,7 @@ export default {
   ],
   parameters: {
     actions: {
-      handles: ['change'],
+      handles: ['change', 'input'],
     },
     backgrounds: {
       disable: true,


### PR DESCRIPTION
Refactors eventing around `sbb-toggle` and `sbb-toggle-option` to be more consistent on when an event is fired.
