### PR TITLE
fix: provide CSS variables to set `z-index` for overlay components

### DIFF
--- a/src/components/sbb-dialog/readme.md
+++ b/src/components/sbb-dialog/readme.md
@@ -39,6 +39,8 @@ with an optional result as a payload. You can also indicate that an element with
 the dialog when clicked by marking it with the `sbb-dialog-close` attribute.
 
 ### Usage notes
+The default `z-index` of the component is set to `1000`; to specify a custom stack order, the `z-index` can be changed by defining the CSS variable `--sbb-dialog-z-index`. 
+
 The dialog title can be provided via the `titleContent` property and via slot `name="title"` 
 (e.g. `<span slot="title">My dialog title</span>`). 
 You can also set the property `titleBackButton` to display the back button in the title section 

--- a/src/components/sbb-dialog/sbb-dialog.scss
+++ b/src/components/sbb-dialog/sbb-dialog.scss
@@ -105,7 +105,7 @@
   display: flex;
   align-items: center;
   inset: var(--sbb-dialog-inset);
-  z-index: 10;
+  z-index: var(--sbb-dialog-z-index, 1000);
 
   // Dialog backdrop (not visible on mobile)
   &::before {
@@ -188,7 +188,7 @@
   padding-inline: var(--sbb-dialog-padding-inline);
   padding-block: var(--sbb-dialog-header-padding-block);
   background-color: var(--sbb-dialog-background-color);
-  z-index: 10;
+  z-index: var(--sbb-dialog-z-index, 1000);
 
   :host([data-fullscreen]) & {
     position: fixed;

--- a/src/components/sbb-dialog/sbb-dialog.scss
+++ b/src/components/sbb-dialog/sbb-dialog.scss
@@ -105,7 +105,7 @@
   display: flex;
   align-items: center;
   inset: var(--sbb-dialog-inset);
-  z-index: var(--sbb-dialog-z-index, 1000);
+  z-index: var(--sbb-dialog-z-index, var(--sbb-overlay-z-index));
 
   // Dialog backdrop (not visible on mobile)
   &::before {
@@ -188,7 +188,7 @@
   padding-inline: var(--sbb-dialog-padding-inline);
   padding-block: var(--sbb-dialog-header-padding-block);
   background-color: var(--sbb-dialog-background-color);
-  z-index: var(--sbb-dialog-z-index, 1000);
+  z-index: var(--sbb-dialog-z-index, var(--sbb-overlay-z-index));
 
   :host([data-fullscreen]) & {
     position: fixed;

--- a/src/components/sbb-menu/readme.md
+++ b/src/components/sbb-menu/readme.md
@@ -46,6 +46,8 @@ You can also provide custom content inside the `sbb-menu`:
 </sbb-menu>
 ```
 
+The default `z-index` of the component is set to `1000`; to specify a custom stack order, the `z-index` can be changed by defining the CSS variable `--sbb-menu-z-index`. 
+
 Clicking in the backdrop or pressing the `ESC` key closes the menu.
 
 ### Accessibility

--- a/src/components/sbb-menu/sbb-menu.scss
+++ b/src/components/sbb-menu/sbb-menu.scss
@@ -72,7 +72,7 @@
 .sbb-menu__container {
   position: fixed;
   inset: var(--sbb-menu-inset);
-  z-index: 10;
+  z-index: var(--sbb-menu-z-index, 1000);
 
   // Menu backdrop (only visible on mobile)
   &::before {

--- a/src/components/sbb-menu/sbb-menu.scss
+++ b/src/components/sbb-menu/sbb-menu.scss
@@ -72,7 +72,7 @@
 .sbb-menu__container {
   position: fixed;
   inset: var(--sbb-menu-inset);
-  z-index: var(--sbb-menu-z-index, 1000);
+  z-index: var(--sbb-menu-z-index, var(--sbb-overlay-z-index));
 
   // Menu backdrop (only visible on mobile)
   &::before {

--- a/src/components/sbb-navigation-section/sbb-navigation-section.scss
+++ b/src/components/sbb-navigation-section/sbb-navigation-section.scss
@@ -93,7 +93,7 @@
   inset-block-start: 0;
   width: var(--sbb-navigation-section-width);
   height: var(--sbb-navigation-section-height);
-  z-index: var(--sbb-navigation-z-index, 1000);
+  z-index: var(--sbb-navigation-z-index, var(--sbb-overlay-z-index));
 
   @include sbb.mq($from: large) {
     transform: translateX(calc(var(--sbb-grid-base-gutter-responsive) * -1));

--- a/src/components/sbb-navigation-section/sbb-navigation-section.scss
+++ b/src/components/sbb-navigation-section/sbb-navigation-section.scss
@@ -93,7 +93,7 @@
   inset-block-start: 0;
   width: var(--sbb-navigation-section-width);
   height: var(--sbb-navigation-section-height);
-  z-index: 10;
+  z-index: var(--sbb-navigation-z-index, 1000);
 
   @include sbb.mq($from: large) {
     transform: translateX(calc(var(--sbb-grid-base-gutter-responsive) * -1));

--- a/src/components/sbb-navigation/readme.md
+++ b/src/components/sbb-navigation/readme.md
@@ -14,6 +14,8 @@ Some of its features are:
 
 To display the navigation you can either provide a trigger element or call the `open()` method on the `sbb-navigation` component.
 
+The default `z-index` of the component is set to `1000`; to specify a custom stack order, the `z-index` can be changed by defining the CSS variable `--sbb-navigation-z-index`. 
+
 ```html
 <!-- Trigger element -->
 <sbb-button id="nav-trigger">Navigation trigger</sbb-button>

--- a/src/components/sbb-navigation/sbb-navigation.scss
+++ b/src/components/sbb-navigation/sbb-navigation.scss
@@ -97,7 +97,7 @@
   inset: var(--sbb-navigation-inset);
   pointer-events: none;
   overflow: hidden;
-  z-index: var(--sbb-navigation-z-index, 1000);
+  z-index: var(--sbb-navigation-z-index, var(--sbb-overlay-z-index));
   transform: var(--sbb-navgation-transform);
 
   @include sbb.mq($from: large) {
@@ -181,7 +181,7 @@
   width: var(--sbb-navigation-expanded-width);
   pointer-events: none;
   padding: var(--sbb-spacing-responsive-xs);
-  z-index: calc(var(--sbb-navigation-z-index, 1000) + 1);
+  z-index: calc(var(--sbb-navigation-z-index, var(--sbb-overlay-z-index)) + 1);
 }
 
 .sbb-navigation__close {

--- a/src/components/sbb-navigation/sbb-navigation.scss
+++ b/src/components/sbb-navigation/sbb-navigation.scss
@@ -97,7 +97,7 @@
   inset: var(--sbb-navigation-inset);
   pointer-events: none;
   overflow: hidden;
-  z-index: 10;
+  z-index: var(--sbb-navigation-z-index, 1000);
   transform: var(--sbb-navgation-transform);
 
   @include sbb.mq($from: large) {
@@ -181,7 +181,7 @@
   width: var(--sbb-navigation-expanded-width);
   pointer-events: none;
   padding: var(--sbb-spacing-responsive-xs);
-  z-index: 11;
+  z-index: calc(var(--sbb-navigation-z-index, 1000) + 1);
 }
 
 .sbb-navigation__close {

--- a/src/components/sbb-tooltip/readme.md
+++ b/src/components/sbb-tooltip/readme.md
@@ -36,6 +36,8 @@ You can also indicate that the tooltip should be shown on hover with the propert
 
 The tooltip will automatically disappear after the hiding delay if neither the trigger element nor the tooltip are on hover or if another action is performed on the page.
 
+The default `z-index` of the component is set to `1000`; to specify a custom stack order, the `z-index` can be changed by defining the CSS variable `--sbb-tooltip-z-index`. 
+
 ### Placement
 
 The tooltip automatically calculates where it should place itself, based on available space. Default is below and center.

--- a/src/components/sbb-tooltip/sbb-tooltip.scss
+++ b/src/components/sbb-tooltip/sbb-tooltip.scss
@@ -60,6 +60,7 @@
   position: fixed;
   inset: var(--sbb-tooltip-inset);
   pointer-events: none;
+  z-index: var(--sbb-tooltip-z-index, 1000);
 }
 
 .sbb-tooltip {

--- a/src/components/sbb-tooltip/sbb-tooltip.scss
+++ b/src/components/sbb-tooltip/sbb-tooltip.scss
@@ -60,7 +60,7 @@
   position: fixed;
   inset: var(--sbb-tooltip-inset);
   pointer-events: none;
-  z-index: var(--sbb-tooltip-z-index, 1000);
+  z-index: var(--sbb-tooltip-z-index, var(--sbb-overlay-z-index));
 }
 
 .sbb-tooltip {

--- a/src/global/styles/core/variables.scss
+++ b/src/global/styles/core/variables.scss
@@ -59,6 +59,9 @@
   // Header
   --sbb-header-height: var(--sbb-spacing-fixed-14x);
 
+  // Overlay
+  --sbb-overlay-z-index: 1000;
+
   @include mediaqueries.mq($from: micro) {
     // Layout
     --sbb-layout-base-offset-responsive: var(--sbb-layout-base-offset-responsive-micro);


### PR DESCRIPTION
Provide the possibility to manually set the `z-index` property for all dialog based components. This is necessary since we use the `show()` method instead of the `showModal()` method (see more here #1368), which would otherwise place the dialog on top of everything else in the web page, regardless of the z-index of other elements.
