### PR TITLE
build: refine preview image cleanup

### DIFF
--- a/.github/workflows/preview-image-cleanup.yml
+++ b/.github/workflows/preview-image-cleanup.yml
@@ -15,12 +15,19 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
-            const response = await github.rest.packages.getAllPackageVersionsForPackageOwnedByUser({
+            const pullRequestOptions = await github.rest.pulls.list.endpoint.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open'
+            });
+            const { data: pullRequests } = await github.paginate(pullRequestOptions);
+            console.log(pullRequests)
+            const { data: versions } = await github.rest.packages.getAllPackageVersionsForPackageOwnedByUser({
               package_type: 'container',
               package_name: 'lyne-components/storybook-preview',
               username: context.repo.owner,
             });
-            console.log(response)
+            console.log(versions)
       - uses: actions/delete-package-versions@v4
         with:
           package-name: 'lyne-components/storybook-preview'

--- a/.github/workflows/preview-image-cleanup.yml
+++ b/.github/workflows/preview-image-cleanup.yml
@@ -12,12 +12,16 @@ jobs:
   preview-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/delete-package-versions@v4
+      - uses: actions/github-script@v6
         with:
-          package-name: 'lyne-components/storybook-preview'
-          package-type: 'container'
-          ignore-versions: '^preview-'
-          min-versions-to-keep: 0
+          script: |
+            const response = github.rest.packages.getAllPackageVersionsForPackageOwnedByUser({
+              package_type: 'container',
+              package_name: 'lyne-components/storybook-preview',
+              username: context.repo.owner,
+            });
+            const versions = await github.paginate(response);
+            console.log(versions)
       - uses: actions/delete-package-versions@v4
         with:
           package-name: 'lyne-components/storybook-preview'

--- a/.github/workflows/preview-image-cleanup.yml
+++ b/.github/workflows/preview-image-cleanup.yml
@@ -12,35 +12,34 @@ jobs:
   preview-image:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Container: Login to GitHub Container Repository'
-        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
       - uses: actions/github-script@v6
         with:
           script: |
-            const pullRequestOptions = await github.rest.pulls.list.endpoint.merge({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open'
-            });
-            const pullRequests = await github.paginate(pullRequestOptions);
+            const { owner, repo } = context.repo;
+            const pullRequests = await github.paginate(
+              github.rest.pulls.list.endpoint.merge({ owner, repo, state: 'all' })
+            );
+            const twoWeeksAgo = new Date(Date.now() - (14 * 24 * 60 * 60 * 1000));
+            const olderThanTwoWeeks = (date) => new Date(date) < twoWeeksAgo;
+            const isExpiredPrTag = (version) => {
+              const previewTag = version.metadata?.container?.tags?.find((t) => t.startsWith('preview-pr'));
+              const prNumber = +previewTag?.split('preview-pr')[1];
+              const pr = pullRequests.find((p) => p.number === prNumber);
+              return !!prNumber && pr.state === 'closed' && olderThanTwoWeeks(pr.closed_at);
+            };
 
-            const { data: versions } = await github.rest.packages.getAllPackageVersionsForPackageOwnedByUser({
+            const params = {
               package_type: 'container',
-              package_name: 'lyne-components/storybook-preview',
-              username: context.repo.owner,
-            });
-
-            const { execSync } = require('child_process');
-            for (const version of versions) {
-              const tags = version.metadata?.container?.tags ?? [];
-              const revTag = tags.find((t) => t.startsWith('rev-'));
-              if (revTag) {
-                execSync(`docker rmi ghcr.io/lyne-design-system/lyne-components/storybook-preview:${revTag}`, { stdio: 'inherit' });
-              }
-
-              const previewTag = tags.find((t) => t.startsWith('preview-pr'));
-              if (previewTag) {
-
+              package_name: `${repo}/storybook-preview`,
+              username: owner
+            };
+            const { data: versions } = await github.rest.packages.getAllPackageVersionsForPackageOwnedByUser(params);
+            for (const version of versions.filter(isExpiredPrTag)) {
+              try {
+                await github.rest.packages.deletePackageVersionForUser({ ...params, package_version_id: version.id });
+                console.log(`Deleted ${version.name} (${version.metadata.container.tags.join(', ')})`);
+              } catch(e) {
+                console.error(`Failed to delete ${version.name} (${version.metadata.container.tags.join(', ')})`);
               }
             }
       - uses: actions/delete-package-versions@v4

--- a/.github/workflows/preview-image-cleanup.yml
+++ b/.github/workflows/preview-image-cleanup.yml
@@ -12,6 +12,8 @@ jobs:
   preview-image:
     runs-on: ubuntu-latest
     steps:
+      - name: 'Container: Login to GitHub Container Repository'
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
       - uses: actions/github-script@v6
         with:
           script: |
@@ -21,19 +23,24 @@ jobs:
               state: 'open'
             });
             const pullRequests = await github.paginate(pullRequestOptions);
-            console.log(pullRequests)
+
             const { data: versions } = await github.rest.packages.getAllPackageVersionsForPackageOwnedByUser({
               package_type: 'container',
               package_name: 'lyne-components/storybook-preview',
               username: context.repo.owner,
             });
