### PR TITLE
fix(sbb-navigation): set correct dimension on mobile

### DIFF
--- a/src/components/sbb-menu/sbb-menu.scss
+++ b/src/components/sbb-menu/sbb-menu.scss
@@ -13,6 +13,13 @@
   --sbb-menu-max-width: 100%;
   --sbb-menu-min-width: 100%;
   --sbb-menu-inset: 0 auto auto 0;
+  --sbb-menu-container-height: 100vh;
+
+  // Needed for backwards compatibility on Chromatic
+  // TODO: Remove once not needed
+  @supports (height: 100dvh) {
+    --sbb-menu-container-height: 100dvh;
+  }
 
   // 85vh is not an exact value but looks optimized for mobile view.
   --sbb-menu-max-height: calc(85vh - var(--sbb-spacing-fixed-8x));
@@ -65,7 +72,7 @@
   position: fixed;
   pointer-events: none;
   inset: var(--sbb-menu-inset);
-  height: 100dvh;
+  height: var(--sbb-menu-container-height);
   z-index: var(--sbb-menu-z-index, var(--sbb-overlay-z-index));
 
   // Menu backdrop (only visible on mobile)
@@ -75,7 +82,7 @@
     pointer-events: all;
     position: fixed;
     inset: var(--sbb-menu-inset);
-    height: 100dvh;
+    height: var(--sbb-menu-container-height);
     background-color: var(--sbb-menu-backdrop-color);
     transition: {
       duration: var(--sbb-menu-animation-duration);

--- a/src/components/sbb-navigation-section/sbb-navigation-section.scss
+++ b/src/components/sbb-navigation-section/sbb-navigation-section.scss
@@ -16,8 +16,8 @@
   --sbb-navigation-section-transform: translateX(100%);
   --sbb-navigation-section-content-padding-inline-start: var(--sbb-spacing-fixed-12x);
   --sbb-focus-outline-color: var(--sbb-focus-outline-color-dark);
-  --sbb-navigation-section-width: 100vw;
-  --sbb-navigation-section-height: 100vh;
+  --sbb-navigation-section-width: 100dvw;
+  --sbb-navigation-section-height: 100dvh;
 
   // We use this rule to make the inner container element to appear as if it were a
   // direct child of the host's parent element. This is useful because the host

--- a/src/components/sbb-navigation-section/sbb-navigation-section.scss
+++ b/src/components/sbb-navigation-section/sbb-navigation-section.scss
@@ -19,8 +19,11 @@
   --sbb-navigation-section-width: 100vw;
   --sbb-navigation-section-height: 100vh;
 
-  @supports (height: 100dvh) {
+  @supports (width: 100dvw) {
     --sbb-navigation-section-width: 100dvw;
+  }
+
+  @supports (height: 100dvh) {
     --sbb-navigation-section-height: 100dvh;
   }
 

--- a/src/components/sbb-navigation-section/sbb-navigation-section.scss
+++ b/src/components/sbb-navigation-section/sbb-navigation-section.scss
@@ -19,10 +19,14 @@
   --sbb-navigation-section-width: 100vw;
   --sbb-navigation-section-height: 100vh;
 
+  // Needed for backwards compatibility on Chromatic
+  // TODO: Remove once not needed
   @supports (width: 100dvw) {
     --sbb-navigation-section-width: 100dvw;
   }
 
+  // Needed for backwards compatibility on Chromatic
+  // TODO: Remove once not needed
   @supports (height: 100dvh) {
     --sbb-navigation-section-height: 100dvh;
   }

--- a/src/components/sbb-navigation-section/sbb-navigation-section.scss
+++ b/src/components/sbb-navigation-section/sbb-navigation-section.scss
@@ -16,8 +16,13 @@
   --sbb-navigation-section-transform: translateX(100%);
   --sbb-navigation-section-content-padding-inline-start: var(--sbb-spacing-fixed-12x);
   --sbb-focus-outline-color: var(--sbb-focus-outline-color-dark);
-  --sbb-navigation-section-width: 100dvw;
-  --sbb-navigation-section-height: 100dvh;
+  --sbb-navigation-section-width: 100vw;
+  --sbb-navigation-section-height: 100vh;
+
+  @supports (height: 100dvh) {
+    --sbb-navigation-section-width: 100dvw;
+    --sbb-navigation-section-height: 100dvh;
+  }
 
   // We use this rule to make the inner container element to appear as if it were a
   // direct child of the host's parent element. This is useful because the host

--- a/src/components/sbb-navigation/sbb-navigation.scss
+++ b/src/components/sbb-navigation/sbb-navigation.scss
@@ -31,6 +31,8 @@
   --sbb-navigation-width: 100%;
   --sbb-navigation-height: 100vh;
 
+  // Needed for backwards compatibility on Chromatic
+  // TODO: Remove once not needed
   @supports (height: 100dvh) {
     --sbb-navigation-height: 100dvh;
   }
@@ -81,8 +83,14 @@
   --sbb-navigation-content-transform: translateX(-100%);
 
   @include sbb.mq($from: 'large') {
-    --sbb-navigation-expanded-width: 100dvw;
+    --sbb-navigation-expanded-width: 100vw;
     --sbb-navigation-content-transform: translateX(0%);
+
+    // Needed for backwards compatibility on Chromatic
+    // TODO: Remove once not needed
+    @supports (height: 100dvw) {
+      --sbb-navigation-expanded-width: 100dvw;
+    }
   }
 }
 

--- a/src/components/sbb-navigation/sbb-navigation.scss
+++ b/src/components/sbb-navigation/sbb-navigation.scss
@@ -24,12 +24,17 @@
   --sbb-navigation-backdrop-color: transparent;
   --sbb-navigation-list-margin-block-start: var(--sbb-spacing-responsive-xxl);
   --sbb-navigation-inline-start: 0;
-  --sbb-navigation-height: 100dvh;
-  --sbb-navigation-width: 100%;
   --sbb-navigation-expanded-width: 100%;
   --sbb-navigation-inset: 0 auto auto 0;
   --sbb-navgation-transform: translateX(-100%);
   --sbb-navigation-content-transform: translateX(0);
+  --sbb-navigation-width: 100%;
+  --sbb-navigation-height: 100vh;
+
+  @supports (height: 100dvh) {
+    --sbb-navigation-height: 100dvh;
+  }
+
   --sbb-focus-outline-color: var(--sbb-focus-outline-color-dark);
 
   // We use this rule to make the inner container element to appear as if it were a

--- a/src/components/sbb-navigation/sbb-navigation.scss
+++ b/src/components/sbb-navigation/sbb-navigation.scss
@@ -24,7 +24,7 @@
   --sbb-navigation-backdrop-color: transparent;
   --sbb-navigation-list-margin-block-start: var(--sbb-spacing-responsive-xxl);
   --sbb-navigation-inline-start: 0;
-  --sbb-navigation-height: 100vh;
+  --sbb-navigation-height: 100dvh;
   --sbb-navigation-width: 100%;
   --sbb-navigation-expanded-width: 100%;
   --sbb-navigation-inset: 0 auto auto 0;
@@ -76,7 +76,7 @@
   --sbb-navigation-content-transform: translateX(-100%);
 
   @include sbb.mq($from: 'large') {
-    --sbb-navigation-expanded-width: 100vw;
+    --sbb-navigation-expanded-width: 100dvw;
     --sbb-navigation-content-transform: translateX(0%);
   }
 }


### PR DESCRIPTION
Use dynamic viewport units to calculate the correct dimension for the `sbb-navigation` and the `sbb-navigation-section`. The bug is visible when the nav or the section goes in overflow on mobile.