### PR TITLE
refactor: migrate to new English named pictograms

### DIFF
--- a/src/components/sbb-icon/sbb-icon-request.ts
+++ b/src/components/sbb-icon/sbb-icon-request.ts
@@ -2,9 +2,12 @@ import { validateContent } from './sbb-icon-validate';
 import { readConfig, SbbIconConfig } from '../../global/helpers/config';
 
 const iconCdn = 'https://d1s1onrtynjaa8.cloudfront.net/';
+
+// TODO: remove picto-legacy namespace
 const iconNamespaces = new Map<string, string>()
   .set('default', `${iconCdn}icons/`)
-  .set('picto', `${iconCdn}pictograms/`);
+  .set('picto-legacy', `${iconCdn}pictograms/`)
+  .set('picto', `${iconCdn}picto/`);
 const requests = new Map<string, Promise<any>>();
 
 /** Fetches icon svg content from providers and asserts only one request per icon is made. */

--- a/src/components/sbb-timetable-row/sbb-timetable-row.helper.spec.ts
+++ b/src/components/sbb-timetable-row/sbb-timetable-row.helper.spec.ts
@@ -11,11 +11,27 @@ import { PtSituation } from '../../global/interfaces/timetable-properties';
 
 describe('getTransportIcon', () => {
   it('should return ship / jetty', () => {
-    expect(getTransportIcon('SHIP', 'de')).toBe('jetty-right');
+    expect(getTransportIcon('SHIP', '', 'de')).toBe('jetty-right');
   });
 
   it('should return empty string', () => {
-    expect(getTransportIcon('UNKNOWN', 'de')).toBe('');
+    expect(getTransportIcon('UNKNOWN', '', 'de')).toBe('');
+  });
+
+  it('should return metro string', () => {
+    expect(getTransportIcon('METRO', 'PB', 'fr')).toBe('metro-right-fr');
+  });
+
+  it('should return metro en string', () => {
+    expect(getTransportIcon('METRO', 'PB', 'en')).toBe('metro-right-de');
+  });
+
+  it('should return cableway string', () => {
+    expect(getTransportIcon('GONDOLA', 'PB', 'de')).toBe('cableway-right');
+  });
+
+  it('should return gondola string', () => {
+    expect(getTransportIcon('GONDOLA', 'GB', 'de')).toBe('gondola-lift-right');
   });
 });
 

