### PR TITLE
feat(sbb-form-field): reference label for custom form components

### DIFF
--- a/src/components/sbb-datepicker/sbb-datepicker.e2e.ts
+++ b/src/components/sbb-datepicker/sbb-datepicker.e2e.ts
@@ -129,7 +129,7 @@ describe('sbb-datepicker', () => {
 
   describe('with form-field', () => {
     const template = `
-      <sbb-form-field>
+      <sbb-form-field label="Example">
         <sbb-datepicker></sbb-datepicker>
         <input/>
       </sbb-form-field>

--- a/src/components/sbb-datepicker/sbb-datepicker.e2e.ts
+++ b/src/components/sbb-datepicker/sbb-datepicker.e2e.ts
@@ -129,7 +129,7 @@ describe('sbb-datepicker', () => {
 
   describe('with form-field', () => {
     const template = `
-      <sbb-form-field label="Example">
+      <sbb-form-field>
         <sbb-datepicker></sbb-datepicker>
         <input/>
       </sbb-form-field>
@@ -141,7 +141,7 @@ describe('sbb-datepicker', () => {
       await page.setContent(template);
       expect(await page.find('sbb-datepicker')).toHaveClass('hydrated');
       expect(await page.find('input')).toEqualHtml(
-        '<input aria-atomic="true" aria-live="polite" id="sbb-form-field-input-0" placeholder="DD.MM.YYYY" type="text">'
+        '<input aria-atomic="true" aria-live="polite" placeholder="DD.MM.YYYY" type="text">'
       );
     });
 

--- a/src/components/sbb-form-field/readme.md
+++ b/src/components/sbb-form-field/readme.md
@@ -73,9 +73,9 @@ contained within the form field.
 When you provide a label via `<label>` or the `label` attribute, `<sbb-form-field>` automatically
 associates this label with the field's form element via a native `<label>` element, using the `for`
 attribute to reference the control's ID.
-When using a non-native form element (e.g. `<sbb-select>`) `aria-label` is used, to connect the
+When using a non-native form element (e.g. `<sbb-select>`) `aria-labelledby` is used, to connect the
 form element with the label, by setting an id on the label and referencing this id in the
-`aria-label` attribute placed on the form element.
+`aria-labelledby` attribute placed on the form element.
 Please note that only one `<label>` element is supported. Additionally, if you place the `<label>`
 element outside the `<sbb-form-field>`, the automatic assignement is skipped and it is up to the
 consumer to use the correct id references.

--- a/src/components/sbb-form-field/readme.md
+++ b/src/components/sbb-form-field/readme.md
@@ -71,8 +71,14 @@ element. However, several of the form field's optional features interact with th
 contained within the form field.
 
 When you provide a label via `<label>` or the `label` attribute, `<sbb-form-field>` automatically
-associates this label with the field's form element via a native <label> element, using the `for`
+associates this label with the field's form element via a native `<label>` element, using the `for`
 attribute to reference the control's ID.
+When using a non-native form element (e.g. `<sbb-select>`) `aria-label` is used, to connect the
+form element with the label, by setting an id on the label and referencing this id in the
+`aria-label` attribute placed on the form element.
+Please note that only one `<label>` element is supported. Additionally, if you place the `<label>`
+element outside the `<sbb-form-field>`, the automatic assignement is skipped and it is up to the
+consumer to use the correct id references.
 
 When you provide informational text via `<sbb-form-error>`, `<sbb-form-error>` automatically adds
 these elements' IDs to the form element's aria-describedby attribute. Additionally, 

--- a/src/components/sbb-form-field/sbb-form-field.e2e.ts
+++ b/src/components/sbb-form-field/sbb-form-field.e2e.ts
@@ -2,56 +2,99 @@
 import { E2EElement, E2EPage, newE2EPage } from '@stencil/core/testing';
 
 describe('sbb-form-field', () => {
-  let element: E2EElement, page: E2EPage;
+  describe('with input', () => {
+    let element: E2EElement, page: E2EPage;
 
-  beforeEach(async () => {
-    page = await newE2EPage();
-    await page.setContent('<sbb-form-field><input/></sbb-form-field>');
+    beforeEach(async () => {
+      page = await newE2EPage();
+      await page.setContent('<sbb-form-field><input/></sbb-form-field>');
 
-    element = await page.find('sbb-form-field');
-  });
-
-  it('renders', async () => {
-    expect(element).toHaveClass('hydrated');
-  });
-
-  it('should remove the label element if no label is configured', async () => {
-    expect(await page.findAll('sbb-form-field label')).toEqual([]);
-    expect(element.shadowRoot.querySelector('label')).toBeNull();
-
-    element.setAttribute('label', 'Label');
-    await page.waitForChanges();
-    expect(await element.find('label')).not.toBeNull();
-
-    element.removeAttribute('label');
-    await page.waitForChanges();
-    expect(await element.find('label')).toBeNull();
-  });
-
-  it('should update empty input state', async () => {
-    const input = await page.find('input');
-    await page.waitForChanges();
-    expect(element.getAttribute('data-input-empty')).not.toBeNull();
-
-    await input.type('v');
-    await page.waitForChanges();
-    expect(element.getAttribute('data-input-empty')).toBeNull();
-
-    await input.press('Backspace');
-    await page.waitForChanges();
-    expect(element.getAttribute('data-input-empty')).not.toBeNull();
-
-    await input.type('v');
-    await page.waitForChanges();
-    expect(element.getAttribute('data-input-empty')).toBeNull();
-
-    // Clearing value programmatically which does not trigger input event but can be caught by blur event.
-    await page.evaluate(() => {
-      const htmlInputElement = document.querySelector('input');
-      htmlInputElement.value = '';
-      htmlInputElement.blur();
+      element = await page.find('sbb-form-field');
     });
-    await page.waitForChanges();
-    expect(element.getAttribute('data-input-empty')).not.toBeNull();
+
+    it('renders', async () => {
+      expect(element).toHaveClass('hydrated');
+    });
+
+    it('should remove the label element if no label is configured', async () => {
+      expect(await page.findAll('sbb-form-field label')).toEqual([]);
+      expect(element.shadowRoot.querySelector('label')).toBeNull();
+
+      element.setAttribute('label', 'Label');
+      await page.waitForChanges();
+      expect(await element.find('label')).not.toBeNull();
+
+      element.removeAttribute('label');
+      await page.waitForChanges();
+      expect(await element.find('label')).toBeNull();
+    });
+
+    it('should update empty input state', async () => {
+      const input = await page.find('input');
+      await page.waitForChanges();
+      expect(element.getAttribute('data-input-empty')).not.toBeNull();
+
+      await input.type('v');
+      await page.waitForChanges();
+      expect(element.getAttribute('data-input-empty')).toBeNull();
+
+      await input.press('Backspace');
+      await page.waitForChanges();
+      expect(element.getAttribute('data-input-empty')).not.toBeNull();
+
+      await input.type('v');
+      await page.waitForChanges();
+      expect(element.getAttribute('data-input-empty')).toBeNull();
+
+      // Clearing value programmatically which does not trigger input event but can be caught by blur event.
+      await page.evaluate(() => {
+        const htmlInputElement = document.querySelector('input');
+        htmlInputElement.value = '';
+        htmlInputElement.blur();
+      });
+      await page.waitForChanges();
+      expect(element.getAttribute('data-input-empty')).not.toBeNull();
+    });
+
+    it('should assign id to input and reference it in the label', async () => {
+      element.setAttribute('label', 'Example');
+      await page.waitForChanges();
+      const input = await page.find('input');
+      const label = await page.find('label');
+
+      await page.waitForChanges();
+
+      expect(input.id).toMatch(/^sbb-form-field-input-/);
+      expect(label.getAttribute('for')).toEqual(input.id);
+    });
+  });
+
+  describe('with sbb-select', () => {
+    let element: E2EElement, page: E2EPage;
+
+    beforeEach(async () => {
+      page = await newE2EPage();
+      await page.setContent(
+        '<sbb-form-field label="Example"><sbb-select><sbb-option>Test</sbb-option></sbb-select></sbb-form-field>'
+      );
+
+      element = await page.find('sbb-form-field');
+    });
+
+    it('renders', async () => {
+      expect(element).toHaveClass('hydrated');
+    });
+
+    it('should assign id to label and reference it in the sbb-select', async () => {
+      element.setAttribute('label', 'Example');
+      await page.waitForChanges();
+      const select = await page.find('sbb-select');
+      const label = await page.find('label');
+
+      await page.waitForChanges();
+
+      expect(label.id).toMatch(/^sbb-form-field-label-/);
+      expect(select.getAttribute('aria-labelledby')).toEqual(label.id);
+    });
   });
 });

--- a/src/components/sbb-form-field/sbb-form-field.spec.ts
+++ b/src/components/sbb-form-field/sbb-form-field.spec.ts
@@ -8,7 +8,7 @@ describe('sbb-form-field', () => {
       components: [SbbFormField],
       html: `
         <sbb-form-field label="Fill input">
-          <input slot='input' class='input' placeholder='This is an input' />
+          <input placeholder='This is an input' />
         </sbb-form-field>`,
     });
 
@@ -39,7 +39,7 @@ describe('sbb-form-field', () => {
         <label data-creator="SBB-FORM-FIELD" slot="label">
           Fill input
         </label>
-        <input class="input" placeholder="This is an input" slot="input">
+        <input placeholder="This is an input">
       </sbb-form-field>
     `);
   });

--- a/src/components/sbb-form-field/sbb-form-field.tsx
+++ b/src/components/sbb-form-field/sbb-form-field.tsx
@@ -40,10 +40,10 @@ const supportedPopupTagNames = ['SBB-TOOLTIP', 'SBB-AUTOCOMPLETE', 'SBB-SELECT']
   tag: 'sbb-form-field',
 })
 export class SbbFormField implements ComponentInterface {
+  private readonly _supportedNativeInputElements = ['INPUT', 'SELECT'];
   // List of supported element selectors in unnamed slot
   private readonly _supportedInputElements = [
-    'INPUT',
-    'SELECT',
+    ...this._supportedNativeInputElements,
     'SBB-SELECT',
     'SBB-SLIDER',
     'SBB-TIME-INPUT',
@@ -105,10 +105,11 @@ export class SbbFormField implements ComponentInterface {
    */
   @State() private _currentLanguage = documentLanguage();
 
-  /**
-   * It is used internally to get the `input` slot.
-   */
+  /** Reference to the slotted input element. */
   @State() private _input?: HTMLInputElement | HTMLSelectElement | HTMLElement;
+
+  /** Reference to the slotted label elements. */
+  @State() private _labels: HTMLLabelElement[] = [];
 
   private _handlerRepository = new HandlerRepository(
     this._element,
@@ -196,10 +197,8 @@ export class SbbFormField implements ComponentInterface {
     if (labels.length > 1 && createdLabel) {
       createdLabel.remove();
     }
-    const inputId = this._input?.id;
-    if (inputId) {
-      labels.forEach((l) => (l.htmlFor = inputId));
-    }
+    this._labels = Array.from(this._element.querySelectorAll('label'));
+    this._syncLabelInputReferences();
   }
 
   /**
@@ -225,15 +224,37 @@ export class SbbFormField implements ComponentInterface {
       attributes: true,
       attributeFilter: ['readonly', 'disabled', 'class'],
     });
+    this._element.dataset.inputType = this._input.tagName.toLowerCase();
+    this._syncLabelInputReferences();
+  }
 
-    if (!this._input.id) {
-      this._input.id = `sbb-form-field-input-${nextId++}`;
+  private _syncLabelInputReferences(): void {
+    if (!this._input || !this._labels.length) {
+      return;
     }
 
-    this._element.dataset.inputType = this._input.tagName.toLowerCase();
-    const label = this._element.querySelector('label');
-    if (label) {
-      label.htmlFor = this._input.id;
+    if (this._supportedNativeInputElements.includes(this._input.tagName)) {
+      // For native input elements we use the `for` attribute on the label to reference the input
+      // via id reference.
+      if (!this._input.id) {
+        this._input.id = `sbb-form-field-input-${nextId++}`;
+      }
+
+      this._labels.forEach((l) => (l.htmlFor = this._input.id));
+    } else {
+      // For non-native input elements, that do not support references via the label for attribute,
+      // we use aria-labelledby on the input element to reference the label element via id.
+      this._labels.filter((l) => !l.id).forEach((l) => (l.id = `sbb-form-field-label-${nextId++}`));
+      const labelIds = this._labels.map((l) => l.id);
+      const labelledby =
+        this._input
+          .getAttribute('aria-labelledby')
+          ?.split(' ')
+          .filter((l) => !!l && !labelIds.includes(l)) ?? [];
+      this._input.setAttribute(
+        'aria-labelledby',
+        [...labelledby, ...this._labels.map((l) => l.id)].join(' ')
+      );
     }
   }
 


### PR DESCRIPTION
Currently `<sbb-form-field>` only links native form elements correctly via the `<label>` `for` attribute. This PR adds the functionality for custom form elements to be able to reference the `<label>` via `aria-labelledby` on the custom form element, which is done internally in the `<sbb-form-field>`.