### PR TITLE
fix(sbb-icon): empty icon on Safari

### DIFF
--- a/src/components/sbb-icon/sbb-icon.scss
+++ b/src/components/sbb-icon/sbb-icon.scss
@@ -10,6 +10,10 @@
   -webkit-tap-highlight-color: transparent;
 }
 
+:host([data-empty]) {
+  --sbb-icon-default-dimension: 0;
+}
+
 :host([data-empty][data-namespace='default'][name$='-small']) {
   --sbb-icon-default-dimension: var(--sbb-size-icon-ui-small);
 }

--- a/src/components/sbb-tab-group/sbb-tab-group.stories.js
+++ b/src/components/sbb-tab-group/sbb-tab-group.stories.js
@@ -252,8 +252,8 @@ const basicArgTypes = {
 
 const basicArgs = {
   label: 'Tab label one',
-  iconSlot: '',
-  amountSlot: '',
+  iconSlot: undefined,
+  amountSlot: undefined,
   disabled: true,
 };
 
@@ -273,13 +273,13 @@ nestedTabGroups.argTypes = basicArgTypes;
 tintedBackground.argTypes = basicArgTypes;
 ellipsisLabel.argTypes = basicArgTypes;
 
-defaultTabs.args = JSON.parse(JSON.stringify(basicArgs));
-numbers.args = JSON.parse(JSON.stringify(basicArgs));
-icons.args = JSON.parse(JSON.stringify(basicArgs));
-numbersAndIcons.args = JSON.parse(JSON.stringify(basicArgs));
-nestedTabGroups.args = JSON.parse(JSON.stringify(basicArgs));
-tintedBackground.args = JSON.parse(JSON.stringify(basicArgs));
-ellipsisLabel.args = JSON.parse(JSON.stringify(basicArgs));
+defaultTabs.args = { ...basicArgs };
+numbers.args = { ...basicArgs };
+icons.args = { ...basicArgs };
+numbersAndIcons.args = { ...basicArgs };
+nestedTabGroups.args = { ...basicArgs };
+tintedBackground.args = { ...basicArgs };
+ellipsisLabel.args = { ...basicArgs };
 
 /* VARIANTS */
 numbers.args.amountSlot = '77';


### PR DESCRIPTION
Fix incorrect rendering on Safari when an `sbb-icon` is provided without a specified name property.