### PR TITLE
fix(sbb-navigation): focus outline on the trigger element in Safari

### DIFF
--- a/src/components/sbb-dialog/sbb-dialog.tsx
+++ b/src/components/sbb-dialog/sbb-dialog.tsx
@@ -12,7 +12,7 @@ import {
 } from '@stencil/core';
 import { InterfaceTitleAttributes } from '../sbb-title/sbb-title.custom';
 import { isEventOnElement } from '../../global/helpers/position';
-import { IS_FOCUSABLE_QUERY, FocusTrap, seModalityOnNextFocus } from '../../global/helpers/focus';
+import { IS_FOCUSABLE_QUERY, FocusTrap } from '../../global/helpers/focus';
 import { i18nCloseDialog, i18nGoBack } from '../../global/i18n';
 import { hostContext } from '../../global/helpers/host-context';
 import { isValidAttribute } from '../../global/helpers/is-valid-attribute';
@@ -26,6 +26,7 @@ import {
   sbbInputModalityDetector,
   languageChangeHandlerAspect,
   namedSlotChangeHandlerAspect,
+  setModalityOnNextFocus,
 } from '../../global/helpers';
 import { SbbOverlayState } from '../../global/helpers/overlay';
 
@@ -290,10 +291,10 @@ export class SbbDialog implements ComponentInterface {
     } else if (event.animationName === 'close') {
       this._state = 'closed';
       this._dialogWrapperElement.querySelector('.sbb-dialog__content').scrollTo(0, 0);
-      seModalityOnNextFocus(this._lastFocusedElement);
+      setModalityOnNextFocus(this._lastFocusedElement);
+      this._dialog.close();
       // Manually focus last focused element in order to avoid showing outline in Safari
       this._lastFocusedElement?.focus();
-      this._dialog.close();
       this.didClose.emit({ returnValue: this._returnValue, closeTarget: this._dialogCloseElement });
       this._windowEventsController?.abort();
       this._focusTrap.disconnect();

--- a/src/components/sbb-dialog/sbb-dialog.tsx
+++ b/src/components/sbb-dialog/sbb-dialog.tsx
@@ -12,7 +12,11 @@ import {
 } from '@stencil/core';
 import { InterfaceTitleAttributes } from '../sbb-title/sbb-title.custom';
 import { isEventOnElement } from '../../global/helpers/position';
-import { IS_FOCUSABLE_QUERY, FocusTrap } from '../../global/helpers/focus';
+import {
+  IS_FOCUSABLE_QUERY,
+  FocusTrap,
+  focusAndSetCloseModality,
+} from '../../global/helpers/focus';
 import { i18nCloseDialog, i18nGoBack } from '../../global/i18n';
 import { hostContext } from '../../global/helpers/host-context';
 import { isValidAttribute } from '../../global/helpers/is-valid-attribute';
@@ -290,8 +294,7 @@ export class SbbDialog implements ComponentInterface {
     } else if (event.animationName === 'close') {
       this._state = 'closed';
       this._dialogWrapperElement.querySelector('.sbb-dialog__content').scrollTo(0, 0);
-      // Manually focus last focused element in order to avoid showing outline in Safari
-      this._lastFocusedElement?.focus();
+      focusAndSetCloseModality(this._lastFocusedElement);
       this._dialog.close();
       this.didClose.emit({ returnValue: this._returnValue, closeTarget: this._dialogCloseElement });
       this._windowEventsController?.abort();

--- a/src/components/sbb-dialog/sbb-dialog.tsx
+++ b/src/components/sbb-dialog/sbb-dialog.tsx
@@ -12,7 +12,7 @@ import {
 } from '@stencil/core';
 import { InterfaceTitleAttributes } from '../sbb-title/sbb-title.custom';
 import { isEventOnElement } from '../../global/helpers/position';
-import { IS_FOCUSABLE_QUERY, FocusTrap, focusAndSetModality } from '../../global/helpers/focus';
+import { IS_FOCUSABLE_QUERY, FocusTrap, seModalityOnNextFocus } from '../../global/helpers/focus';
 import { i18nCloseDialog, i18nGoBack } from '../../global/i18n';
 import { hostContext } from '../../global/helpers/host-context';
 import { isValidAttribute } from '../../global/helpers/is-valid-attribute';
@@ -290,7 +290,9 @@ export class SbbDialog implements ComponentInterface {
     } else if (event.animationName === 'close') {
       this._state = 'closed';
       this._dialogWrapperElement.querySelector('.sbb-dialog__content').scrollTo(0, 0);
-      focusAndSetModality(this._lastFocusedElement);
+      seModalityOnNextFocus(this._lastFocusedElement);
+      // Manually focus last focused element in order to avoid showing outline in Safari
+      this._lastFocusedElement?.focus();
       this._dialog.close();
       this.didClose.emit({ returnValue: this._returnValue, closeTarget: this._dialogCloseElement });
       this._windowEventsController?.abort();

--- a/src/components/sbb-dialog/sbb-dialog.tsx
+++ b/src/components/sbb-dialog/sbb-dialog.tsx
@@ -12,11 +12,7 @@ import {
 } from '@stencil/core';
 import { InterfaceTitleAttributes } from '../sbb-title/sbb-title.custom';
 import { isEventOnElement } from '../../global/helpers/position';
-import {
-  IS_FOCUSABLE_QUERY,
-  FocusTrap,
-  focusAndSetCloseModality,
-} from '../../global/helpers/focus';
+import { IS_FOCUSABLE_QUERY, FocusTrap, focusAndSetModality } from '../../global/helpers/focus';
 import { i18nCloseDialog, i18nGoBack } from '../../global/i18n';
 import { hostContext } from '../../global/helpers/host-context';
 import { isValidAttribute } from '../../global/helpers/is-valid-attribute';
@@ -294,7 +290,7 @@ export class SbbDialog implements ComponentInterface {
     } else if (event.animationName === 'close') {
       this._state = 'closed';
       this._dialogWrapperElement.querySelector('.sbb-dialog__content').scrollTo(0, 0);
-      focusAndSetCloseModality(this._lastFocusedElement);
+      focusAndSetModality(this._lastFocusedElement);
       this._dialog.close();
       this.didClose.emit({ returnValue: this._returnValue, closeTarget: this._dialogCloseElement });
       this._windowEventsController?.abort();

--- a/src/components/sbb-menu/sbb-menu.tsx
+++ b/src/components/sbb-menu/sbb-menu.tsx
@@ -15,7 +15,7 @@ import {
 } from '@stencil/core';
 import { getElementPosition, isEventOnElement } from '../../global/helpers/position';
 import { isBreakpoint } from '../../global/helpers/breakpoint';
-import { IS_FOCUSABLE_QUERY, FocusTrap, focusAndSetModality } from '../../global/helpers/focus';
+import { IS_FOCUSABLE_QUERY, FocusTrap, seModalityOnNextFocus } from '../../global/helpers/focus';
 import { isValidAttribute } from '../../global/helpers/is-valid-attribute';
 import { assignId } from '../../global/helpers/assign-id';
 import {
@@ -278,9 +278,10 @@ export class SbbMenu implements ComponentInterface {
     } else if (event.animationName === 'close') {
       this._state = 'closed';
       this._dialog.firstElementChild.scrollTo(0, 0);
-      // Manually focus last focused element in order to avoid showing outline in Safari.
-      // When inside the sbb-header, we prevent the scroll to avoid the snapping to the top of the page.
-      focusAndSetModality(this._triggerElement, {
+      seModalityOnNextFocus(this._triggerElement);
+      // Manually focus last focused element in order to avoid showing outline in Safari
+      this._triggerElement?.focus({
+        // When inside the sbb-header, we prevent the scroll to avoid the snapping to the top of the page
         preventScroll: this._triggerElement.tagName === 'SBB-HEADER-ACTION',
       });
       this._dialog.close();

--- a/src/components/sbb-menu/sbb-menu.tsx
+++ b/src/components/sbb-menu/sbb-menu.tsx
@@ -15,11 +15,7 @@ import {
 } from '@stencil/core';
 import { getElementPosition, isEventOnElement } from '../../global/helpers/position';
 import { isBreakpoint } from '../../global/helpers/breakpoint';
-import {
-  IS_FOCUSABLE_QUERY,
-  FocusTrap,
-  focusAndSetCloseModality,
-} from '../../global/helpers/focus';
+import { IS_FOCUSABLE_QUERY, FocusTrap, focusAndSetModality } from '../../global/helpers/focus';
 import { isValidAttribute } from '../../global/helpers/is-valid-attribute';
 import { assignId } from '../../global/helpers/assign-id';
 import {
@@ -284,7 +280,7 @@ export class SbbMenu implements ComponentInterface {
       this._dialog.firstElementChild.scrollTo(0, 0);
       // Manually focus last focused element in order to avoid showing outline in Safari.
       // When inside the sbb-header, we prevent the scroll to avoid the snapping to the top of the page.
-      focusAndSetCloseModality(this._triggerElement, {
+      focusAndSetModality(this._triggerElement, {
         preventScroll: this._triggerElement.tagName === 'SBB-HEADER-ACTION',
       });
       this._dialog.close();

--- a/src/components/sbb-menu/sbb-menu.tsx
+++ b/src/components/sbb-menu/sbb-menu.tsx
@@ -15,7 +15,11 @@ import {
 } from '@stencil/core';
 import { getElementPosition, isEventOnElement } from '../../global/helpers/position';
 import { isBreakpoint } from '../../global/helpers/breakpoint';
-import { IS_FOCUSABLE_QUERY, FocusTrap } from '../../global/helpers/focus';
+import {
+  IS_FOCUSABLE_QUERY,
+  FocusTrap,
+  focusAndSetCloseModality,
+} from '../../global/helpers/focus';
 import { isValidAttribute } from '../../global/helpers/is-valid-attribute';
 import { assignId } from '../../global/helpers/assign-id';
 import {
@@ -278,9 +282,9 @@ export class SbbMenu implements ComponentInterface {
     } else if (event.animationName === 'close') {
       this._state = 'closed';
       this._dialog.firstElementChild.scrollTo(0, 0);
-      // Manually focus last focused element in order to avoid showing outline in Safari
-      this._triggerElement?.focus({
-        // When inside the sbb-header, we prevent the scroll to avoid the snapping to the top of the page
+      // Manually focus last focused element in order to avoid showing outline in Safari.
+      // When inside the sbb-header, we prevent the scroll to avoid the snapping to the top of the page.
+      focusAndSetCloseModality(this._triggerElement, {
         preventScroll: this._triggerElement.tagName === 'SBB-HEADER-ACTION',
       });
       this._dialog.close();

--- a/src/components/sbb-menu/sbb-menu.tsx
+++ b/src/components/sbb-menu/sbb-menu.tsx
@@ -15,7 +15,7 @@ import {
 } from '@stencil/core';
 import { getElementPosition, isEventOnElement } from '../../global/helpers/position';
 import { isBreakpoint } from '../../global/helpers/breakpoint';
-import { IS_FOCUSABLE_QUERY, FocusTrap, seModalityOnNextFocus } from '../../global/helpers/focus';
+import { IS_FOCUSABLE_QUERY, FocusTrap } from '../../global/helpers/focus';
 import { isValidAttribute } from '../../global/helpers/is-valid-attribute';
 import { assignId } from '../../global/helpers/assign-id';
 import {
@@ -23,7 +23,7 @@ import {
   removeAriaOverlayTriggerAttributes,
 } from '../../global/helpers/overlay-trigger-attributes';
 import { ScrollHandler } from '../../global/helpers/scroll';
-import { sbbInputModalityDetector } from '../../global/helpers';
+import { sbbInputModalityDetector, setModalityOnNextFocus } from '../../global/helpers';
 
 import { SbbOverlayState } from '../../global/helpers/overlay';
 
@@ -278,13 +278,13 @@ export class SbbMenu implements ComponentInterface {
     } else if (event.animationName === 'close') {
       this._state = 'closed';
       this._dialog.firstElementChild.scrollTo(0, 0);
-      seModalityOnNextFocus(this._triggerElement);
+      setModalityOnNextFocus(this._triggerElement);
+      this._dialog.close();
       // Manually focus last focused element in order to avoid showing outline in Safari
       this._triggerElement?.focus({
         // When inside the sbb-header, we prevent the scroll to avoid the snapping to the top of the page
         preventScroll: this._triggerElement.tagName === 'SBB-HEADER-ACTION',
       });
-      this._dialog.close();
       this.didClose.emit();
       this._windowEventsController?.abort();
       this._focusTrap.disconnect();

--- a/src/components/sbb-navigation/sbb-navigation.tsx
+++ b/src/components/sbb-navigation/sbb-navigation.tsx
@@ -14,7 +14,7 @@ import {
   Watch,
 } from '@stencil/core';
 import { isBreakpoint } from '../../global/helpers/breakpoint';
-import { focusAndSetModality, FocusTrap, IS_FOCUSABLE_QUERY } from '../../global/helpers/focus';
+import { seModalityOnNextFocus, FocusTrap, IS_FOCUSABLE_QUERY } from '../../global/helpers/focus';
 import { AgnosticMutationObserver as MutationObserver } from '../../global/helpers/mutation-observer';
 import { isEventOnElement } from '../../global/helpers/position';
 import { ScrollHandler } from '../../global/helpers/scroll';
@@ -233,8 +233,10 @@ export class SbbNavigation implements ComponentInterface {
     } else if (event.animationName === 'close') {
       this._state = 'closed';
       this._navigationContentElement.scrollTo(0, 0);
-      focusAndSetModality(this._triggerElement);
+      seModalityOnNextFocus(this._triggerElement);
       this._navigation.close();
+      // To enable focusing other element than the trigger, we need to call focus() a second time.
+      this._triggerElement?.focus();
       this.didClose.emit();
       this._windowEventsController?.abort();
       this._focusTrap.disconnect();

--- a/src/components/sbb-navigation/sbb-navigation.tsx
+++ b/src/components/sbb-navigation/sbb-navigation.tsx
@@ -14,7 +14,11 @@ import {
   Watch,
 } from '@stencil/core';
 import { isBreakpoint } from '../../global/helpers/breakpoint';
-import { FocusTrap, IS_FOCUSABLE_QUERY } from '../../global/helpers/focus';
+import {
+  focusAndSetCloseModality,
+  FocusTrap,
+  IS_FOCUSABLE_QUERY,
+} from '../../global/helpers/focus';
 import { AgnosticMutationObserver as MutationObserver } from '../../global/helpers/mutation-observer';
 import { isEventOnElement } from '../../global/helpers/position';
 import { ScrollHandler } from '../../global/helpers/scroll';
@@ -30,7 +34,6 @@ import {
   HandlerRepository,
   sbbInputModalityDetector,
   languageChangeHandlerAspect,
-  SbbInputModality,
 } from '../../global/helpers';
 import { SbbOverlayState } from '../../global/helpers/overlay';
 
@@ -234,28 +237,8 @@ export class SbbNavigation implements ComponentInterface {
     } else if (event.animationName === 'close') {
       this._state = 'closed';
       this._navigationContentElement.scrollTo(0, 0);
-
-      const closedByModality = sbbInputModalityDetector.mostRecentModality;
-
-      // Set focus origin to element which should receive focus
-      if (this._triggerElement && closedByModality !== null) {
-        this._triggerElement.addEventListener(
-          'focus',
-          () => {
-            (this._triggerElement.dataset.focusOrigin as SbbInputModality) = closedByModality;
-            this._triggerElement.addEventListener(
-              'blur',
-              () => delete this._triggerElement.dataset.focusOrigin,
-              { once: true }
-            );
-          },
-          { once: true }
-        );
-      }
-
+      focusAndSetCloseModality(this._triggerElement);
       this._navigation.close();
-      // To enable focusing other element than the trigger, we need to call focus() a second time.
-      this._triggerElement?.focus();
       this.didClose.emit();
       this._windowEventsController?.abort();
       this._focusTrap.disconnect();

--- a/src/components/sbb-navigation/sbb-navigation.tsx
+++ b/src/components/sbb-navigation/sbb-navigation.tsx
@@ -14,11 +14,7 @@ import {
   Watch,
 } from '@stencil/core';
 import { isBreakpoint } from '../../global/helpers/breakpoint';
-import {
-  focusAndSetCloseModality,
-  FocusTrap,
-  IS_FOCUSABLE_QUERY,
-} from '../../global/helpers/focus';
+import { focusAndSetModality, FocusTrap, IS_FOCUSABLE_QUERY } from '../../global/helpers/focus';
 import { AgnosticMutationObserver as MutationObserver } from '../../global/helpers/mutation-observer';
 import { isEventOnElement } from '../../global/helpers/position';
 import { ScrollHandler } from '../../global/helpers/scroll';
@@ -237,7 +233,7 @@ export class SbbNavigation implements ComponentInterface {
     } else if (event.animationName === 'close') {
       this._state = 'closed';
       this._navigationContentElement.scrollTo(0, 0);
-      focusAndSetCloseModality(this._triggerElement);
+      focusAndSetModality(this._triggerElement);
       this._navigation.close();
       this.didClose.emit();
       this._windowEventsController?.abort();

--- a/src/components/sbb-navigation/sbb-navigation.tsx
+++ b/src/components/sbb-navigation/sbb-navigation.tsx
@@ -14,7 +14,7 @@ import {
   Watch,
 } from '@stencil/core';
 import { isBreakpoint } from '../../global/helpers/breakpoint';
-import { seModalityOnNextFocus, FocusTrap, IS_FOCUSABLE_QUERY } from '../../global/helpers/focus';
+import { FocusTrap, IS_FOCUSABLE_QUERY } from '../../global/helpers/focus';
 import { AgnosticMutationObserver as MutationObserver } from '../../global/helpers/mutation-observer';
 import { isEventOnElement } from '../../global/helpers/position';
 import { ScrollHandler } from '../../global/helpers/scroll';
@@ -30,6 +30,7 @@ import {
   HandlerRepository,
   sbbInputModalityDetector,
   languageChangeHandlerAspect,
+  setModalityOnNextFocus,
 } from '../../global/helpers';
 import { SbbOverlayState } from '../../global/helpers/overlay';
 
@@ -233,7 +234,7 @@ export class SbbNavigation implements ComponentInterface {
     } else if (event.animationName === 'close') {
       this._state = 'closed';
       this._navigationContentElement.scrollTo(0, 0);
-      seModalityOnNextFocus(this._triggerElement);
+      setModalityOnNextFocus(this._triggerElement);
       this._navigation.close();
       // To enable focusing other element than the trigger, we need to call focus() a second time.
       this._triggerElement?.focus();

--- a/src/components/sbb-tooltip/sbb-tooltip.e2e.ts
+++ b/src/components/sbb-tooltip/sbb-tooltip.e2e.ts
@@ -12,7 +12,7 @@ describe('sbb-tooltip', () => {
       <sbb-tooltip id="tooltip" trigger="tooltip-trigger" disable-animation>
         Tooltip content. <sbb-link id="tooltip-link" variant="inline" sbb-tooltip-close>Link</sbb-link>
       </sbb-tooltip>
-      <sbb-link href="#somewhere" id="interactive-background-element">Other interactive element</sbb-link>
+      <sbb-link href="#somewhere" id="interactive-background-element">Other interactive elemento</sbb-link>
     `);
     trigger = await page.find('sbb-button');
     element = await page.find('sbb-tooltip');
@@ -402,9 +402,7 @@ describe('sbb-tooltip', () => {
     await waitForCondition(() => didOpenEventSpy.events.length === 1);
     await page.waitForChanges();
 
-    await interactiveBackgroundElement.focus();
-    // Simulate backdrop click
-    await page.evaluate(() => window.dispatchEvent(new PointerEvent('pointerup')));
+    await interactiveBackgroundElement.click();
     await page.waitForChanges();
 
     await waitForCondition(() => didCloseEventSpy.events.length === 1);

--- a/src/components/sbb-tooltip/sbb-tooltip.e2e.ts
+++ b/src/components/sbb-tooltip/sbb-tooltip.e2e.ts
@@ -12,7 +12,7 @@ describe('sbb-tooltip', () => {
       <sbb-tooltip id="tooltip" trigger="tooltip-trigger" disable-animation>
         Tooltip content. <sbb-link id="tooltip-link" variant="inline" sbb-tooltip-close>Link</sbb-link>
       </sbb-tooltip>
-      <sbb-link href="#somewhere" id="interactive-background-element">Other interactive elemento</sbb-link>
+      <sbb-link href="#somewhere" id="interactive-background-element">Other interactive element</sbb-link>
     `);
     trigger = await page.find('sbb-button');
     element = await page.find('sbb-tooltip');

--- a/src/components/sbb-tooltip/sbb-tooltip.tsx
+++ b/src/components/sbb-tooltip/sbb-tooltip.tsx
@@ -13,7 +13,11 @@ import {
   Watch,
 } from '@stencil/core';
 import { Alignment, getElementPosition, isEventOnElement } from '../../global/helpers/position';
-import { IS_FOCUSABLE_QUERY, FocusTrap } from '../../global/helpers/focus';
+import {
+  IS_FOCUSABLE_QUERY,
+  FocusTrap,
+  focusAndSetCloseModality,
+} from '../../global/helpers/focus';
 import { i18nCloseTooltip } from '../../global/i18n';
 import { isValidAttribute } from '../../global/helpers/is-valid-attribute';
 import { assignId } from '../../global/helpers/assign-id';
@@ -26,7 +30,6 @@ import {
   HandlerRepository,
   languageChangeHandlerAspect,
   sbbInputModalityDetector,
-  SbbInputModality,
 } from '../../global/helpers';
 import { SbbOverlayState } from '../../global/helpers/overlay';
 
@@ -399,23 +402,7 @@ export class SbbTooltip implements ComponentInterface {
         ? this._nextFocusedElement
         : this._triggerElement;
 
-      const closedByModality = sbbInputModalityDetector.mostRecentModality;
-
-      // Set focus origin to element which should receive focus
-      if (elementToFocus && closedByModality !== null) {
-        elementToFocus.addEventListener(
-          'focus',
-          () => {
-            (elementToFocus.dataset.focusOrigin as SbbInputModality) = closedByModality;
-            elementToFocus.addEventListener(
-              'blur',
-              () => delete elementToFocus.dataset.focusOrigin,
-              { once: true }
-            );
-          },
-          { once: true }
-        );
-      }
+      focusAndSetCloseModality(elementToFocus);
       this._dialog.close();
       // To enable focusing other element than the trigger, we need to call focus() a second time.
       elementToFocus?.focus();

--- a/src/components/sbb-tooltip/sbb-tooltip.tsx
+++ b/src/components/sbb-tooltip/sbb-tooltip.tsx
@@ -348,12 +348,10 @@ export class SbbTooltip implements ComponentInterface {
   // Close tooltip on backdrop click.
   private _closeOnBackdropClick = async (event: PointerEvent): Promise<void> => {
     if (!this._isPointerDownEventOnTooltip && !isEventOnElement(this._dialog, event)) {
-      const composedPathElements = event
+      this._nextFocusedElement = event
         .composedPath()
-        .filter((el) => el instanceof window.HTMLElement);
-      this._nextFocusedElement = composedPathElements.find((el) =>
-        (el as HTMLElement).matches(IS_FOCUSABLE_QUERY)
-      ) as HTMLElement;
+        .filter((el) => el instanceof window.HTMLElement)
+        .find((el) => (el as HTMLElement).matches(IS_FOCUSABLE_QUERY)) as HTMLElement;
       clearTimeout(this._closeTimeout);
       await this.close();
     }

--- a/src/components/sbb-tooltip/sbb-tooltip.tsx
+++ b/src/components/sbb-tooltip/sbb-tooltip.tsx
@@ -13,11 +13,7 @@ import {
   Watch,
 } from '@stencil/core';
 import { Alignment, getElementPosition, isEventOnElement } from '../../global/helpers/position';
-import {
-  IS_FOCUSABLE_QUERY,
-  FocusTrap,
-  focusAndSetCloseModality,
-} from '../../global/helpers/focus';
+import { IS_FOCUSABLE_QUERY, FocusTrap, focusAndSetModality } from '../../global/helpers/focus';
 import { i18nCloseTooltip } from '../../global/i18n';
 import { isValidAttribute } from '../../global/helpers/is-valid-attribute';
 import { assignId } from '../../global/helpers/assign-id';
@@ -402,10 +398,8 @@ export class SbbTooltip implements ComponentInterface {
         ? this._nextFocusedElement
         : this._triggerElement;
 
-      focusAndSetCloseModality(elementToFocus);
+      focusAndSetModality(elementToFocus);
       this._dialog.close();
-      // To enable focusing other element than the trigger, we need to call focus() a second time.
-      elementToFocus?.focus();
       this.didClose.emit({ closeTarget: this._tooltipCloseElement });
       this._windowEventsController?.abort();
       this._focusTrap.disconnect();

--- a/src/components/sbb-tooltip/sbb-tooltip.tsx
+++ b/src/components/sbb-tooltip/sbb-tooltip.tsx
@@ -13,7 +13,7 @@ import {
   Watch,
 } from '@stencil/core';
 import { Alignment, getElementPosition, isEventOnElement } from '../../global/helpers/position';
-import { IS_FOCUSABLE_QUERY, FocusTrap, seModalityOnNextFocus } from '../../global/helpers/focus';
+import { IS_FOCUSABLE_QUERY, FocusTrap } from '../../global/helpers/focus';
 import { i18nCloseTooltip } from '../../global/i18n';
 import { isValidAttribute } from '../../global/helpers/is-valid-attribute';
 import { assignId } from '../../global/helpers/assign-id';
@@ -26,6 +26,7 @@ import {
   HandlerRepository,
   languageChangeHandlerAspect,
   sbbInputModalityDetector,
+  setModalityOnNextFocus,
 } from '../../global/helpers';
 import { SbbOverlayState } from '../../global/helpers/overlay';
 
@@ -401,7 +402,7 @@ export class SbbTooltip implements ComponentInterface {
 
       const elementToFocus = this._nextFocusedElement || this._triggerElement;
 
-      seModalityOnNextFocus(elementToFocus);
+      setModalityOnNextFocus(elementToFocus);
       this._dialog.close();
       // To enable focusing other element than the trigger, we need to call focus() a second time.
       elementToFocus?.focus();

--- a/src/global/helpers/eventing/input-modality-detector.ts
+++ b/src/global/helpers/eventing/input-modality-detector.ts
@@ -165,3 +165,27 @@ class SbbInputModalityDetector {
 }
 
 export const sbbInputModalityDetector = new SbbInputModalityDetector();
+
+// Set the input modality in order to avoid showing the outline in Safari.
+export function setModalityOnNextFocus(elementToFocus: HTMLElement): void {
+  if (!elementToFocus) {
+    return;
+  }
+
+  const mostRecentModality = sbbInputModalityDetector.mostRecentModality;
+
+  // Set focus origin to element which should receive focus
+  if (!(elementToFocus && mostRecentModality !== null)) {
+    return;
+  }
+  elementToFocus.addEventListener(
+    'focus',
+    () => {
+      (elementToFocus.dataset.focusOrigin as SbbInputModality) = mostRecentModality;
+      elementToFocus.addEventListener('blur', () => delete elementToFocus.dataset.focusOrigin, {
+        once: true,
+      });
+    },
+    { once: true }
+  );
+}

--- a/src/global/helpers/focus.ts
+++ b/src/global/helpers/focus.ts
@@ -31,7 +31,8 @@ export function getFocusableElements(
   return [...focusableEls];
 }
 
-export function focusAndSetCloseModality(
+// Focus an element and set the input modality in order to avoid showing the outline in Safari.
+export function focusAndSetModality(
   elementToFocus: HTMLElement,
   focusOptions?: FocusOptions
 ): void {
@@ -39,16 +40,16 @@ export function focusAndSetCloseModality(
     return;
   }
 
-  const closedByModality = sbbInputModalityDetector.mostRecentModality;
+  const mostRecentModality = sbbInputModalityDetector.mostRecentModality;
 
   // Set focus origin to element which should receive focus
-  if (!(elementToFocus && closedByModality !== null)) {
+  if (!(elementToFocus && mostRecentModality !== null)) {
     return;
   }
   elementToFocus.addEventListener(
     'focus',
     () => {
-      (elementToFocus.dataset.focusOrigin as SbbInputModality) = closedByModality;
+      (elementToFocus.dataset.focusOrigin as SbbInputModality) = mostRecentModality;
       elementToFocus.addEventListener('blur', () => delete elementToFocus.dataset.focusOrigin, {
         once: true,
       });

--- a/src/global/helpers/focus.ts
+++ b/src/global/helpers/focus.ts
@@ -31,11 +31,8 @@ export function getFocusableElements(
   return [...focusableEls];
 }
 
-// Focus an element and set the input modality in order to avoid showing the outline in Safari.
-export function focusAndSetModality(
-  elementToFocus: HTMLElement,
-  focusOptions?: FocusOptions
-): void {
+// Set the input modality in order to avoid showing the outline in Safari.
+export function seModalityOnNextFocus(elementToFocus: HTMLElement): void {
   if (!elementToFocus) {
     return;
   }
@@ -56,7 +53,6 @@ export function focusAndSetModality(
     },
     { once: true }
   );
-  elementToFocus?.focus(focusOptions);
 }
 
 export class FocusTrap {

--- a/src/global/helpers/focus.ts
+++ b/src/global/helpers/focus.ts
@@ -1,3 +1,5 @@
+import { SbbInputModality, sbbInputModalityDetector } from './eventing';
+
 export const IS_FOCUSABLE_QUERY = `:is(button, [href], input, select, textarea, details, summary:not(:disabled), [tabindex], sbb-button, sbb-link, sbb-menu-action, sbb-navigation-action):not([disabled]:not([disabled='false'])):not([tabindex="-1"]):not([static])`;
 
 // Note: the use of this function for more complex scenarios (with many nested elements) may be expensive.
@@ -27,6 +29,33 @@ export function getFocusableElements(
   getFocusables(elements, filterFunc);
 
   return [...focusableEls];
+}
+
+export function focusAndSetCloseModality(
+  elementToFocus: HTMLElement,
+  focusOptions?: FocusOptions
+): void {
+  if (!elementToFocus) {
+    return;
+  }
+
+  const closedByModality = sbbInputModalityDetector.mostRecentModality;
+
+  // Set focus origin to element which should receive focus
+  if (!(elementToFocus && closedByModality !== null)) {
+    return;
+  }
+  elementToFocus.addEventListener(
+    'focus',
+    () => {
+      (elementToFocus.dataset.focusOrigin as SbbInputModality) = closedByModality;
+      elementToFocus.addEventListener('blur', () => delete elementToFocus.dataset.focusOrigin, {
+        once: true,
+      });
+    },
+    { once: true }
+  );
+  elementToFocus?.focus(focusOptions);
 }
 
 export class FocusTrap {

--- a/src/global/helpers/focus.ts
+++ b/src/global/helpers/focus.ts
@@ -1,5 +1,3 @@
-import { SbbInputModality, sbbInputModalityDetector } from './eventing';
-
 export const IS_FOCUSABLE_QUERY = `:is(button, [href], input, select, textarea, details, summary:not(:disabled), [tabindex], sbb-button, sbb-link, sbb-menu-action, sbb-navigation-action):not([disabled]:not([disabled='false'])):not([tabindex="-1"]):not([static])`;
 
 // Note: the use of this function for more complex scenarios (with many nested elements) may be expensive.
@@ -29,30 +27,6 @@ export function getFocusableElements(
   getFocusables(elements, filterFunc);
 
   return [...focusableEls];
-}
-
-// Set the input modality in order to avoid showing the outline in Safari.
-export function seModalityOnNextFocus(elementToFocus: HTMLElement): void {
-  if (!elementToFocus) {
-    return;
-  }
-
-  const mostRecentModality = sbbInputModalityDetector.mostRecentModality;
-
-  // Set focus origin to element which should receive focus
-  if (!(elementToFocus && mostRecentModality !== null)) {
-    return;
-  }
-  elementToFocus.addEventListener(
-    'focus',
-    () => {
-      (elementToFocus.dataset.focusOrigin as SbbInputModality) = mostRecentModality;
-      elementToFocus.addEventListener('blur', () => delete elementToFocus.dataset.focusOrigin, {
-        once: true,
-      });
-    },
-    { once: true }
-  );
 }
 
 export class FocusTrap {


### PR DESCRIPTION
Closes #1776.
