### PR TITLE
fix(sbb-header): prevent unwanted hiding and use transform for the animation

### DIFF
--- a/src/components/sbb-header/sbb-header.e2e.ts
+++ b/src/components/sbb-header/sbb-header.e2e.ts
@@ -37,13 +37,12 @@ describe('sbb-header', () => {
     expect(await page.evaluate(() => document.querySelector('sbb-header').offsetHeight)).toBe(56);
     expect(await page.evaluate(() => document.documentElement.offsetHeight)).toBe(2056);
 
-    // Scroll bottom (0px to 200px): header fixed.
-    await page.evaluate(() => window.scrollTo({ top: 200 }));
+    // Scroll bottom (0px to 400px): header fixed.
+    await page.evaluate(() => window.scrollTo({ top: 400 }));
     await page.waitForChanges();
-    expect(element).toHaveAttribute('data-fixed');
 
-    // Scroll top (200px to 100px): header fixed and visible, with shadow and animated.
-    await page.evaluate(() => window.scrollTo({ top: 100 }));
+    // Scroll top (400px to 200px): header fixed and visible, with shadow and animated.
+    await page.evaluate(() => window.scrollTo({ top: 200 }));
     await page.waitForChanges();
     expect(element).toHaveAttribute('data-shadow');
     expect(element).toHaveAttribute('data-animated');
@@ -79,7 +78,6 @@ describe('sbb-header', () => {
     // Scroll down a little bit
     await page.evaluate(() => window.scrollTo({ top: 200 }));
     await page.waitForChanges();
-    expect(element).toHaveAttribute('data-fixed');
 
     // Scroll up to show header
     await page.evaluate(() => window.scrollTo({ top: 190 }));

--- a/src/components/sbb-header/sbb-header.scss
+++ b/src/components/sbb-header/sbb-header.scss
@@ -8,7 +8,6 @@
   // Overwrites logo in slotted and default case
   --sbb-logo-height: #{sbb.px-to-rem-build(16)};
   --sbb-header-position: fixed;
-  --sbb-header-transform-y: translateY(0);
   --sbb-header-transition-duration: var(--sbb-animation-duration-6x);
   --sbb-header-transition-property: box-shadow;
 
@@ -24,13 +23,8 @@
   --sbb-header-position: absolute;
 }
 
-:host([hide-on-scroll][data-animated]) {
-  --sbb-header-transition-property: all;
-}
-
 :host([hide-on-scroll][data-fixed]) {
   --sbb-header-position: fixed;
-  --sbb-header-transform-y: translateY(-100%);
 }
 
 :host([hide-on-scroll][data-fixed][data-animated]) {
@@ -39,8 +33,6 @@
 }
 
 :host([hide-on-scroll][data-fixed][data-visible]) {
-  --sbb-header-transform-y: translateY(0);
-
   // Show transition
   --sbb-header-transition-timing: cubic-bezier(0, 0, 0.2, 1);
 }
@@ -48,15 +40,30 @@
 .sbb-header {
   position: var(--sbb-header-position);
   inset: 0 0 auto;
-  transform: var(--sbb-header-transform-y);
   background: var(--sbb-color-white-default);
   z-index: 10;
-  transition-property: var(--sbb-header-transition-property);
-  transition-duration: var(--sbb-header-transition-duration);
-  transition-timing-function: var(--sbb-header-transition-timing);
+  transition: {
+    property: var(--sbb-header-transition-property);
+    duration: var(--sbb-header-transition-duration);
+    timing-function: var(--sbb-header-transition-timing);
+  }
+  animation: {
+    duration: var(--sbb-header-transition-duration);
+    timing-function: var(--sbb-header-transition-timing);
+  }
 
   :host([data-shadow]) & {
     @include sbb.shadow-level-9-soft;
+  }
+
+  :host([hide-on-scroll][data-fixed]) & {
+    animation-name: hide;
+    transform: translate3d(0, -100%, 0);
+  }
+
+  :host([hide-on-scroll][data-fixed][data-visible]) & {
+    animation-name: show;
+    transform: translate3d(0, 0, 0);
   }
 
   @include sbb.if-forced-colors {
@@ -112,4 +119,24 @@
 
   // As if the outline has an offset, the border radius increases, we set it to the smallest possible border-radius.
   border-radius: 0.1px;
+}
+
+@keyframes show {
+  from {
+    transform: translate3d(0, -100%, 0);
+  }
+
+  to {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@keyframes hide {
+  from {
+    transform: translate3d(0, 0, 0);
+  }
+
+  to {
+    transform: translate3d(0, -100%, 0);
+  }
 }

--- a/src/components/sbb-header/sbb-header.scss
+++ b/src/components/sbb-header/sbb-header.scss
@@ -8,7 +8,7 @@
   // Overwrites logo in slotted and default case
   --sbb-logo-height: #{sbb.px-to-rem-build(16)};
   --sbb-header-position: fixed;
-  --sbb-header-inset-block-start: 0;
+  --sbb-header-transform-y: translateY(0);
   --sbb-header-transition-duration: var(--sbb-animation-duration-6x);
   --sbb-header-transition-property: box-shadow;
 
@@ -48,7 +48,7 @@
 .sbb-header {
   position: var(--sbb-header-position);
   inset: 0 0 auto;
-  inset-block-start: var(--sbb-header-inset-block-start);
+  transform: var(--sbb-header-transform-y);
   background: var(--sbb-color-white-default);
   z-index: 10;
   transition-property: var(--sbb-header-transition-property);

--- a/src/components/sbb-header/sbb-header.scss
+++ b/src/components/sbb-header/sbb-header.scss
@@ -30,7 +30,7 @@
 
 :host([hide-on-scroll][data-fixed]) {
   --sbb-header-position: fixed;
-  --sbb-header-inset-block-start: calc(var(--sbb-header-height) * -1);
+  --sbb-header-transform-y: translateY(-100%);
 }
 
 :host([hide-on-scroll][data-fixed][data-animated]) {
@@ -39,7 +39,7 @@
 }
 
 :host([hide-on-scroll][data-fixed][data-visible]) {
-  --sbb-header-inset-block-start: 0;
+  --sbb-header-transform-y: translateY(0);
 
   // Show transition
   --sbb-header-transition-timing: cubic-bezier(0, 0, 0.2, 1);

--- a/src/components/sbb-header/sbb-header.scss
+++ b/src/components/sbb-header/sbb-header.scss
@@ -9,7 +9,6 @@
   --sbb-logo-height: #{sbb.px-to-rem-build(16)};
   --sbb-header-position: fixed;
   --sbb-header-transition-duration: var(--sbb-animation-duration-6x);
-  --sbb-header-transition-property: box-shadow;
 
   @include sbb.mq($from: medium) {
     --sbb-logo-height: #{sbb.px-to-rem-build(20)};
@@ -25,6 +24,8 @@
 
 :host([hide-on-scroll][data-fixed]) {
   --sbb-header-position: fixed;
+  --sbb-header-animation-name: hide;
+  --sbb-header-transform: translate3d(0, -100%, 0);
 }
 
 :host([hide-on-scroll][data-fixed][data-animated]) {
@@ -33,6 +34,9 @@
 }
 
 :host([hide-on-scroll][data-fixed][data-visible]) {
+  --sbb-header-animation-name: show;
+  --sbb-header-transform: translate3d(0, 0, 0);
+
   // Show transition
   --sbb-header-transition-timing: cubic-bezier(0, 0, 0.2, 1);
 }
@@ -42,28 +46,20 @@
   inset: 0 0 auto;
   background: var(--sbb-color-white-default);
   z-index: 10;
+  transform: var(--sbb-header-transform);
   transition: {
-    property: var(--sbb-header-transition-property);
+    property: box-shadow;
     duration: var(--sbb-header-transition-duration);
     timing-function: var(--sbb-header-transition-timing);
   }
   animation: {
+    name: var(--sbb-header-animation-name);
     duration: var(--sbb-header-transition-duration);
     timing-function: var(--sbb-header-transition-timing);
   }
 
   :host([data-shadow]) & {
     @include sbb.shadow-level-9-soft;
-  }
-
-  :host([hide-on-scroll][data-fixed]) & {
-    animation-name: hide;
-    transform: translate3d(0, -100%, 0);
-  }
-
-  :host([hide-on-scroll][data-fixed][data-visible]) & {
-    animation-name: show;
-    transform: translate3d(0, 0, 0);
   }
 
   @include sbb.if-forced-colors {

--- a/src/components/sbb-header/sbb-header.tsx
+++ b/src/components/sbb-header/sbb-header.tsx
@@ -1,6 +1,6 @@
 import { Component, ComponentInterface, Element, h, JSX, Prop, State, Watch } from '@stencil/core';
 import { toggleDatasetEntry } from '../../global/helpers/dataset';
-import { isValidAttribute } from '../../global/helpers/is-valid-attribute';
+import { pageScrollDisabled } from '../../global/helpers/scroll';
 
 const IS_MENU_OPENED_QUERY = "[aria-controls][aria-expanded='true']";
 
@@ -98,10 +98,9 @@ export class SbbHeader implements ComponentInterface {
    */
   private _scrollListener(): void {
     const currentScroll = this._getCurrentScroll();
-    const pageScrollDisabled = isValidAttribute(document.body, 'data-scroll-disabled');
-    toggleDatasetEntry(this._element, 'shadow', currentScroll !== 0 || pageScrollDisabled);
+    toggleDatasetEntry(this._element, 'shadow', currentScroll !== 0 || pageScrollDisabled());
 
-    if (pageScrollDisabled) {
+    if (pageScrollDisabled()) {
       return;
     }
     // Close open overlays when scrolling down if the header is scrolled out of sight.

--- a/src/components/sbb-header/sbb-header.tsx
+++ b/src/components/sbb-header/sbb-header.tsx
@@ -87,6 +87,14 @@ export class SbbHeader implements ComponentInterface {
     return this.hideOnScroll ? this._scrollListener() : this._scrollShadowListener();
   }
 
+  /** Calculates the correct scrollTop value based on the value of `_scrollElement`. */
+  private _getScrollDocumentElement(): HTMLElement {
+    if (this._scrollElement instanceof Document) {
+      return this._scrollElement.documentElement || this._scrollElement.body;
+    }
+    return this._scrollElement;
+  }
+
   /**
    * Sets the correct value for `scrollTop`, then:
    * - apply the shadow if the element/document has been scrolled down;
@@ -98,11 +106,17 @@ export class SbbHeader implements ComponentInterface {
    */
   private _scrollListener(): void {
     const currentScroll = this._getCurrentScroll();
-    toggleDatasetEntry(this._element, 'shadow', currentScroll !== 0 || pageScrollDisabled());
 
-    if (pageScrollDisabled()) {
+    // Whether the scroll view is bouncing past the edge of content and back again.
+    const isBouncing =
+      this._getScrollDocumentElement().scrollHeight - window.innerHeight - currentScroll <= 0;
+
+    if (isBouncing || pageScrollDisabled()) {
       return;
     }
+
+    toggleDatasetEntry(this._element, 'shadow', currentScroll !== 0 || pageScrollDisabled());
+
     // Close open overlays when scrolling down if the header is scrolled out of sight.
     if (
       currentScroll > this._element.offsetHeight &&
@@ -128,7 +142,7 @@ export class SbbHeader implements ComponentInterface {
     } else {
       // Check if header in its original position, scroll position < header height.
       // Reset header behaviour when scroll hits top of the page, on scroll position = 0.
-      if (currentScroll === 0) {
+      if (currentScroll <= 0) {
         this._headerOnTop = true;
       }
       if (this._headerOnTop) {

--- a/src/components/sbb-header/sbb-header.tsx
+++ b/src/components/sbb-header/sbb-header.tsx
@@ -105,9 +105,6 @@ export class SbbHeader implements ComponentInterface {
    * - apply the shadow if the element/document has been scrolled down;
    * - hides the header, remove the shadow and possibly close any open menu on the header if it is not visible anymore;
    * - shows the header and re-apply the shadow if the element/document has been scrolled up.
-   *
-   * As soon the header is not in its static context anymore, the data-fixed attribute has to be set.
-   * This is needed to enable the transition when the header is becoming visible. Otherwise, it would jump.
    */
   private _scrollListener(): void {
     const currentScroll = this._getCurrentScroll();

--- a/src/components/sbb-header/sbb-header.tsx
+++ b/src/components/sbb-header/sbb-header.tsx
@@ -117,7 +117,7 @@ export class SbbHeader implements ComponentInterface {
       return;
     }
 
-    toggleDatasetEntry(this._element, 'shadow', currentScroll !== 0 || pageScrollDisabled());
+    toggleDatasetEntry(this._element, 'shadow', currentScroll !== 0);
 
     // Close open overlays when scrolling down if the header is scrolled out of sight.
     if (

--- a/src/components/sbb-header/sbb-header.tsx
+++ b/src/components/sbb-header/sbb-header.tsx
@@ -104,17 +104,24 @@ export class SbbHeader implements ComponentInterface {
     if (pageScrollDisabled) {
       return;
     }
-    // Check if header is scrolled out of sight, scroll position > header height.
-    if (currentScroll > this._element.offsetHeight) {
+    // Close open overlays when scrolling down if the header is scrolled out of sight.
+    if (
+      currentScroll > this._element.offsetHeight &&
+      currentScroll > 0 &&
+      this._lastScroll < currentScroll
+    ) {
+      this._closeOpenOverlays();
+    }
+    // Check if header is scrolled out of sight, scroll position > header height * 2.
+    if (currentScroll > this._element.offsetHeight * 2) {
       this._headerOnTop = false;
       if (currentScroll > 0 && this._lastScroll < currentScroll) {
         // Scrolling down
         toggleDatasetEntry(this._element, 'shadow', false);
-        toggleDatasetEntry(this._element, 'fixed', true);
         toggleDatasetEntry(this._element, 'visible', false);
-        this._closeOpenOverlays();
       } else {
         // Scrolling up
+        toggleDatasetEntry(this._element, 'fixed', true);
         toggleDatasetEntry(this._element, 'shadow', true);
         toggleDatasetEntry(this._element, 'animated', true);
         toggleDatasetEntry(this._element, 'visible', true);

--- a/src/components/sbb-header/sbb-header.tsx
+++ b/src/components/sbb-header/sbb-header.tsx
@@ -1,5 +1,6 @@
 import { Component, ComponentInterface, Element, h, JSX, Prop, State, Watch } from '@stencil/core';
 import { toggleDatasetEntry } from '../../global/helpers/dataset';
+import { isValidAttribute } from '../../global/helpers/is-valid-attribute';
 
 const IS_MENU_OPENED_QUERY = "[aria-controls][aria-expanded='true']";
 
@@ -97,7 +98,12 @@ export class SbbHeader implements ComponentInterface {
    */
   private _scrollListener(): void {
     const currentScroll = this._getCurrentScroll();
-    toggleDatasetEntry(this._element, 'shadow', currentScroll !== 0);
+    const pageScrollDisabled = isValidAttribute(document.body, 'data-scroll-disabled');
+    toggleDatasetEntry(this._element, 'shadow', currentScroll !== 0 || pageScrollDisabled);
+
+    if (pageScrollDisabled) {
+      return;
+    }
     // Check if header is scrolled out of sight, scroll position > header height.
     if (currentScroll > this._element.offsetHeight) {
       this._headerOnTop = false;

--- a/src/components/sbb-header/sbb-header.tsx
+++ b/src/components/sbb-header/sbb-header.tsx
@@ -87,12 +87,17 @@ export class SbbHeader implements ComponentInterface {
     return this.hideOnScroll ? this._scrollListener() : this._scrollShadowListener();
   }
 
-  /** Calculates the correct scrollTop value based on the value of `_scrollElement`. */
+  /** Return the correct scroll element. */
   private _getScrollDocumentElement(): HTMLElement {
     if (this._scrollElement instanceof Document) {
       return this._scrollElement.documentElement || this._scrollElement.body;
     }
     return this._scrollElement;
+  }
+
+  /** Calculates the correct scrollTop value based on the value of `_scrollElement`. */
+  private _getCurrentScroll(): number {
+    return this._getScrollDocumentElement().scrollTop;
   }
 
   /**
@@ -142,7 +147,7 @@ export class SbbHeader implements ComponentInterface {
     } else {
       // Check if header in its original position, scroll position < header height.
       // Reset header behaviour when scroll hits top of the page, on scroll position = 0.
-      if (currentScroll <= 0) {
+      if (currentScroll === 0) {
         this._headerOnTop = true;
       }
       if (this._headerOnTop) {
@@ -159,14 +164,6 @@ export class SbbHeader implements ComponentInterface {
   /** Apply the shadow if the element/document has been scrolled down. */
   private _scrollShadowListener(): void {
     toggleDatasetEntry(this._element, 'shadow', this._getCurrentScroll() !== 0);
-  }
-
-  /** Calculates the correct scrollTop value based on the value of `_scrollElement`. */
-  private _getCurrentScroll(): number {
-    if (this._scrollElement instanceof Document) {
-      return this._scrollElement.documentElement.scrollTop || this._scrollElement.body.scrollTop;
-    }
-    return this._scrollElement.scrollTop;
   }
 
   private _closeOpenOverlays(): void {

--- a/src/components/sbb-menu/sbb-menu.scss
+++ b/src/components/sbb-menu/sbb-menu.scss
@@ -5,7 +5,6 @@
 @include sbb.host-component-properties;
 
 :host {
-  --sbb-menu-position: fixed;
   --sbb-menu-position-x: 0;
   --sbb-menu-position-y: 0;
   --sbb-menu-animation-duration: var(--sbb-animation-duration-6x);
@@ -29,7 +28,6 @@
   display: contents;
 
   @include sbb.mq($from: medium) {
-    --sbb-menu-position: absolute;
     --sbb-menu-transform: translateY(var(--sbb-spacing-fixed-2x));
     --sbb-menu-max-width: #{sbb.px-to-rem-build(320)};
     --sbb-menu-min-width: #{sbb.px-to-rem-build(180)};
@@ -67,7 +65,9 @@
 
 .sbb-menu__container {
   position: fixed;
+  pointer-events: none;
   inset: var(--sbb-menu-inset);
+  height: 100dvh;
   z-index: var(--sbb-menu-z-index, var(--sbb-overlay-z-index));
 
   // Menu backdrop (only visible on mobile)
@@ -77,6 +77,7 @@
     pointer-events: var(--sbb-menu-pointer-events);
     position: fixed;
     inset: var(--sbb-menu-inset);
+    height: 100dvh;
     background-color: var(--sbb-menu-backdrop-color);
     transition: {
       duration: var(--sbb-menu-animation-duration);
@@ -94,7 +95,7 @@
   max-width: var(--sbb-menu-max-width);
   min-width: var(--sbb-menu-min-width);
   text-align: start;
-  position: var(--sbb-menu-position);
+  position: absolute;
   inset-inline-start: 0;
   inset-block-start: unset;
   inset-block-end: 0;

--- a/src/components/sbb-menu/sbb-menu.tsx
+++ b/src/components/sbb-menu/sbb-menu.tsx
@@ -312,7 +312,12 @@ export class SbbMenu implements ComponentInterface {
   // Set menu position and max height if the breakpoint is medium-ultra.
   private _setMenuPosition(): void {
     // Starting from breakpoint medium
-    if (!isBreakpoint('medium') || !this._dialog || !this._triggerElement) {
+    if (
+      !isBreakpoint('medium') ||
+      !this._dialog ||
+      !this._triggerElement ||
+      this._state === 'closing'
+    ) {
       return;
     }
 

--- a/src/global/helpers/scroll.ts
+++ b/src/global/helpers/scroll.ts
@@ -1,4 +1,9 @@
 import { toggleDatasetEntry } from './dataset';
+import { isValidAttribute } from './is-valid-attribute';
+
+export function pageScrollDisabled(): boolean {
+  return isValidAttribute(document.body, 'data-sbb-scroll-disabled');
+}
 
 /**
  * Handle the page scroll, allowing to disable/enable the window scroll avoiding a potential
@@ -12,6 +17,10 @@ export class ScrollHandler {
   private _inlineSize: string;
 
   public disableScroll(): void {
+    if (pageScrollDisabled()) {
+      return;
+    }
+
     if (!this._hasScrollbar()) {
       document.body.style.overflowY = 'hidden';
       return;
@@ -31,10 +40,14 @@ export class ScrollHandler {
     document.body.style.position = 'fixed';
     document.body.style.overflowY = 'scroll';
     document.body.style.inlineSize = this._inlineSize || '100%';
-    toggleDatasetEntry(document.body, 'scrollDisabled', true);
+    toggleDatasetEntry(document.body, 'sbbScrollDisabled', true);
   }
 
   public enableScroll(): void {
+    if (!pageScrollDisabled()) {
+      return;
+    }
+
     // Revert body inline styles.
     document.body.style.top = this._top || null;
     document.body.style.position = this._position || null;
@@ -43,7 +56,7 @@ export class ScrollHandler {
 
     // Scroll the page to the correct position.
     document.documentElement.scrollTo(0, this._documentScrollTop);
-    toggleDatasetEntry(document.body, 'scrollDisabled', false);
+    toggleDatasetEntry(document.body, 'sbbScrollDisabled', false);
   }
 
   private _hasScrollbar(): boolean {

--- a/src/global/helpers/scroll.ts
+++ b/src/global/helpers/scroll.ts
@@ -1,3 +1,5 @@
+import { toggleDatasetEntry } from './dataset';
+
 /**
  * Handle the page scroll, allowing to disable/enable the window scroll avoiding a potential
  * content shift caused by the disappearance/appearance of the scrollbar.
@@ -29,6 +31,7 @@ export class ScrollHandler {
     document.body.style.position = 'fixed';
     document.body.style.overflowY = 'scroll';
     document.body.style.inlineSize = this._inlineSize || '100%';
+    toggleDatasetEntry(document.body, 'scrollDisabled', true);
   }
 
   public enableScroll(): void {
@@ -40,6 +43,7 @@ export class ScrollHandler {
 
     // Scroll the page to the correct position.
     document.documentElement.scrollTo(0, this._documentScrollTop);
+    toggleDatasetEntry(document.body, 'scrollDisabled', false);
   }
 
   private _hasScrollbar(): boolean {


### PR DESCRIPTION
Prevent the header from being hidden when the navigation is open/closed. Use the CSS `translateY` to perform the animation, instead of using `inset-block-start`.