### PR TITLE
fix(sbb-footer, sbb-header): display divider to content on windows high contrast mode

### DIFF
--- a/src/components/sbb-footer/sbb-footer.scss
+++ b/src/components/sbb-footer/sbb-footer.scss
@@ -22,6 +22,10 @@
 .sbb-footer {
   padding-block: var(--sbb-spacing-responsive-l);
   background-color: var(--sbb-footer-background-color);
+
+  @include sbb.if-forced-colors {
+    border-block-start: var(--sbb-border-width-1x) solid CanvasText;
+  }
 }
 
 .sbb-footer-wrapper {

--- a/src/components/sbb-header/sbb-header.scss
+++ b/src/components/sbb-header/sbb-header.scss
@@ -25,6 +25,10 @@
   :host([shadow]:not([shadow='false'])) & {
     @include sbb.shadow-level-9-soft;
   }
+
+  @include sbb.if-forced-colors {
+    border-block-end: var(--sbb-border-width-1x) solid CanvasText;
+  }
 }
 
 .sbb-header__wrapper {


### PR DESCRIPTION
Closes #1592
Closes #1593