### PR TITLE
feat(sbb-header): style slotted link of sbb-logo

### DIFF
--- a/src/components/sbb-header/readme.md
+++ b/src/components/sbb-header/readme.md
@@ -89,8 +89,18 @@ The examples below shows how to use the component (with shadow on).
     target="_blank"
   >
     Menu
-  </sbb-header-action>,
-  <sbb-header-action icon-name="magnifying-glass-small">Search</sbb-header-action>,
+  </sbb-header-action>
+  <sbb-header-action icon-name="magnifying-glass-small">Search</sbb-header-action>
+</sbb-header>
+```
+
+Header with logo link and slotted sbb-logo:
+```html
+<sbb-header shadow="true">
+  <sbb-header-action icon-name="magnifying-glass-small">Search</sbb-header-action>
+  <a href="https://www.sbb.ch" slot="logo">
+    <sbb-logo protective-room="none"></sbb-logo>
+  </a>
 </sbb-header>
 ```
 

--- a/src/components/sbb-header/sbb-header.scss
+++ b/src/components/sbb-header/sbb-header.scss
@@ -5,10 +5,11 @@
 @include sbb.host-component-properties;
 
 :host {
-  --sbb-header-logo-height: #{sbb.px-to-rem-build(16)};
+  // Overwrites logo in slotted and default case
+  --sbb-logo-height: #{sbb.px-to-rem-build(16)};
 
   @include sbb.mq($from: medium) {
-    --sbb-header-logo-height: #{sbb.px-to-rem-build(20)};
+    --sbb-logo-height: #{sbb.px-to-rem-build(20)};
   }
 
   // Setting the height here reserves the space for the header which will else be lost with fixed position.
@@ -49,15 +50,35 @@
 
 .sbb-header__logo {
   margin-inline-start: auto;
-
-  // Only apply height to standard logo. If slotted, no styles will be applied.
-  sbb-logo {
-    height: var(--sbb-header-logo-height);
-  }
 }
 
 // Fix left offset if first element of the header is a sbb-header-action.
 // The value of the offset is calculated inside sbb-header-action styles.
 .sbb-header__wrapper > ::slotted(sbb-header-action:first-child) {
   margin-inline-start: var(--sbb-header-first-item-margin-inline-start);
+}
+
+// Apply padding and outline to possible slotted link
+::slotted(a) {
+  display: block;
+  padding-block: var(--sbb-spacing-fixed-3x);
+  position: relative;
+  outline: none;
+}
+
+// To show the correct outline, we need to span a hidden element filling the link but without the outline-offset.
+::slotted(a)::before {
+  content: '';
+  display: block;
+  position: absolute;
+  inset: var(--sbb-spacing-fixed-3x) 0;
+}
+
+::slotted(a:focus-visible)::before {
+  @include sbb.focus-outline;
+
+  outline-offset: var(--sbb-spacing-fixed-3x);
+
+  // As if the outline has an offset, the border radius increases, we set it to the smallest possible border-radius.
+  border-radius: 0.1px;
 }

--- a/src/components/sbb-header/sbb-header.scss
+++ b/src/components/sbb-header/sbb-header.scss
@@ -58,8 +58,8 @@
   margin-inline-start: var(--sbb-header-first-item-margin-inline-start);
 }
 
-// Apply padding and outline to possible slotted link
-::slotted(a) {
+// Apply padding and outline to possible slotted link in logo slot
+::slotted(a[slot='logo']) {
   display: block;
   padding-block: var(--sbb-spacing-fixed-3x);
   position: relative;
@@ -67,14 +67,14 @@
 }
 
 // To show the correct outline, we need to span a hidden element filling the link but without the outline-offset.
-::slotted(a)::before {
+::slotted(a[slot='logo'])::before {
   content: '';
   display: block;
   position: absolute;
   inset: var(--sbb-spacing-fixed-3x) 0;
 }
 
-::slotted(a:focus-visible)::before {
+::slotted(a[slot='logo']:focus-visible)::before {
   @include sbb.focus-outline;
 
   outline-offset: var(--sbb-spacing-fixed-3x);

--- a/src/components/sbb-logo/sbb-logo.scss
+++ b/src/components/sbb-logo/sbb-logo.scss
@@ -20,6 +20,8 @@
     --sbb-logo-signet-color: Canvas !important;
     --sbb-logo-word-mark-color: ButtonText !important;
   }
+
+  height: var(--sbb-logo-height);
 }
 
 :host([negative]:not([negative='false'])) {

--- a/src/storybook/pages/home/home--logged-in.stories.js
+++ b/src/storybook/pages/home/home--logged-in.stories.js
@@ -73,6 +73,9 @@ const Template = (args) => (
         <sbb-menu-action>Italiano</sbb-menu-action>
         <sbb-menu-action icon-name="tick-small">English</sbb-menu-action>
       </sbb-menu>
+      <a href="https://www.sbb.ch" slot="logo">
+        <sbb-logo protective-room="none"></sbb-logo>
+      </a>
     </sbb-header>
 
     <Navigation />

--- a/src/storybook/pages/home/home.stories.js
+++ b/src/storybook/pages/home/home.stories.js
@@ -55,6 +55,9 @@ const Template = (args) => (
         <sbb-menu-action>Italiano</sbb-menu-action>
         <sbb-menu-action icon-name="tick-small">English</sbb-menu-action>
       </sbb-menu>
+      <a href="https://www.sbb.ch" slot="logo">
+        <sbb-logo protective-room="none"></sbb-logo>
+      </a>
     </sbb-header>
 
     <Navigation />


### PR DESCRIPTION
Removed `--sbb-header-logo-height` CSS variable of `sbb-header` but introduced the `--sbb-logo-height` CSS var on the `sbb-logo`. With this change we can now style the logo through multiple levels in DOM.