### PR TITLE
fix: stabilize positioning function

### DIFF
--- a/src/components/sbb-menu/sbb-menu.scss
+++ b/src/components/sbb-menu/sbb-menu.scss
@@ -23,7 +23,7 @@
 
   // 85vh is not an exact value but looks optimized for mobile view.
   --sbb-menu-max-height: calc(85vh - var(--sbb-spacing-fixed-8x));
-  --sbb-menu-min-height: #{sbb.px-to-rem-build(120)};
+  --sbb-menu-min-height: #{sbb.px-to-rem-build(48.5)};
   --sbb-menu-border-radius: var(--sbb-border-radius-4x);
   --sbb-menu-visibility: hidden;
   --sbb-menu-backdrop-color: transparent;
@@ -134,15 +134,15 @@
 
   @include sbb.mq($from: medium) {
     inset-block-start: 0;
+    inset-block-end: unset;
     inset-inline-start: 0;
     inset-inline-end: unset;
-    inset-block-end: unset;
     max-height: fit-content;
     border-radius: var(--sbb-menu-border-radius);
 
     &[open] {
-      top: var(--sbb-menu-position-y);
-      left: var(--sbb-menu-position-x);
+      inset-block-start: var(--sbb-menu-position-y);
+      inset-inline-start: var(--sbb-menu-position-x);
       max-height: var(--sbb-menu-max-height);
       min-height: var(--sbb-menu-min-height);
     }

--- a/src/global/helpers/position.spec.ts
+++ b/src/global/helpers/position.spec.ts
@@ -87,6 +87,52 @@ describe('getElementPosition', () => {
     });
   });
 
+  it('changes the vertical alignment if there is more space above and the element overflows', () => {
+    jest.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({
+      x: 48,
+      y: 600,
+      width: 80,
+      height: 48,
+      top: 600,
+      right: 952,
+      bottom: 72,
+      left: 48,
+      toJSON: () => {},
+    });
+
+    const elementPosition = getElementPosition(element, trigger);
+
+    expect(elementPosition).toEqual({
+      top: 520,
+      left: 48,
+      maxHeight: '600px',
+      alignment: { horizontal: 'start', vertical: 'above' },
+    });
+  });
+
+  it('does not changes the vertical alignment if there is more space above and the element does not overlflow', () => {
+    jest.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({
+      x: 48,
+      y: 592,
+      width: 80,
+      height: 48,
+      top: 592,
+      right: 952,
+      bottom: 80,
+      left: 48,
+      toJSON: () => {},
+    });
+
+    const elementPosition = getElementPosition(element, trigger);
+
+    expect(elementPosition).toEqual({
+      top: 640,
+      left: 48,
+      maxHeight: '80px',
+      alignment: { horizontal: 'start', vertical: 'below' },
+    });
+  });
+
   it('changes the alignment to end/above', () => {
     jest.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({
       x: 952,

--- a/src/global/helpers/position.ts
+++ b/src/global/helpers/position.ts
@@ -161,7 +161,9 @@ export function getElementPosition(
     (availableSpaceBelow - verticalOffset < elementRec.scrollHeight &&
       availableSpaceAbove - verticalOffset >
         (responsiveHeight ? elementRec.clientHeight : elementRec.scrollHeight)) ||
-    (availableSpaceAbove > availableSpaceBelow && !responsiveHeight)
+    (availableSpaceAbove > availableSpaceBelow &&
+      availableSpaceBelow - verticalOffset < elementRec.clientHeight &&
+      !responsiveHeight)
   ) {
     elementYPosition =
       availableSpaceAbove < elementRec.scrollHeight


### PR DESCRIPTION
Make sure that the positioned element is overflowing before repositioning it to where there is more space available.