### PR TITLE
fix(sbb-train): improve accessibility by replacing `span` with heading tag

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1760,7 +1760,7 @@ export namespace Components {
          */
         "directionLabel": string;
         /**
-          * Heading level of the direction label, used for screenreaders.
+          * Heading level of the direction label, used for screen readers.
          */
         "directionLabelLevel": InterfaceTitleAttributes['level'];
         /**
@@ -4259,7 +4259,7 @@ declare namespace LocalJSX {
          */
         "directionLabel": string;
         /**
-          * Heading level of the direction label, used for screenreaders.
+          * Heading level of the direction label, used for screen readers.
          */
         "directionLabelLevel"?: InterfaceTitleAttributes['level'];
         "onTrainSlotChange"?: (event: SbbTrainCustomEvent<any>) => void;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1760,6 +1760,10 @@ export namespace Components {
          */
         "directionLabel": string;
         /**
+          * Heading level of the direction label, used for screenreaders.
+         */
+        "directionLabelLevel": InterfaceTitleAttributes['level'];
+        /**
           * Label for the destination station of the train.
          */
         "station"?: string;
@@ -4254,6 +4258,10 @@ declare namespace LocalJSX {
           * General label for "driving direction".
          */
         "directionLabel": string;
+        /**
+          * Heading level of the direction label, used for screenreaders.
+         */
+        "directionLabelLevel"?: InterfaceTitleAttributes['level'];
         "onTrainSlotChange"?: (event: SbbTrainCustomEvent<any>) => void;
         /**
           * Label for the destination station of the train.

--- a/src/components/sbb-title/readme.md
+++ b/src/components/sbb-title/readme.md
@@ -29,7 +29,6 @@ via simple CSS rules.
  - [sbb-link-list](../sbb-link-list)
  - [sbb-skiplink-list](../sbb-skiplink-list)
  - [sbb-teaser](../sbb-teaser)
- - [sbb-train](../sbb-train)
 
 ### Graph
 ```mermaid
@@ -40,7 +39,6 @@ graph TD;
   sbb-link-list --> sbb-title
   sbb-skiplink-list --> sbb-title
   sbb-teaser --> sbb-title
-  sbb-train --> sbb-title
   style sbb-title fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/sbb-title/readme.md
+++ b/src/components/sbb-title/readme.md
@@ -29,6 +29,7 @@ via simple CSS rules.
  - [sbb-link-list](../sbb-link-list)
  - [sbb-skiplink-list](../sbb-skiplink-list)
  - [sbb-teaser](../sbb-teaser)
+ - [sbb-train](../sbb-train)
 
 ### Graph
 ```mermaid
@@ -39,6 +40,7 @@ graph TD;
   sbb-link-list --> sbb-title
   sbb-skiplink-list --> sbb-title
   sbb-teaser --> sbb-title
+  sbb-train --> sbb-title
   style sbb-title fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/sbb-train/readme.md
+++ b/src/components/sbb-train/readme.md
@@ -28,7 +28,7 @@ It should refer to the section where the locomotive is placed.
 | `accessibilityLabel`          | `accessibility-label`   | Accessibility label for additional information regarding the leaving direction of the train. | `string`                                 | `undefined` |
 | `direction`                   | `direction`             | Controls the direction indicator to show the arrow left or right. Default is left.           | `"left" \| "right"`                      | `'left'`    |
 | `directionLabel` _(required)_ | `direction-label`       | General label for "driving direction".                                                       | `string`                                 | `undefined` |
-| `directionLabelLevel`         | `direction-label-level` | Heading level of the direction label, used for screen readers.                               | `"1" \| "2" \| "3" \| "4" \| "5" \| "6"` | `'3'`       |
+| `directionLabelLevel`         | `direction-label-level` | Heading level of the direction label, used for screen readers.                               | `"1" \| "2" \| "3" \| "4" \| "5" \| "6"` | `'6'`       |
 | `station`                     | `station`               | Label for the destination station of the train.                                              | `string`                                 | `undefined` |
 
 

--- a/src/components/sbb-train/readme.md
+++ b/src/components/sbb-train/readme.md
@@ -23,12 +23,13 @@ It should refer to the section where the locomotive is placed.
 
 ## Properties
 
-| Property                      | Attribute             | Description                                                                                  | Type                | Default     |
-| ----------------------------- | --------------------- | -------------------------------------------------------------------------------------------- | ------------------- | ----------- |
-| `accessibilityLabel`          | `accessibility-label` | Accessibility label for additional information regarding the leaving direction of the train. | `string`            | `undefined` |
-| `direction`                   | `direction`           | Controls the direction indicator to show the arrow left or right. Default is left.           | `"left" \| "right"` | `'left'`    |
-| `directionLabel` _(required)_ | `direction-label`     | General label for "driving direction".                                                       | `string`            | `undefined` |
-| `station`                     | `station`             | Label for the destination station of the train.                                              | `string`            | `undefined` |
+| Property                      | Attribute               | Description                                                                                  | Type                                     | Default     |
+| ----------------------------- | ----------------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------- | ----------- |
+| `accessibilityLabel`          | `accessibility-label`   | Accessibility label for additional information regarding the leaving direction of the train. | `string`                                 | `undefined` |
+| `direction`                   | `direction`             | Controls the direction indicator to show the arrow left or right. Default is left.           | `"left" \| "right"`                      | `'left'`    |
+| `directionLabel` _(required)_ | `direction-label`       | General label for "driving direction".                                                       | `string`                                 | `undefined` |
+| `directionLabelLevel`         | `direction-label-level` | Heading level of the direction label, used for screenreaders.                                | `"1" \| "2" \| "3" \| "4" \| "5" \| "6"` | `'3'`       |
+| `station`                     | `station`               | Label for the destination station of the train.                                              | `string`                                 | `undefined` |
 
 
 ## Slots
@@ -42,11 +43,13 @@ It should refer to the section where the locomotive is placed.
 
 ### Depends on
 
+- [sbb-title](../sbb-title)
 - [sbb-icon](../sbb-icon)
 
 ### Graph
 ```mermaid
 graph TD;
+  sbb-train --> sbb-title
   sbb-train --> sbb-icon
   style sbb-train fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/src/components/sbb-train/readme.md
+++ b/src/components/sbb-train/readme.md
@@ -28,7 +28,7 @@ It should refer to the section where the locomotive is placed.
 | `accessibilityLabel`          | `accessibility-label`   | Accessibility label for additional information regarding the leaving direction of the train. | `string`                                 | `undefined` |
 | `direction`                   | `direction`             | Controls the direction indicator to show the arrow left or right. Default is left.           | `"left" \| "right"`                      | `'left'`    |
 | `directionLabel` _(required)_ | `direction-label`       | General label for "driving direction".                                                       | `string`                                 | `undefined` |
-| `directionLabelLevel`         | `direction-label-level` | Heading level of the direction label, used for screenreaders.                                | `"1" \| "2" \| "3" \| "4" \| "5" \| "6"` | `'3'`       |
+| `directionLabelLevel`         | `direction-label-level` | Heading level of the direction label, used for screen readers.                               | `"1" \| "2" \| "3" \| "4" \| "5" \| "6"` | `'3'`       |
 | `station`                     | `station`               | Label for the destination station of the train.                                              | `string`                                 | `undefined` |
 
 

--- a/src/components/sbb-train/readme.md
+++ b/src/components/sbb-train/readme.md
@@ -43,13 +43,11 @@ It should refer to the section where the locomotive is placed.
 
 ### Depends on
 
-- [sbb-title](../sbb-title)
 - [sbb-icon](../sbb-icon)
 
 ### Graph
 ```mermaid
 graph TD;
-  sbb-train --> sbb-title
   sbb-train --> sbb-icon
   style sbb-train fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/src/components/sbb-train/sbb-train.scss
+++ b/src/components/sbb-train/sbb-train.scss
@@ -127,7 +127,3 @@
   overflow: hidden;
   padding: 0 var(--sbb-train-direction-station-padding);
 }
-
-.sbb-screenreaderonly {
-  @include sbb.screen-reader-only;
-}

--- a/src/components/sbb-train/sbb-train.scss
+++ b/src/components/sbb-train/sbb-train.scss
@@ -127,3 +127,7 @@
   overflow: hidden;
   padding: 0 var(--sbb-train-direction-station-padding);
 }
+
+.sbb-train__direction-label-sr {
+  @include sbb.screen-reader-only;
+}

--- a/src/components/sbb-train/sbb-train.spec.ts
+++ b/src/components/sbb-train/sbb-train.spec.ts
@@ -12,7 +12,7 @@ describe('sbb-train', () => {
       <sbb-train direction-label="Driving direction" station="Bern" direction="left">
         <mock:shadow-root>
           <div class="sbb-train">
-            <sbb-title visually-hidden level="6">Train, Driving direction Bern.</sbb-title>
+            <h6 class="sbb-train__direction-label-sr">Train, Driving direction Bern.</h6>
             <ul class="sbb-train__wagons" aria-label="Coaches of the train"></ul>
             <span hidden>
               <slot />
@@ -80,7 +80,9 @@ describe('sbb-train', () => {
         html: '<sbb-train />',
       });
 
-      expect(root.shadowRoot.querySelector('sbb-title').textContent).toEqual('Train.');
+      expect(root.shadowRoot.querySelector('.sbb-train__direction-label-sr').textContent).toEqual(
+        'Train.'
+      );
     });
 
     it('should create aria label with direction-label and no accessibility-label', async () => {
@@ -89,7 +91,9 @@ describe('sbb-train', () => {
         html: '<sbb-train direction-label="Direction of Travel"/>',
       });
 
-      expect(root.shadowRoot.querySelector('sbb-title').textContent).toEqual('Train.');
+      expect(root.shadowRoot.querySelector('.sbb-train__direction-label-sr').textContent).toEqual(
+        'Train.'
+      );
     });
 
     it('should create aria label with direction-label, station and no accessibility-label', async () => {
@@ -98,7 +102,7 @@ describe('sbb-train', () => {
         html: '<sbb-train direction-label="Direction of Travel" station="Bern"/>',
       });
 
-      expect(root.shadowRoot.querySelector('sbb-title').textContent).toEqual(
+      expect(root.shadowRoot.querySelector('.sbb-train__direction-label-sr').textContent).toEqual(
         'Train, Direction of Travel Bern.'
       );
     });
@@ -109,7 +113,7 @@ describe('sbb-train', () => {
         html: '<sbb-train direction-label="Direction of Travel" station="Bern" accessibility-label="Additional label"/>',
       });
 
-      expect(root.shadowRoot.querySelector('sbb-title').textContent).toEqual(
+      expect(root.shadowRoot.querySelector('.sbb-train__direction-label-sr').textContent).toEqual(
         'Train, Direction of Travel Bern, Additional label.'
       );
     });

--- a/src/components/sbb-train/sbb-train.spec.ts
+++ b/src/components/sbb-train/sbb-train.spec.ts
@@ -12,7 +12,7 @@ describe('sbb-train', () => {
       <sbb-train direction-label="Driving direction" station="Bern" direction="left">
         <mock:shadow-root>
           <div class="sbb-train">
-            <span class="sbb-screenreaderonly">Train, Driving direction Bern.</span>
+            <sbb-title visually-hidden level="3">Train, Driving direction Bern.</sbb-title>
             <ul class="sbb-train__wagons" aria-label="Coaches of the train"></ul>
             <span hidden>
               <slot />
@@ -80,7 +80,7 @@ describe('sbb-train', () => {
         html: '<sbb-train />',
       });
 
-      expect(root.shadowRoot.querySelector('.sbb-screenreaderonly').textContent).toEqual('Train.');
+      expect(root.shadowRoot.querySelector('sbb-title').textContent).toEqual('Train.');
     });
 
     it('should create aria label with direction-label and no accessibility-label', async () => {
@@ -89,7 +89,7 @@ describe('sbb-train', () => {
         html: '<sbb-train direction-label="Direction of Travel"/>',
       });
 
-      expect(root.shadowRoot.querySelector('.sbb-screenreaderonly').textContent).toEqual('Train.');
+      expect(root.shadowRoot.querySelector('sbb-title').textContent).toEqual('Train.');
     });
 
     it('should create aria label with direction-label, station and no accessibility-label', async () => {
@@ -98,7 +98,7 @@ describe('sbb-train', () => {
         html: '<sbb-train direction-label="Direction of Travel" station="Bern"/>',
       });
 
-      expect(root.shadowRoot.querySelector('.sbb-screenreaderonly').textContent).toEqual(
+      expect(root.shadowRoot.querySelector('sbb-title').textContent).toEqual(
         'Train, Direction of Travel Bern.'
       );
     });
@@ -109,7 +109,7 @@ describe('sbb-train', () => {
         html: '<sbb-train direction-label="Direction of Travel" station="Bern" accessibility-label="Additional label"/>',
       });
 
-      expect(root.shadowRoot.querySelector('.sbb-screenreaderonly').textContent).toEqual(
+      expect(root.shadowRoot.querySelector('sbb-title').textContent).toEqual(
         'Train, Direction of Travel Bern, Additional label.'
       );
     });

--- a/src/components/sbb-train/sbb-train.spec.ts
+++ b/src/components/sbb-train/sbb-train.spec.ts
@@ -12,7 +12,7 @@ describe('sbb-train', () => {
       <sbb-train direction-label="Driving direction" station="Bern" direction="left">
         <mock:shadow-root>
           <div class="sbb-train">
-            <sbb-title visually-hidden level="3">Train, Driving direction Bern.</sbb-title>
+            <sbb-title visually-hidden level="6">Train, Driving direction Bern.</sbb-title>
             <ul class="sbb-train__wagons" aria-label="Coaches of the train"></ul>
             <span hidden>
               <slot />

--- a/src/components/sbb-train/sbb-train.stories.tsx
+++ b/src/components/sbb-train/sbb-train.stories.tsx
@@ -15,7 +15,6 @@ const directionLabel: InputType = {
   },
 };
 
-
 const directionLabelLevel: InputType = {
   control: {
     type: 'inline-radio',

--- a/src/components/sbb-train/sbb-train.stories.tsx
+++ b/src/components/sbb-train/sbb-train.stories.tsx
@@ -15,6 +15,17 @@ const directionLabel: InputType = {
   },
 };
 
+
+const directionLabelLevel: InputType = {
+  control: {
+    type: 'inline-radio',
+  },
+  options: [2, 3, 4, 5, 6],
+  table: {
+    category: 'Direction indicator',
+  },
+};
+
 const station: InputType = {
   control: {
     type: 'text',
@@ -48,6 +59,7 @@ const defaultArgTypes: ArgTypes = {
   'accessibility-label': accessibilityLabel,
   station,
   direction,
+  directionLabelLevel,
 };
 
 const defaultArgs: Args = {
@@ -56,6 +68,7 @@ const defaultArgs: Args = {
     'The top of the train is in Sector A. The train leaves the station in this direction',
   station: 'Bern',
   direction: direction.options[0],
+  'direction-label-level': directionLabelLevel.options[1],
 };
 
 export const train: StoryObj = {

--- a/src/components/sbb-train/sbb-train.stories.tsx
+++ b/src/components/sbb-train/sbb-train.stories.tsx
@@ -68,7 +68,7 @@ const defaultArgs: Args = {
     'The top of the train is in Sector A. The train leaves the station in this direction',
   station: 'Bern',
   direction: direction.options[0],
-  'direction-label-level': directionLabelLevel.options[1],
+  'direction-label-level': directionLabelLevel.options[4],
 };
 
 export const train: StoryObj = {

--- a/src/components/sbb-train/sbb-train.tsx
+++ b/src/components/sbb-train/sbb-train.tsx
@@ -32,7 +32,7 @@ export class SbbTrain implements ComponentInterface {
   @Prop() public directionLabel!: string;
 
   /** Heading level of the direction label, used for screen readers. */
-  @Prop() public directionLabelLevel: InterfaceTitleAttributes['level'] = '3';
+  @Prop() public directionLabelLevel: InterfaceTitleAttributes['level'] = '6';
 
   /** Label for the destination station of the train. */
   @Prop() public station?: string;

--- a/src/components/sbb-train/sbb-train.tsx
+++ b/src/components/sbb-train/sbb-train.tsx
@@ -16,6 +16,7 @@ import {
   HandlerRepository,
   languageChangeHandlerAspect,
 } from '../../global/helpers';
+import { InterfaceTitleAttributes } from '../sbb-title/sbb-title.custom';
 
 /**
  * @slot unnamed - Used for slotting sbb-train-wagons.
@@ -29,6 +30,9 @@ import {
 export class SbbTrain implements ComponentInterface {
   /** General label for "driving direction". */
   @Prop() public directionLabel!: string;
+
+  /** Heading level of the direction label, used for screenreaders. */
+  @Prop() public directionLabelLevel: InterfaceTitleAttributes['level'] = '3';
 
   /** Label for the destination station of the train. */
   @Prop() public station?: string;
@@ -110,7 +114,9 @@ export class SbbTrain implements ComponentInterface {
 
     return (
       <div class="sbb-train">
-        <span class="sbb-screenreaderonly">{this._getDirectionAriaLabel()}</span>
+        <sbb-title visually-hidden level={this.directionLabelLevel}>
+          {this._getDirectionAriaLabel()}
+        </sbb-title>
         <ul class="sbb-train__wagons" aria-label={i18nWagonsLabel[this._currentLanguage]}>
           {this._wagons.map((_, index) => (
             <li>

--- a/src/components/sbb-train/sbb-train.tsx
+++ b/src/components/sbb-train/sbb-train.tsx
@@ -110,13 +110,14 @@ export class SbbTrain implements ComponentInterface {
   }
 
   public render(): JSX.Element {
+    const TITLE_TAG_NAME = `h${this.directionLabelLevel}`;
     this._wagons.forEach((wagon, index) => wagon.setAttribute('slot', `wagon-${index}`));
 
     return (
       <div class="sbb-train">
-        <sbb-title visually-hidden level={this.directionLabelLevel}>
+        <TITLE_TAG_NAME class="sbb-train__direction-label-sr">
           {this._getDirectionAriaLabel()}
-        </sbb-title>
+        </TITLE_TAG_NAME>
         <ul class="sbb-train__wagons" aria-label={i18nWagonsLabel[this._currentLanguage]}>
           {this._wagons.map((_, index) => (
             <li>

--- a/src/components/sbb-train/sbb-train.tsx
+++ b/src/components/sbb-train/sbb-train.tsx
@@ -31,7 +31,7 @@ export class SbbTrain implements ComponentInterface {
   /** General label for "driving direction". */
   @Prop() public directionLabel!: string;
 
-  /** Heading level of the direction label, used for screenreaders. */
+  /** Heading level of the direction label, used for screen readers. */
   @Prop() public directionLabelLevel: InterfaceTitleAttributes['level'] = '3';
 
   /** Label for the destination station of the train. */


### PR DESCRIPTION
Closes #1771 