### PR TITLE
refactor: update icon cdn domain

### DIFF
--- a/src/components/sbb-icon/sbb-icon-request.ts
+++ b/src/components/sbb-icon/sbb-icon-request.ts
@@ -1,7 +1,7 @@
 import { validateContent } from './sbb-icon-validate';
 import { readConfig, SbbIconConfig } from '../../global/helpers/config';
 
-const iconCdn = 'https://d1s1onrtynjaa8.cloudfront.net/';
+const iconCdn = 'https://icons.app.sbb.ch/';
 
 // TODO: remove picto-legacy namespace
 const iconNamespaces = new Map<string, string>()


### PR DESCRIPTION
Our icon CDN is now available at https://icons.app.sbb.ch/.