### PR TITLE
fix(sbb-form-field): fix accessibility when slotting form error

### DIFF
--- a/src/components/sbb-autocomplete/sbb-autocomplete.spec.ts
+++ b/src/components/sbb-autocomplete/sbb-autocomplete.spec.ts
@@ -71,7 +71,7 @@ describe('sbb-autocomplete', () => {
               </div>
               <slot name="suffix"></slot>
             </div>
-            <div aria-live="polite" class="sbb-form-field__error">
+            <div class="sbb-form-field__error">
               <slot name="error"></slot>
             </div>
           </div>

--- a/src/components/sbb-form-field/sbb-form-field.e2e.ts
+++ b/src/components/sbb-form-field/sbb-form-field.e2e.ts
@@ -66,6 +66,60 @@ describe('sbb-form-field', () => {
       expect(input.id).toMatch(/^sbb-form-field-input-/);
       expect(label.getAttribute('for')).toEqual(input.id);
     });
+
+    it('should reference sbb-form-error', async () => {
+      const input = await page.find('input');
+      await page.waitForChanges();
+
+      // When adding a sbb-form-error
+      await page.evaluate(() => {
+        const formError = document.createElement('sbb-form-error');
+        document.querySelector('sbb-form-field').append(formError);
+      });
+      const formError = await page.find('sbb-form-error');
+      await page.waitForChanges();
+
+      // Then input should be linked and sbb-form-error configured
+      expect(input.getAttribute('aria-describedby')).toMatch(/^sbb-form-field-error-/);
+      expect(formError.id).toEqual(input.getAttribute('aria-describedby'));
+      expect(formError.getAttribute('role')).toEqual('status');
+
+      // When removing sbb-form-error
+      await page.evaluate(() => {
+        document.querySelector('sbb-form-error').remove();
+      });
+      await page.waitForChanges();
+
+      // Then aria-describedby should be removed
+      expect(input.getAttribute('aria-describedby')).toBeNull();
+    });
+
+    it('should reference sbb-form-error with original aria-describedby', async () => {
+      const input = await page.find('input');
+      await page.waitForChanges();
+      await page.evaluate(() => {
+        document.querySelector('input').setAttribute('aria-describedby', 'foo');
+      });
+
+      // When adding a sbb-form-error
+      await page.evaluate(() => {
+        const formError = document.createElement('sbb-form-error');
+        document.querySelector('sbb-form-field').append(formError);
+      });
+      await page.waitForChanges();
+
+      // Then input should be linked and original aria-describedby preserved
+      expect(input.getAttribute('aria-describedby')).toMatch(/^foo sbb-form-field-error-/);
+
+      // When removing sbb-form-error
+      await page.evaluate(() => {
+        document.querySelector('sbb-form-error').remove();
+      });
+      await page.waitForChanges();
+
+      // Then aria-describedby should be set to foo
+      expect(input.getAttribute('aria-describedby')).toBe('foo');
+    });
   });
 
   describe('with sbb-select', () => {

--- a/src/components/sbb-form-field/sbb-form-field.spec.ts
+++ b/src/components/sbb-form-field/sbb-form-field.spec.ts
@@ -31,7 +31,7 @@ describe('sbb-form-field', () => {
               </div>
               <slot name="suffix"></slot>
             </div>
-            <div class="sbb-form-field__error" aria-live="polite">
+            <div class="sbb-form-field__error">
               <slot name="error"></slot>
             </div>
           </div>
@@ -77,7 +77,7 @@ describe('sbb-form-field', () => {
               </div>
               <slot name="suffix"></slot>
             </div>
-            <div class="sbb-form-field__error" aria-live="polite">
+            <div class="sbb-form-field__error">
               <slot name="error"></slot>
             </div>
           </div>
@@ -118,7 +118,7 @@ describe('sbb-form-field', () => {
               </div>
               <slot name="suffix"></slot>
             </div>
-            <div class="sbb-form-field__error" aria-live="polite">
+            <div class="sbb-form-field__error">
               <slot name="error"></slot>
             </div>
           </div>
@@ -162,7 +162,7 @@ describe('sbb-form-field', () => {
               </div>
               <slot name="suffix"></slot>
             </div>
-            <div class="sbb-form-field__error" aria-live="polite">
+            <div class="sbb-form-field__error">
               <slot name="error"></slot>
             </div>
           </div>
@@ -204,7 +204,7 @@ describe('sbb-form-field', () => {
               </div>
               <slot name="suffix"></slot>
             </div>
-            <div class="sbb-form-field__error" aria-live="polite">
+            <div class="sbb-form-field__error">
               <slot name="error"></slot>
             </div>
           </div>
@@ -251,7 +251,7 @@ describe('sbb-form-field', () => {
               </div>
               <slot name="suffix"></slot>
             </div>
-            <div class="sbb-form-field__error" aria-live="polite">
+            <div class="sbb-form-field__error">
               <slot name="error"></slot>
             </div>
           </div>


### PR DESCRIPTION
Previously, aria-describedby of the input was not correctly updated when removing or first adding a sbb-form-error. Additionally, to support removing and adding sbb-form-error multiple times for screen readers, we had to move the aria-live region to a single element, although according to documentation the aria-live region should be on a container.
