### PR TITLE
fix(sbb-form-field): use space to combine aria-describedby ids

### DIFF
--- a/src/components/sbb-form-field/sbb-form-field.tsx
+++ b/src/components/sbb-form-field/sbb-form-field.tsx
@@ -289,7 +289,7 @@ export class SbbFormField implements ComponentInterface {
 
   private _applyAriaDescribedby(): void {
     const value = this._errorElements.length
-      ? this._errorElements.map((e) => e.id).join(',')
+      ? this._errorElements.map((e) => e.id).join(' ')
       : this._originalInputAriaDescribedby;
     if (value) {
       this._input?.setAttribute('aria-describedby', value);


### PR DESCRIPTION
The `aria-describedby` attribute supports multiple values, but these must be combined with space and not comma.