### PR TITLE
fix(sbb-icon): remove unwanted white space

### DIFF
--- a/src/components/sbb-dialog/sbb-dialog.stories.js
+++ b/src/components/sbb-dialog/sbb-dialog.stories.js
@@ -193,10 +193,7 @@ const SlottedTitleTemplate = (args) => [
   triggerButton('my-dialog-2'),
   <sbb-dialog data-testid="dialog" id="my-dialog-2" {...args}>
     <span slot="title">
-      <sbb-icon
-        name="book-medium"
-        style={'vertical-align: sub; margin-inline-end: 0.5rem;'}
-      ></sbb-icon>
+      <sbb-icon name="book-medium" style={'margin-inline-end: 0.5rem;'}></sbb-icon>
       The Catcher in the Rye
     </span>
     <p id="dialog-content-2" style={'margin: 0'}>

--- a/src/components/sbb-icon/sbb-icon.scss
+++ b/src/components/sbb-icon/sbb-icon.scss
@@ -6,7 +6,6 @@
 
 :host {
   display: inline-block;
-  line-height: 0;
   -webkit-tap-highlight-color: transparent;
 }
 
@@ -20,6 +19,11 @@
 
 :host([data-empty][data-namespace='default'][name$='-large']) {
   --sbb-icon-default-dimension: var(--sbb-size-icon-ui-large);
+}
+
+.sbb-icon__container {
+  display: flex;
+  @include sbb.zero-width-space;
 }
 
 svg {

--- a/src/components/sbb-icon/sbb-icon.spec.ts
+++ b/src/components/sbb-icon/sbb-icon.spec.ts
@@ -11,7 +11,7 @@ describe('sbb-icon', () => {
     expect(root).toEqualHtml(`
         <sbb-icon aria-hidden="true" role="img" data-empty data-namespace="default">
           <mock:shadow-root>
-            <span class="sbb-icon-inner"><svg height="0" width="0"></svg></span>
+            <span class="sbb-icon__container"><svg height="0" width="0"></svg></span>
           </mock:shadow-root>
         </sbb-icon>
       `);
@@ -26,7 +26,7 @@ describe('sbb-icon', () => {
     expect(root).toEqualHtml(`
       <sbb-icon name="app-icon-medium" aria-hidden="true" role="img" data-namespace="default" data-empty>
         <mock:shadow-root>
-          <span class="sbb-icon-inner"><svg height="0" width="0"></svg></span>
+          <span class="sbb-icon__container"><svg height="0" width="0"></svg></span>
         </mock:shadow-root>
       </sbb-icon>
     `);
@@ -41,7 +41,7 @@ describe('sbb-icon', () => {
     expect(root).toEqualHtml(`
       <sbb-icon name="app-icon-medium" aria-hidden="false" aria-label="Icon app icon medium" role="img" data-namespace="default" data-empty>
         <mock:shadow-root>
-          <span class="sbb-icon-inner"><svg height="0" width="0"></svg></span>
+          <span class="sbb-icon__container"><svg height="0" width="0"></svg></span>
         </mock:shadow-root>
       </sbb-icon>
     `);
@@ -56,7 +56,7 @@ describe('sbb-icon', () => {
     expect(root).toEqualHtml(`
       <sbb-icon name="app-icon-medium" aria-hidden="false" aria-label="Custom label" role="img" data-namespace="default" data-empty>
         <mock:shadow-root>
-          <span class="sbb-icon-inner"><svg height="0" width="0"></svg></span>
+          <span class="sbb-icon__container"><svg height="0" width="0"></svg></span>
         </mock:shadow-root>
       </sbb-icon>
     `);
@@ -73,7 +73,7 @@ describe('sbb-icon', () => {
     expect(icon).toEqualHtml(`
       <sbb-icon name="app-icon-medium" aria-hidden="false" aria-label="Icon app icon medium" role="img" data-namespace="default" data-empty>
         <mock:shadow-root>
-          <span class="sbb-icon-inner"><svg height="0" width="0"></svg></span>
+          <span class="sbb-icon__container"><svg height="0" width="0"></svg></span>
         </mock:shadow-root>
       </sbb-icon>
     `);
@@ -84,7 +84,7 @@ describe('sbb-icon', () => {
     expect(icon).toEqualHtml(`
       <sbb-icon name="pie-medium" aria-hidden="false" aria-label="Icon pie medium" role="img" data-namespace="default" data-empty>
         <mock:shadow-root>
-          <span class="sbb-icon-inner"><svg height="0" width="0"></svg></span>
+          <span class="sbb-icon__container"><svg height="0" width="0"></svg></span>
         </mock:shadow-root>
       </sbb-icon>
     `);
@@ -101,7 +101,7 @@ describe('sbb-icon', () => {
     expect(root).toEqualHtml(`
       <sbb-icon name="kom:heart-medium" aria-hidden="true" role="img" data-namespace="kom" data-empty>
         <mock:shadow-root>
-          <span class="sbb-icon-inner"><svg height="0" width="0"></svg></span>
+          <span class="sbb-icon__container"><svg height="0" width="0"></svg></span>
         </mock:shadow-root>
       </sbb-icon>
     `);
@@ -122,7 +122,7 @@ describe('sbb-icon', () => {
     expect(root).toEqualHtml(`
       <sbb-icon name="dom:app-logo" aria-hidden="true" role="img" data-namespace="dom">
         <mock:shadow-root>
-          <span class="sbb-icon-inner">
+          <span class="sbb-icon__container">
             <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0,0,36,36"><path fill-rule="evenodd" clip-rule="evenodd" d="m4.25,9.5391c0-2.92036,2.36814-5.2885,5.2885-5.2885h16.923c2.9204,0,5.2885,2.36814,5.2885,5.2885v16.9215c0,2.9219-2.3696,5.29-5.2885,5.29H9.5385c-2.92019,0-5.2885-2.3695-5.2885-5.29V9.5391zm5.2885-6.2885c-3.47264,0-6.2885,2.81586-6.2885,6.2885v16.9215c0,3.4725,2.81569,6.29,6.2885,6.29h16.923c3.4711,0,6.2885-2.8159,6.2885-6.29V9.5391c0-3.47264-2.8159-6.2885-6.2885-6.2885H9.5385zm13.8859,13.726L19.8964,13.5h2.6216L27,18l-4.482,4.5h-2.6216l3.528-3.4534h-4.3868V22.5h-2.0739v-3.4534h-4.3624l3.528,3.4534h-2.6229L9,18l4.5064-4.5h2.6229l-3.528,3.4766h4.3624V13.5h2.0739v3.4766h4.3868z"/></svg>
           </span>
         </mock:shadow-root>
@@ -146,7 +146,7 @@ describe('sbb-icon', () => {
     expect(root).toEqualHtml(`
       <sbb-icon name="dom:app-logo" aria-hidden="true" role="img" data-namespace="dom">
         <mock:shadow-root>
-          <span class="sbb-icon-inner">
+          <span class="sbb-icon__container">
             <svg xmlns="http://www.w3.org/2000/svg" class="color-immutable" width="36" height="36" viewBox="0,0,36,36"><path fill-rule="evenodd" clip-rule="evenodd" d="m4.25,9.5391c0-2.92036,2.36814-5.2885,5.2885-5.2885h16.923c2.9204,0,5.2885,2.36814,5.2885,5.2885v16.9215c0,2.9219-2.3696,5.29-5.2885,5.29H9.5385c-2.92019,0-5.2885-2.3695-5.2885-5.29V9.5391zm5.2885-6.2885c-3.47264,0-6.2885,2.81586-6.2885,6.2885v16.9215c0,3.4725,2.81569,6.29,6.2885,6.29h16.923c3.4711,0,6.2885-2.8159,6.2885-6.29V9.5391c0-3.47264-2.8159-6.2885-6.2885-6.2885H9.5385zm13.8859,13.726L19.8964,13.5h2.6216L27,18l-4.482,4.5h-2.6216l3.528-3.4534h-4.3868V22.5h-2.0739v-3.4534h-4.3624l3.528,3.4534h-2.6229L9,18l4.5064-4.5h2.6229l-3.528,3.4766h4.3624V13.5h2.0739v3.4766h4.3868z"/></svg>
           </span>
         </mock:shadow-root>

--- a/src/components/sbb-icon/sbb-icon.tsx
+++ b/src/components/sbb-icon/sbb-icon.tsx
@@ -138,9 +138,9 @@ export class SbbIcon implements ComponentInterface {
     return (
       <Host role="img" data-namespace={this._svgNamespace} data-empty={!this._svgIcon}>
         {this._svgIcon ? (
-          <span class="sbb-icon-inner" innerHTML={this._svgIcon}></span>
+          <span class="sbb-icon__container" innerHTML={this._svgIcon}></span>
         ) : (
-          <span class="sbb-icon-inner">
+          <span class="sbb-icon__container">
             {/* To reserve space, we need an empty svg to apply dimension to. */}
             <svg width="0" height="0"></svg>
           </span>

--- a/src/components/sbb-tab-title/sbb-tab-title.scss
+++ b/src/components/sbb-tab-title/sbb-tab-title.scss
@@ -52,6 +52,11 @@
   }
 }
 
+slot[name='icon'] {
+  display: flex;
+  flex-shrink: 0;
+}
+
 // If the the device can hover over elements with ease
 @include sbb.hover-mq($hover: true) {
   .sbb-tab-title:hover {


### PR DESCRIPTION
Get rid of unwanted white space under the `sbb-icon`.