--- a/src/components/sbb-timetable-row/sbb-timetable-row.helper.spec.ts
+++ b/src/components/sbb-timetable-row/sbb-timetable-row.helper.spec.ts
@@ -10,12 +10,12 @@ import { walkTimeTrip, partiallyCancelled } from './sbb-timetable-row.sample-dat
 import { PtSituation } from '../../global/interfaces/timetable-properties';
 
 describe('getTransportIcon', () => {
-  it('should return schiff', () => {
-    expect(getTransportIcon('SHIP')).toBe('schiff-right');
+  it('should return ship / jetty', () => {
+    expect(getTransportIcon('SHIP', 'de')).toBe('jetty-right');
   });
 
   it('should return empty string', () => {
-    expect(getTransportIcon('UNKNOWN')).toBe('');
+    expect(getTransportIcon('UNKNOWN', 'de')).toBe('');
   });
 });
 

--- a/src/components/sbb-timetable-row/sbb-timetable-row.helper.tsx
+++ b/src/components/sbb-timetable-row/sbb-timetable-row.helper.tsx
@@ -9,28 +9,31 @@ import {
 import { isRideLeg } from '../../global/helpers/timetable-helper';
 import { i18nTripQuayChange } from '../../global/i18n';
 
-export const getTransportIcon = (vehicleMode: VehicleModeEnum): string => {
+export const getTransportIcon = (vehicleMode: VehicleModeEnum, language: string): string => {
+  // As there are no English pictograms, we fall back to German
+  const normalizedLanguage = language.replace('en', 'de');
+
   switch (vehicleMode) {
     case 'BUS':
       return 'bus-right';
     case 'CABLEWAY':
-      return 'standseilbahn-right';
+      return 'cableway-right';
     case 'CHAIRLIFT':
-      return 'sessellift-right';
+      return 'chair-lift-right';
     case 'COG_RAILWAY':
-      return 'zahnradbahn-right';
+      return 'cog-railway-right';
     case 'GONDOLA':
-      return 'gondelbahn-right';
+      return 'gondola-lift-right';
     case 'METRO':
-      return 'metro-right';
+      return `metro-right-${normalizedLanguage}`;
     case 'PLANE':
-      return 'flugzeug-right';
+      return 'aeroplane-right';
     case 'SHIP':
-      return 'schiff-right';
+      return 'jetty-right';
     case 'TAXI':
       return 'taxi-right';
     case 'TRAIN':
-      return 'zug-right';
+      return 'train-right';
     case 'TRAMWAY':
       return 'tram-right';
     case 'ELEVATOR':

--- a/src/components/sbb-timetable-row/sbb-timetable-row.helper.tsx
+++ b/src/components/sbb-timetable-row/sbb-timetable-row.helper.tsx
@@ -9,37 +9,42 @@ import {
 import { isRideLeg } from '../../global/helpers/timetable-helper';
 import { i18nTripQuayChange } from '../../global/i18n';
 
-export const getTransportIcon = (vehicleMode: VehicleModeEnum, language: string): string => {
+export const getTransportIcon = (
+  vehicleMode: VehicleModeEnum,
+  vehicleSubMode: string,
+  language: string
+): string => {
   // As there are no English pictograms, we fall back to German
   const normalizedLanguage = language.replace('en', 'de');
 
-  switch (vehicleMode) {
-    case 'BUS':
-      return 'bus-right';
-    case 'CABLEWAY':
-      return 'cableway-right';
-    case 'CHAIRLIFT':
-      return 'chair-lift-right';
-    case 'COG_RAILWAY':
-      return 'cog-railway-right';
-    case 'GONDOLA':
-      return 'gondola-lift-right';
-    case 'METRO':
-      return `metro-right-${normalizedLanguage}`;
-    case 'PLANE':
-      return 'aeroplane-right';
-    case 'SHIP':
-      return 'jetty-right';
-    case 'TAXI':
-      return 'taxi-right';
-    case 'TRAIN':
-      return 'train-right';
-    case 'TRAMWAY':
-      return 'tram-right';
-    case 'ELEVATOR':
-      return 'lift';
-    default:
-      return '';
+  if (vehicleMode === 'BUS') {
+    return 'bus-right';
+  } else if (vehicleMode === 'CABLEWAY') {
+    return 'funicular-railway-right';
+  } else if (vehicleMode === 'CHAIRLIFT') {
+    return 'chair-lift-right';
+  } else if (vehicleMode === 'COG_RAILWAY') {
+    return 'cog-railway-right';
+  } else if (vehicleMode === 'GONDOLA' && vehicleSubMode === 'PB') {
+    return 'cableway-right';
+  } else if (vehicleMode === 'GONDOLA') {
+    return 'gondola-lift-right';
+  } else if (vehicleMode === 'METRO') {
+    return `metro-right-${normalizedLanguage}`;
+  } else if (vehicleMode === 'PLANE') {
+    return 'aeroplane-right';
+  } else if (vehicleMode === 'SHIP') {
+    return 'jetty-right';
+  } else if (vehicleMode === 'TAXI') {
+    return 'taxi-right';
+  } else if (vehicleMode === 'TRAIN') {
+    return 'train-right';
+  } else if (vehicleMode === 'TRAMWAY') {
+    return 'tram-right';
+  } else if (vehicleMode === 'ELEVATOR') {
+    return 'lift';
+  } else {
+    return '';
   }
 };
 

--- a/src/components/sbb-timetable-row/sbb-timetable-row.spec.ts
+++ b/src/components/sbb-timetable-row/sbb-timetable-row.spec.ts
@@ -24,7 +24,7 @@ describe('sbb-timetable-row', () => {
                 <div class="sbb-timetable__row-header" role="gridcell">
                   <div class="sbb-timetable__row-details">
                     <span class="sbb-timetable__row-transport-wrapper">
-                      <sbb-icon class="sbb-timetable__row-transport-icon" name="picto:zug-right"></sbb-icon>
+                      <sbb-icon class="sbb-timetable__row-transport-icon" name="picto:train-right"></sbb-icon>
                       <span class="sbb-screenreaderonly">
                         Train
                       </span>

--- a/src/components/sbb-timetable-row/sbb-timetable-row.tsx
+++ b/src/components/sbb-timetable-row/sbb-timetable-row.tsx
@@ -175,11 +175,11 @@ export class SbbTimetableRow {
           <div class="sbb-timetable__row" role="row">
             <div class="sbb-timetable__row-header" role="gridcell">
               <div class="sbb-timetable__row-details">
-                {product && getTransportIcon(product.vehicleMode) && (
+                {product && getTransportIcon(product.vehicleMode, this._currentLanguage) && (
                   <span class="sbb-timetable__row-transport-wrapper">
                     <sbb-icon
                       class="sbb-timetable__row-transport-icon"
-                      name={'picto:' + getTransportIcon(product.vehicleMode)}
+                      name={'picto:' + getTransportIcon(product.vehicleMode, this._currentLanguage)}
                     />
                     <span class="sbb-screenreaderonly">
                       {product &&

--- a/src/components/sbb-timetable-row/sbb-timetable-row.tsx
+++ b/src/components/sbb-timetable-row/sbb-timetable-row.tsx
@@ -175,23 +175,35 @@ export class SbbTimetableRow {
           <div class="sbb-timetable__row" role="row">
             <div class="sbb-timetable__row-header" role="gridcell">
               <div class="sbb-timetable__row-details">
-                {product && getTransportIcon(product.vehicleMode, this._currentLanguage) && (
-                  <span class="sbb-timetable__row-transport-wrapper">
-                    <sbb-icon
-                      class="sbb-timetable__row-transport-icon"
-                      name={'picto:' + getTransportIcon(product.vehicleMode, this._currentLanguage)}
-                    />
-                    <span class="sbb-screenreaderonly">
-                      {product &&
-                        product.vehicleMode &&
-                        i18nMeansOfTransport[product.vehicleMode.toLowerCase()] &&
-                        i18nMeansOfTransport[summary.product.vehicleMode.toLowerCase()][
-                          this._currentLanguage
-                        ]}
-                      &nbsp;
+                {product &&
+                  getTransportIcon(
+                    product.vehicleMode,
+                    product.vehicleSubModeShortName,
+                    this._currentLanguage
+                  ) && (
+                    <span class="sbb-timetable__row-transport-wrapper">
+                      <sbb-icon
+                        class="sbb-timetable__row-transport-icon"
+                        name={
+                          'picto:' +
+                          getTransportIcon(
+                            product.vehicleMode,
+                            product.vehicleSubModeShortName,
+                            this._currentLanguage
+                          )
+                        }
+                      />
+                      <span class="sbb-screenreaderonly">
+                        {product &&
+                          product.vehicleMode &&
+                          i18nMeansOfTransport[product.vehicleMode.toLowerCase()] &&
+                          i18nMeansOfTransport[summary.product.vehicleMode.toLowerCase()][
+                            this._currentLanguage
+                          ]}
+                        &nbsp;
+                      </span>
                     </span>
-                  </span>
-                )}
+                  )}
                 {product &&
                   product.vehicleSubModeShortName &&
                   (isProductIcon(product?.vehicleSubModeShortName?.toLocaleLowerCase())

--- a/src/global/interfaces/timetable-properties.ts
+++ b/src/global/interfaces/timetable-properties.ts
@@ -98,15 +98,6 @@ export type OccupancyEnum = 'HIGH' | 'LOW' | 'MEDIUM' | 'UNKNOWN';
 /** Type of Notice */
 export type NoticeTypeEnum = 'ATTRIBUTE' | 'INFO';
 
-export type TextArgumentEnum = 'EMAIL' | 'PHONE' | 'URL';
-
-/** key-value pair. Key is one of: (EMAIL,PHONE,URL) */
-export type TextArgument = {
-  __typename?: 'TextArgument';
-  type?: TextArgumentEnum;
-  values: string[];
-};
-
 /** Mode of public transportation */
 export type VehicleModeEnum =
   | 'BUS'


### PR DESCRIPTION
BREAKING CHANGE:
The `picto:`-namespace is now pointing to the new English named icons. If the old german named icons should be used, you can access them by using the namespace `picto-legacy:` (deprecated).
