### PR TITLE
refactor: adapt chromatic check imports

### DIFF
--- a/src/components/sbb-autocomplete/sbb-autocomplete.stories.tsx
+++ b/src/components/sbb-autocomplete/sbb-autocomplete.stories.tsx
@@ -4,7 +4,7 @@ import events from './sbb-autocomplete.events';
 import readme from './readme.md';
 import { userEvent, within } from '@storybook/testing-library';
 import { waitForComponentsReady } from '../../global/helpers/testing/wait-for-components-ready';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import { waitForStablePosition } from '../../global/helpers/testing/wait-for-stable-position';
 import type { Meta, StoryObj, ArgTypes, Args } from '@storybook/html';
 import type { InputType } from '@storybook/types';

--- a/src/components/sbb-calendar/sbb-calendar.stories.tsx
+++ b/src/components/sbb-calendar/sbb-calendar.stories.tsx
@@ -2,7 +2,7 @@
 import events from './sbb-calendar.events';
 import { h, JSX } from 'jsx-dom';
 import readme from './readme.md';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/html';
 import type { InputType } from '@storybook/types';

--- a/src/components/sbb-clock/sbb-clock.stories.tsx
+++ b/src/components/sbb-clock/sbb-clock.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx h */
 import { h, JSX } from 'jsx-dom';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import readme from './readme.md';
 import type { Meta, StoryObj } from '@storybook/html';
 import type { InputType } from '@storybook/types';

--- a/src/components/sbb-datepicker-toggle/sbb-datepicker-toggle.stories.tsx
+++ b/src/components/sbb-datepicker-toggle/sbb-datepicker-toggle.stories.tsx
@@ -4,7 +4,7 @@ import readme from './readme.md';
 import { userEvent, within } from '@storybook/testing-library';
 import { waitForComponentsReady } from '../../global/helpers/testing/wait-for-components-ready';
 import { waitForStablePosition } from '../../global/helpers/testing/wait-for-stable-position';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/html';
 import type { InputType } from '@storybook/types';

--- a/src/components/sbb-datepicker/sbb-datepicker.stories.tsx
+++ b/src/components/sbb-datepicker/sbb-datepicker.stories.tsx
@@ -5,7 +5,7 @@ import { userEvent, within } from '@storybook/testing-library';
 import { waitForComponentsReady } from '../../global/helpers/testing/wait-for-components-ready';
 import { waitForStablePosition } from '../../global/helpers/testing/wait-for-stable-position';
 import { withActions } from '@storybook/addon-actions/decorator';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/html';
 import type { InputType } from '@storybook/types';
 

--- a/src/components/sbb-dialog/sbb-dialog.stories.tsx
+++ b/src/components/sbb-dialog/sbb-dialog.stories.tsx
@@ -3,7 +3,7 @@ import events from './sbb-dialog.events';
 import { Fragment, h, JSX } from 'jsx-dom';
 import readme from './readme.md';
 import sampleImages from '../../global/images';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import { userEvent, within } from '@storybook/testing-library';
 import { waitForComponentsReady } from '../../global/helpers/testing/wait-for-components-ready';
 import { waitForStablePosition } from '../../global/helpers/testing/wait-for-stable-position';

--- a/src/components/sbb-footer/sbb-footer.stories.tsx
+++ b/src/components/sbb-footer/sbb-footer.stories.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import readme from './readme.md';
 import { h, JSX } from 'jsx-dom';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import type { Meta, StoryObj, ArgTypes, Args } from '@storybook/html';
 import type { InputType } from '@storybook/types';
 

--- a/src/components/sbb-header/sbb-header.stories.tsx
+++ b/src/components/sbb-header/sbb-header.stories.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h, JSX } from 'jsx-dom';
 import readme from './readme.md';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import { userEvent, within } from '@storybook/testing-library';
 import { waitForComponentsReady } from '../../global/helpers/testing/wait-for-components-ready';
 import { waitForStablePosition } from '../../global/helpers/testing/wait-for-stable-position';

--- a/src/components/sbb-image/sbb-image.stories.tsx
+++ b/src/components/sbb-image/sbb-image.stories.tsx
@@ -2,7 +2,7 @@
 import { h, JSX } from 'jsx-dom';
 import images from '../../global/images';
 import readme from './readme.md';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import type { Meta, StoryObj, ArgTypes, Args } from '@storybook/html';
 import type { InputType } from '@storybook/types';
 

--- a/src/components/sbb-journey-summary/sbb-journey-summary.stories.tsx
+++ b/src/components/sbb-journey-summary/sbb-journey-summary.stories.tsx
@@ -7,7 +7,7 @@ import {
   progressLeg,
 } from '../sbb-pearl-chain/sbb-pearl-chain.sample-data';
 import readme from './readme.md';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import type { Meta, StoryObj, ArgTypes, Args } from '@storybook/html';
 import type { InputType } from '@storybook/types';
 

--- a/src/components/sbb-menu/sbb-menu.stories.tsx
+++ b/src/components/sbb-menu/sbb-menu.stories.tsx
@@ -2,7 +2,7 @@
 import events from './sbb-menu.events';
 import { Fragment, h, JSX } from 'jsx-dom';
 import readme from './readme.md';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import { userEvent, within } from '@storybook/testing-library';
 import { waitForComponentsReady } from '../../global/helpers/testing/wait-for-components-ready';
 import { waitForStablePosition } from '../../global/helpers/testing/wait-for-stable-position';