-            console.log(versions)
+
             const { execSync } = require('child_process');
             for (const version of versions) {
               const tags = version.metadata?.container?.tags ?? [];
               const revTag = tags.find((t) => t.startsWith('rev-'));
               if (revTag) {
                 execSync(`docker rmi ghcr.io/lyne-design-system/lyne-components/storybook-preview:${revTag}`, { stdio: 'inherit' });
+              }
+
+              const previewTag = tags.find((t) => t.startsWith('preview-pr'));
+              if (previewTag) {
+
               }
             }
       - uses: actions/delete-package-versions@v4

--- a/.github/workflows/preview-image-cleanup.yml
+++ b/.github/workflows/preview-image-cleanup.yml
@@ -17,6 +17,7 @@ jobs:
           package-name: 'lyne-components/storybook-preview'
           package-type: 'container'
           ignore-versions: '^preview-'
+          min-versions-to-keep: 0
       - uses: actions/delete-package-versions@v4
         with:
           package-name: 'lyne-components/storybook-preview'

--- a/.github/workflows/preview-image-cleanup.yml
+++ b/.github/workflows/preview-image-cleanup.yml
@@ -20,7 +20,7 @@ jobs:
               repo: context.repo.repo,
               state: 'open'
             });
-            const { data: pullRequests } = await github.paginate(pullRequestOptions);
+            const pullRequests = await github.paginate(pullRequestOptions);
             console.log(pullRequests)
             const { data: versions } = await github.rest.packages.getAllPackageVersionsForPackageOwnedByUser({
               package_type: 'container',
@@ -28,6 +28,14 @@ jobs:
               username: context.repo.owner,
             });
             console.log(versions)
+            const { execSync } = require('child_process');
+            for (const version of versions) {
+              const tags = version.metadata?.container?.tags ?? [];
+              const revTag = tags.find((t) => t.startsWith('rev-'));
+              if (revTag) {
+                execSync(`docker rmi ghcr.io/lyne-design-system/lyne-components/storybook-preview:${revTag}`, { stdio: 'inherit' });
+              }
+            }
       - uses: actions/delete-package-versions@v4
         with:
           package-name: 'lyne-components/storybook-preview'

--- a/.github/workflows/preview-image-cleanup.yml
+++ b/.github/workflows/preview-image-cleanup.yml
@@ -17,8 +17,14 @@ jobs:
           script: |
             const versions = github.rest.packages.getAllPackageVersionsForPackageOwnedByUser({
               package_type: 'container',
-              package_name: 'lyne-components%2Fstorybook-preview',
+              package_name: 'lyne-components/storybook-preview',
               username: context.repo.owner,
             });
             const result = await github.paginate(versions);
             console.log(result)
+
+      - uses: actions/delete-package-versions@v4
+        with:
+          package-name: 'lyne-components/storybook-preview'
+          package-type: 'container'
+          delete-only-untagged-versions: 'true'

--- a/.github/workflows/preview-image-cleanup.yml
+++ b/.github/workflows/preview-image-cleanup.yml
@@ -12,17 +12,11 @@ jobs:
   preview-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/delete-package-versions@v4
         with:
-          script: |
-            const versions = github.rest.packages.getAllPackageVersionsForPackageOwnedByUser({
-              package_type: 'container',
-              package_name: 'lyne-components/storybook-preview',
-              username: context.repo.owner,
-            });
-            const result = await github.paginate(versions);
-            console.log(result)
-
+          package-name: 'lyne-components/storybook-preview'
+          package-type: 'container'
+          ignore-versions: '^preview-'
       - uses: actions/delete-package-versions@v4
         with:
           package-name: 'lyne-components/storybook-preview'

--- a/.github/workflows/preview-image-cleanup.yml
+++ b/.github/workflows/preview-image-cleanup.yml
@@ -15,13 +15,12 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
-            const response = github.rest.packages.getAllPackageVersionsForPackageOwnedByUser({
+            const response = await github.rest.packages.getAllPackageVersionsForPackageOwnedByUser({
               package_type: 'container',
               package_name: 'lyne-components/storybook-preview',
               username: context.repo.owner,
             });
-            const versions = await github.paginate(response);
-            console.log(versions)
+            console.log(response)
       - uses: actions/delete-package-versions@v4
         with:
           package-name: 'lyne-components/storybook-preview'

--- a/.github/workflows/preview-image-cleanup.yml
+++ b/.github/workflows/preview-image-cleanup.yml
@@ -12,9 +12,13 @@ jobs:
   preview-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/delete-package-versions@v4
+      - uses: actions/github-script@v6
         with:
-          package-name: 'lyne-components%2Fstorybook-preview'
-          package-type: 'container'
-          min-versions-to-keep: 3
-          delete-only-untagged-versions: 'true'
+          script: |
+            const versions = github.rest.packages.getAllPackageVersionsForPackageOwnedByUser({
+              package_type: 'container',
+              package_name: 'lyne-components%2Fstorybook-preview',
+              username: context.repo.owner,
+            });
+            const result = await github.paginate(versions);
+            console.log(result)


### PR DESCRIPTION
This PR adds a workflow that runs every day or on demand and removes untagged container images from [lyne-components/storybook-preview](https://github.com/orgs/lyne-design-system/packages/container/package/lyne-components%2Fstorybook-preview). It also removes images related to pull requests that have been closed for more than two weeks.