### PR TITLE
refactor: improve scroll handling mechanism

### DIFF
--- a/src/components/sbb-header/sbb-header.scss
+++ b/src/components/sbb-header/sbb-header.scss
@@ -9,6 +9,7 @@
   --sbb-logo-height: #{sbb.px-to-rem-build(16)};
   --sbb-header-position: fixed;
   --sbb-header-transition-duration: var(--sbb-animation-duration-6x);
+  --sbb-header-inset-inline-end: 0;
 
   @include sbb.mq($from: medium) {
     --sbb-logo-height: #{sbb.px-to-rem-build(20)};
@@ -26,6 +27,7 @@
   --sbb-header-position: fixed;
   --sbb-header-animation-name: hide;
   --sbb-header-transform: translate3d(0, -100%, 0);
+  --sbb-header-inset-inline-end: var(--sbb-scrollbar-width, 0);
 }
 
 :host([hide-on-scroll][data-fixed][data-animated]) {
@@ -43,7 +45,7 @@
 
 .sbb-header {
   position: var(--sbb-header-position);
-  inset: 0 0 auto;
+  inset: 0 var(--sbb-header-inset-inline-end) auto 0;
   background: var(--sbb-color-white-default);
   z-index: var(--sbb-header-z-index, 10);
   transform: var(--sbb-header-transform);

--- a/src/components/sbb-header/sbb-header.tsx
+++ b/src/components/sbb-header/sbb-header.tsx
@@ -1,6 +1,5 @@
 import { Component, ComponentInterface, Element, h, JSX, Prop, State, Watch } from '@stencil/core';
 import { toggleDatasetEntry } from '../../global/helpers/dataset';
-import { pageScrollDisabled } from '../../global/helpers/scroll';
 
 const IS_MENU_OPENED_QUERY = "[aria-controls][aria-expanded='true']";
 
@@ -110,10 +109,7 @@ export class SbbHeader implements ComponentInterface {
     const currentScroll = this._getCurrentScroll();
 
     // Whether the scroll view is bouncing past the edge of content and back again.
-    const isBouncing =
-      this._getScrollDocumentElement().scrollHeight - window.innerHeight - currentScroll <= 0;
-
-    if (isBouncing || pageScrollDisabled()) {
+    if (this._getScrollDocumentElement().scrollHeight - window.innerHeight - currentScroll <= 0) {
       return;
     }
 

--- a/src/components/sbb-menu/sbb-menu.scss
+++ b/src/components/sbb-menu/sbb-menu.scss
@@ -19,7 +19,6 @@
   --sbb-menu-min-height: #{sbb.px-to-rem-build(120)};
   --sbb-menu-border-radius: var(--sbb-border-radius-4x);
   --sbb-menu-visibility: hidden;
-  --sbb-menu-pointer-events: none;
   --sbb-menu-backdrop-color: transparent;
 
   // We use this rule to make the inner container element to appear as if it were a
@@ -36,7 +35,6 @@
 
 :host(:is([data-state='opened'], [data-state='opening'])) {
   --sbb-menu-visibility: visible;
-  --sbb-menu-pointer-events: all;
   --sbb-menu-backdrop-color: var(--sbb-color-black-alpha-20);
 
   @include sbb.mq($from: medium) {
@@ -74,7 +72,7 @@
   &::before {
     content: '';
     visibility: var(--sbb-menu-visibility);
-    pointer-events: var(--sbb-menu-pointer-events);
+    pointer-events: all;
     position: fixed;
     inset: var(--sbb-menu-inset);
     height: 100dvh;

--- a/src/components/sbb-navigation/sbb-navigation.tsx
+++ b/src/components/sbb-navigation/sbb-navigation.tsx
@@ -172,9 +172,6 @@ export class SbbNavigation implements ComponentInterface, AccessibilityPropertie
     this._state = 'closing';
     this._openedByKeyboard = false;
     this._triggerElement?.setAttribute('aria-expanded', 'false');
-
-    // Enable scrolling for content below the dialog
-    this._scrollHandler.enableScroll();
   }
 
   // Removes trigger click listener on trigger change.
@@ -248,6 +245,9 @@ export class SbbNavigation implements ComponentInterface, AccessibilityPropertie
       this.didClose.emit();
       this._windowEventsController?.abort();
       this._focusTrap.disconnect();
+
+      // Enable scrolling for content below the dialog
+      this._scrollHandler.enableScroll();
     }
   }
 

--- a/src/global/helpers/scroll.ts
+++ b/src/global/helpers/scroll.ts
@@ -10,36 +10,27 @@ export function pageScrollDisabled(): boolean {
  * content shift caused by the disappearance/appearance of the scrollbar.
  */
 export class ScrollHandler {
-  private _documentScrollTop: number;
-  private _top: string;
   private _position: string;
-  private _overflowY: string;
-  private _inlineSize: string;
+  private _overflow: string;
+  private _marginInlineEnd: string;
 
   public disableScroll(): void {
     if (pageScrollDisabled()) {
       return;
     }
 
-    if (!this._hasScrollbar()) {
-      document.body.style.overflowY = 'hidden';
-      return;
-    }
-
-    // Save a reference to the document's current vertical scroll.
-    this._documentScrollTop = document.documentElement.scrollTop;
-
     // Save any pre-existing styles to reapply them to the body when enabling the scroll again.
-    this._top = document.body.style.top;
     this._position = document.body.style.position;
-    this._overflowY = document.body.style.overflowY;
-    this._inlineSize = document.body.style.inlineSize;
+    this._overflow = document.body.style.overflow;
+    this._marginInlineEnd = document.body.style.marginInlineEnd;
 
-    // Set the page as fixed to the top and keep showing an "empty" scrollbar by setting "overflow-y" to "scroll".
-    document.body.style.top = `-${this._documentScrollTop}px`;
-    document.body.style.position = 'fixed';
-    document.body.style.overflowY = 'scroll';
-    document.body.style.inlineSize = this._inlineSize || '100%';
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+
+    document.body.style.overflow = 'hidden';
+    document.body.style.position = 'relative';
+    document.body.style.marginInlineEnd = `${scrollbarWidth}px`;
+    document.body.style.setProperty('--sbb-scrollbar-width', `${scrollbarWidth}px`);
+
     toggleDatasetEntry(document.body, 'sbbScrollDisabled', true);
   }
 
@@ -49,17 +40,11 @@ export class ScrollHandler {
     }
 
     // Revert body inline styles.
-    document.body.style.top = this._top || null;
     document.body.style.position = this._position || null;
-    document.body.style.overflowY = this._overflowY || null;
-    document.body.style.inlineSize = this._inlineSize || null;
+    document.body.style.overflow = this._overflow || null;
+    document.body.style.marginInlineEnd = this._marginInlineEnd || null;
+    document.body.style.setProperty('--sbb-scrollbar-width', '0');
 
-    // Scroll the page to the correct position.
-    document.documentElement.scrollTo(0, this._documentScrollTop);
     toggleDatasetEntry(document.body, 'sbbScrollDisabled', false);
-  }
-
-  private _hasScrollbar(): boolean {
-    return document.documentElement.scrollHeight > document.documentElement.clientHeight;
   }
 }


### PR DESCRIPTION
Simplifies and improves the mechanism for disabling page scroll.
- no visible "empty" scrollbar
- no "position: fixed" on the body
- no scroll references needed to reposition the page to the correct position