--- a/src/components/sbb-navigation-section/sbb-navigation-section.stories.tsx
+++ b/src/components/sbb-navigation-section/sbb-navigation-section.stories.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { Fragment, h, JSX } from 'jsx-dom';
 import readme from './readme.md';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import { userEvent, waitFor, within } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
 import { waitForComponentsReady } from '../../global/helpers/testing/wait-for-components-ready';

--- a/src/components/sbb-navigation/sbb-navigation.stories.tsx
+++ b/src/components/sbb-navigation/sbb-navigation.stories.tsx
@@ -2,7 +2,7 @@
 import { Fragment, h, JSX } from 'jsx-dom';
 import events from './sbb-navigation.events';
 import readme from './readme.md';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import { userEvent, waitFor, within } from '@storybook/testing-library';
 import { expect } from '@storybook/jest';
 import { waitForComponentsReady } from '../../global/helpers/testing/wait-for-components-ready';

--- a/src/components/sbb-pearl-chain-time/sbb-pearl-chain-time.stories.tsx
+++ b/src/components/sbb-pearl-chain-time/sbb-pearl-chain-time.stories.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h, JSX } from 'jsx-dom';
 import readme from './readme.md';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import { extendedLeg, progressLeg } from '../sbb-pearl-chain/sbb-pearl-chain.sample-data';
 import type { Meta, StoryObj, ArgTypes, Args } from '@storybook/html';
 import type { InputType } from '@storybook/types';

--- a/src/components/sbb-pearl-chain-vertical/sbb-pearl-chain-vertical.stories.tsx
+++ b/src/components/sbb-pearl-chain-vertical/sbb-pearl-chain-vertical.stories.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h, JSX } from 'jsx-dom';
 import readme from './readme.md';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import type { Meta, StoryObj, ArgTypes, Args } from '@storybook/html';
 import type { InputType } from '@storybook/types';
 

--- a/src/components/sbb-pearl-chain/sbb-pearl-chain.stories.tsx
+++ b/src/components/sbb-pearl-chain/sbb-pearl-chain.stories.tsx
@@ -10,7 +10,7 @@ import {
   redirectedOnDepartureLeg,
   redirectedOnArrivalLeg,
 } from './sbb-pearl-chain.sample-data';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import type { Meta, StoryObj, ArgTypes, Args } from '@storybook/html';
 import type { InputType } from '@storybook/types';
 

--- a/src/components/sbb-selection-panel/sbb-selection-panel.stories.tsx
+++ b/src/components/sbb-selection-panel/sbb-selection-panel.stories.tsx
@@ -2,7 +2,7 @@
 import events from './sbb-selection-panel.events';
 import { Fragment, h, JSX } from 'jsx-dom';
 import readme from './readme.md';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/html';
 import type { InputType } from '@storybook/types';

--- a/src/components/sbb-skiplink-list/sbb-skiplink-list.stories.tsx
+++ b/src/components/sbb-skiplink-list/sbb-skiplink-list.stories.tsx
@@ -4,7 +4,7 @@ import readme from './readme.md';
 import { userEvent, within } from '@storybook/testing-library';
 import { waitForComponentsReady } from '../../global/helpers/testing/wait-for-components-ready';
 import { waitForStablePosition } from '../../global/helpers/testing/wait-for-stable-position';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import type { Meta, StoryObj, ArgTypes, Args } from '@storybook/html';
 import type { InputType } from '@storybook/types';
 

--- a/src/components/sbb-timetable-row/sbb-timetable-row.stories.tsx
+++ b/src/components/sbb-timetable-row/sbb-timetable-row.stories.tsx
@@ -20,7 +20,7 @@ import {
   skippedFirstDepartureStopTrip,
   skippedLastArrivalStopTrip,
 } from './sbb-timetable-row.sample-data';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/html';
 import type { InputType } from '@storybook/types';

--- a/src/components/sbb-toggle/sbb-toggle.stories.tsx
+++ b/src/components/sbb-toggle/sbb-toggle.stories.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h, JSX } from 'jsx-dom';
 import readme from './readme.md';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/html';
 import type { InputType } from '@storybook/types';

--- a/src/components/sbb-tooltip/sbb-tooltip.stories.tsx
+++ b/src/components/sbb-tooltip/sbb-tooltip.stories.tsx
@@ -2,7 +2,7 @@
 import events from './sbb-tooltip.events';
 import { Fragment, h, JSX } from 'jsx-dom';
 import readme from './readme.md';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import { userEvent, within } from '@storybook/testing-library';
 import { waitForComponentsReady } from '../../global/helpers/testing/wait-for-components-ready';
 import { waitForStablePosition } from '../../global/helpers/testing/wait-for-stable-position';

--- a/src/storybook/pages/home/home--logged-in.stories.tsx
+++ b/src/storybook/pages/home/home--logged-in.stories.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h, JSX } from 'jsx-dom';
 import readme from './readme.md';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import {
   futureLeg,
   pastLeg,

--- a/src/storybook/pages/home/home.common.tsx
+++ b/src/storybook/pages/home/home.common.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 /** @jsx h */
 import { StoryContext } from '@storybook/html';
-import isChromatic from 'chromatic/isChromatic';
+import isChromatic from 'chromatic';
 import { JSX, h } from 'jsx-dom';
 
 export const SkiplinkList = (): JSX.Element => (


### PR DESCRIPTION
With the new patch release of the `chromatic` package, the imports from `chromatic/isChromatic` no longer work and need to be changed to `chromatic`, due to the `exports` configuration in the `chromatic` package.