### PR TITLE
fix(sbb-form-field): always use label to link to input

### DIFF
--- a/src/components/sbb-form-error/sbb-form-error.spec.ts
+++ b/src/components/sbb-form-error/sbb-form-error.spec.ts
@@ -9,7 +9,7 @@ describe('sbb-form-error', () => {
     });
 
     expect(root).toEqualHtml(`
-      <sbb-form-error aria-live="polite" id="sbb-form-error-1" slot="error">
+      <sbb-form-error id="sbb-form-error-1">
           <mock:shadow-root>
             <span class="form-error__icon">
               <slot name='icon'>

--- a/src/components/sbb-form-error/sbb-form-error.tsx
+++ b/src/components/sbb-form-error/sbb-form-error.tsx
@@ -11,7 +11,7 @@ let nextId = 0;
 export class SbbFormError {
   public render(): JSX.Element {
     return (
-      <Host aria-live="polite" slot="error" ref={assignId(() => `sbb-form-error-${++nextId}`)}>
+      <Host ref={assignId(() => `sbb-form-error-${++nextId}`)}>
         <span class="form-error__icon">
           <slot name="icon">
             <svg

--- a/src/components/sbb-form-field/readme.md
+++ b/src/components/sbb-form-field/readme.md
@@ -24,11 +24,16 @@ The examples below show how to render the component:
 
 
 <sbb-form-field>
-  <span slot="label">Example</span>
+  <label>Example</label>
   <input />
   <sbb-form-error>This field is required!</sbb-form-error>
 </sbb-form-field>
 ```
+
+### Label
+
+Either use a `<label>` or the `label` attribute to provide a label for a form input. The
+`<sbb-form-field>` will automatically assign the correct id reference between label and input.
 
 ### Error messages
 
@@ -67,14 +72,14 @@ By itself, `<sbb-form-field>` does not apply any additional accessibility treatm
 element. However, several of the form field's optional features interact with the form element
 contained within the form field.
 
-When you provide a label via `label` attribute or `slot="label"`, `<sbb-form-field>` automatically
-associates this label with the field's form element via a native <label> element, using the for
+When you provide a label via `<label>` or the `label` attribute, `<sbb-form-field>` automatically
+associates this label with the field's form element via a native <label> element, using the `for`
 attribute to reference the control's ID.
 
 When you provide informational text via `<sbb-form-error>`, `<sbb-form-error>` automatically adds
 these elements' IDs to the form element's aria-describedby attribute. Additionally, 
-`<sbb-form-error>` applies aria-live="polite" by default such that assistive technology will
-announce errors when they appear.
+`<sbb-form-error>` is slotted to an element having `aria-live="polite"` so that assistive
+technology will announce errors when they appear.
 
 <!-- Auto Generated Below -->
 

--- a/src/components/sbb-form-field/sbb-form-field.e2e.ts
+++ b/src/components/sbb-form-field/sbb-form-field.e2e.ts
@@ -20,16 +20,16 @@ describe('sbb-form-field', () => {
       </sbb-form-field>
     `);
 
-    expect(await page.findAll('sbb-form-field >>> label')).toEqual([]);
+    expect(await page.findAll('sbb-form-field label')).toEqual([]);
 
     element = await page.find('sbb-form-field');
     expect(element.shadowRoot.querySelector('label')).toBeNull();
     element.setAttribute('label', 'Label');
     await page.waitForChanges();
-    expect(element.shadowRoot.querySelector('label')).not.toBeNull();
+    expect(await element.find('label')).not.toBeNull();
 
     element.removeAttribute('label');
     await page.waitForChanges();
-    expect(element.shadowRoot.querySelector('label')).toBeNull();
+    expect(await element.find('label')).toBeNull();
   });
 });

--- a/src/components/sbb-form-field/sbb-form-field.scss
+++ b/src/components/sbb-form-field/sbb-form-field.scss
@@ -151,20 +151,18 @@
 
   display: flex;
   max-width: 100%;
+  cursor: default;
 
   // Moves label down and input up to meet positioning requirements
   margin-block-end: var(--sbb-form-field-label-to-input-gap);
   color: var(--sbb-form-field-label-color);
-  user-select: none;
-  pointer-events: none;
 
   :host([data-input-type='select']) & {
     padding-inline-end: var(--sbb-form-field-select-inline-padding-end);
   }
 }
 
-::slotted(*[slot='label']),
-slot[name='label'] > span {
+::slotted(*[slot='label']) {
   @include sbb.ellipsis;
 }
 

--- a/src/components/sbb-form-field/sbb-form-field.spec.ts
+++ b/src/components/sbb-form-field/sbb-form-field.spec.ts
@@ -19,24 +19,23 @@ describe('sbb-form-field', () => {
             <div class="sbb-form-field__wrapper">
                <slot name="prefix"></slot>
               <div class="sbb-form-field__input-container">
-                <label class="sbb-form-field__label">
-                  <slot name="label">
-                    <span>
-                      Fill input
-                    </span>
-                  </slot>
-                </label>
+                <span class="sbb-form-field__label">
+                  <slot name="label"></slot>
+                </span>
                 <div class="sbb-form-field__input">
                   <slot></slot>
                 </div>
               </div>
                <slot name="suffix"></slot>
             </div>
-            <div class="sbb-form-field__error">
+            <div class="sbb-form-field__error" aria-live="polite">
               <slot name="error"></slot>
             </div>
           </div>
         </mock:shadow-root>
+        <label data-creator="SBB-FORM-FIELD" slot="label">
+          Fill input
+        </label>
         <input class="input" placeholder="This is an input" slot="input">
       </sbb-form-field>
     `);
@@ -72,7 +71,7 @@ describe('sbb-form-field', () => {
               </div>
                <slot name="suffix"></slot>
             </div>
-            <div class="sbb-form-field__error">
+            <div class="sbb-form-field__error" aria-live="polite">
               <slot name="error"></slot>
             </div>
           </div>
@@ -101,24 +100,23 @@ describe('sbb-form-field', () => {
             <div class="sbb-form-field__wrapper">
               <slot name="prefix"></slot>
               <div class="sbb-form-field__input-container">
-                <label class="sbb-form-field__label">
-                  <slot name="label">
-                    <span>
-                      Fill input
-                    </span>
-                  </slot>
-                </label>
+                <span class="sbb-form-field__label">
+                  <slot name="label"></slot>
+                </span>
                 <div class="sbb-form-field__input">
                   <slot></slot>
                 </div>
               </div>
                <slot name="suffix"></slot>
             </div>
-            <div class="sbb-form-field__error">
+            <div class="sbb-form-field__error" aria-live="polite">
               <slot name="error"></slot>
             </div>
           </div>
         </mock:shadow-root>
+        <label data-creator="SBB-FORM-FIELD" slot="label">
+          Fill input
+        </label>
         <input class="input" disabled="" placeholder="This is an input" slot="input">
       </sbb-form-field>
     `);
@@ -143,24 +141,23 @@ describe('sbb-form-field', () => {
             <div class="sbb-form-field__wrapper">
               <slot name="prefix"></slot>
               <div class="sbb-form-field__input-container">
-                <label class="sbb-form-field__label">
-                  <slot name="label">
-                    <span>
-                      Fill input
-                    </span>
-                  </slot>
-                </label>
+                <span class="sbb-form-field__label">
+                  <slot name="label"></slot>
+                </span>
                 <div class="sbb-form-field__input">
                   <slot></slot>
                 </div>
               </div>
                <slot name="suffix"></slot>
             </div>
-            <div class="sbb-form-field__error">
+            <div class="sbb-form-field__error" aria-live="polite">
               <slot name="error"></slot>
             </div>
           </div>
         </mock:shadow-root>
+        <label data-creator="SBB-FORM-FIELD" slot="label">
+          Fill input
+        </label>
         <input aria-describedby="error" class="input" placeholder="This is an input" readonly="" slot="input">
         <sbb-form-error id="error">
           You can't change this value.
@@ -195,7 +192,7 @@ describe('sbb-form-field', () => {
               </div>
               <slot name="suffix"></slot>
             </div>
-            <div class="sbb-form-field__error">
+            <div class="sbb-form-field__error" aria-live="polite">
               <slot name="error"></slot>
             </div>
           </div>
@@ -229,25 +226,24 @@ describe('sbb-form-field', () => {
             <div class="sbb-form-field__wrapper">
               <slot name="prefix"></slot>
               <div class="sbb-form-field__input-container">
-                <label class="sbb-form-field__label">
-                  <slot name="label">
-                    <span>
-                      Select option:
-                    </span>
-                  </slot>
+                <span class="sbb-form-field__label">
+                  <slot name="label"></slot>
                   <span aria-hidden="true">&nbsp;(optional)</span>
-                </label>
+                </span>
                 <div class="sbb-form-field__input">
                   <slot></slot>
                 </div>
               </div>
                <slot name="suffix"></slot>
             </div>
-            <div class="sbb-form-field__error">
+            <div class="sbb-form-field__error" aria-live="polite">
               <slot name="error"></slot>
             </div>
           </div>
         </mock:shadow-root>
+        <label data-creator="SBB-FORM-FIELD" slot="label">
+          Select option:
+        </label>
         <select>
           <option>Value 1</option>
           <option>Value 2</option>


### PR DESCRIPTION
BREAKING CHANGE: It is now required to use a `<label>` to label an input via slot/element in a `<sbb-form-field>`.
