### PR TITLE
fix: enable pressing enter on action elements in Firefox

### DIFF
--- a/src/global/helpers/eventing/action-element-handlers.ts
+++ b/src/global/helpers/eventing/action-element-handlers.ts
@@ -26,9 +26,8 @@ async function triggerAnchorWhenNecessary(event: MouseEvent): Promise<void> {
   // page.
   const { altKey, ctrlKey, metaKey, shiftKey } = event;
   target.shadowRoot.querySelector('a')?.dispatchEvent(
-    new PointerEvent('click', {
-      pointerId: -1,
-      pointerType: '',
+    // We need to use a MouseEvent here, as PointerEvent does not work on Firefox.
+    new MouseEvent('click', {
       altKey,
       ctrlKey,
       metaKey,


### PR DESCRIPTION
Previously it was not possible in Firefox for an action element with an internal anchor element (e.g. `<sbb-button href="...">` to be able to "click" it with an Enter press. This PR fixes this by switching from a `PointerEvent` to a `MouseEvent`.