### PR TITLE
fix(sbb-menu-action): assign pointer-events to none when disabled

### DIFF
--- a/src/components/sbb-menu-action/sbb-menu-action.scss
+++ b/src/components/sbb-menu-action/sbb-menu-action.scss
@@ -29,6 +29,9 @@
   --sbb-menu-action-color: var(--sbb-color-graphite-default);
   --sbb-menu-action-forced-color-border-color: GrayText;
 
+  pointer-events: none;
+  cursor: default;
+
   @include sbb.if-forced-colors {
     --sbb-menu-action-color: GrayText;
   }


### PR DESCRIPTION
This PR applies `pointer-events: none` for `<sbb-menu-action>` when disabled. This is done similarly in e.g. `<sbb-button>` and `<sbb-link>`.