### PR TITLE
fix(sbb-menu): fixed the window snap on scrolling with an open menu

### DIFF
--- a/src/components/sbb-menu/sbb-menu.tsx
+++ b/src/components/sbb-menu/sbb-menu.tsx
@@ -289,7 +289,7 @@ export class SbbMenu implements ComponentInterface {
       this._state = 'closed';
       this._dialog.firstElementChild.scrollTo(0, 0);
       // Manually focus last focused element in order to avoid showing outline in Safari
-      this._triggerElement?.focus();
+      this._triggerElement?.focus({ preventScroll: true });
       this._dialog.close();
       this.didClose.emit();
       this._windowEventsController?.abort();

--- a/src/components/sbb-menu/sbb-menu.tsx
+++ b/src/components/sbb-menu/sbb-menu.tsx
@@ -289,7 +289,9 @@ export class SbbMenu implements ComponentInterface {
       this._state = 'closed';
       this._dialog.firstElementChild.scrollTo(0, 0);
       // Manually focus last focused element in order to avoid showing outline in Safari
-      this._triggerElement?.focus({ preventScroll: true });
+      this._triggerElement?.focus({
+        preventScroll: this._triggerElement.tagName === 'SBB-HEADER-ACTION',
+      });
       this._dialog.close();
       this.didClose.emit();
       this._windowEventsController?.abort();

--- a/src/components/sbb-menu/sbb-menu.tsx
+++ b/src/components/sbb-menu/sbb-menu.tsx
@@ -290,6 +290,7 @@ export class SbbMenu implements ComponentInterface {
       this._dialog.firstElementChild.scrollTo(0, 0);
       // Manually focus last focused element in order to avoid showing outline in Safari
       this._triggerElement?.focus({
+        // When inside the sbb-header, we prevent the scroll to avoid the snapping to the top of the page
         preventScroll: this._triggerElement.tagName === 'SBB-HEADER-ACTION',
       });
       this._dialog.close();


### PR DESCRIPTION
## Preflight Checklist

<!-- Please ensure you've completed the following steps by replacing [ ] with [x]-->

- [x] I have read the [Contributing Guidelines](https://github.com/lyne-design-system/lyne-components/blob/master/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/lyne-design-system/lyne-components/blob/master/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [pull request tracker](https://github.com/lyne-design-system/lyne-components/pulls) for a Pull Request (PR) that matches the one I want to submit, without success.

## Issue

With an open menu, if you scroll down the page there is a snap effect that moves the scroll to the focused trigger element

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

See [Review Guidelines](../REVIEW.md) for more information on what is checked during the review process.

## Browsers

I tested the build on the following browsers:

- [x] Firefox Desktop
- [x] Chrome Desktop
- [x] Edge Desktop
- [x] Safari Desktop
- [x] Chrome Mobile
- [x] Safari Mobile

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
