### PR TITLE
fix(sbb-navigation-section): use divider instead of separation border

### DIFF
--- a/src/components/sbb-divider/readme.md
+++ b/src/components/sbb-divider/readme.md
@@ -20,6 +20,7 @@ Based on the orientation property, the `sbb-divider` can be displayed vertically
 
  - [sbb-alert](../sbb-alert)
  - [sbb-journey-summary](../sbb-journey-summary)
+ - [sbb-navigation-section](../sbb-navigation-section)
  - [sbb-notification](../sbb-notification)
  - [sbb-optgroup](../sbb-optgroup)
  - [sbb-selection-panel](../sbb-selection-panel)
@@ -29,6 +30,7 @@ Based on the orientation property, the `sbb-divider` can be displayed vertically
 graph TD;
   sbb-alert --> sbb-divider
   sbb-journey-summary --> sbb-divider
+  sbb-navigation-section --> sbb-divider
   sbb-notification --> sbb-divider
   sbb-optgroup --> sbb-divider
   sbb-selection-panel --> sbb-divider

--- a/src/components/sbb-navigation-section/readme.md
+++ b/src/components/sbb-navigation-section/readme.md
@@ -70,11 +70,13 @@ Type: `Promise<void>`
 ### Depends on
 
 - [sbb-button](../sbb-button)
+- [sbb-divider](../sbb-divider)
 
 ### Graph
 ```mermaid
 graph TD;
   sbb-navigation-section --> sbb-button
+  sbb-navigation-section --> sbb-divider
   sbb-button --> sbb-icon
   style sbb-navigation-section fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/src/components/sbb-navigation-section/sbb-navigation-section.scss
+++ b/src/components/sbb-navigation-section/sbb-navigation-section.scss
@@ -186,6 +186,17 @@
   }
 }
 
+.sbb-navigation-section__divider {
+  display: none;
+
+  @include sbb.mq($from: wide) {
+    display: block;
+    position: absolute;
+    inset-block: 0;
+    inset-inline-start: 0;
+  }
+}
+
 .sbb-navigation-section__content {
   display: grid;
   grid-template-columns: 1fr;
@@ -210,7 +221,6 @@
 
   @include sbb.mq($from: wide) {
     grid-template-columns: repeat(3, 1fr);
-    border-inline-start: var(--sbb-border-width-1x) solid var(--sbb-color-charcoal-default);
   }
 
   :host([data-state='closing']) & {

--- a/src/components/sbb-navigation-section/sbb-navigation-section.spec.ts
+++ b/src/components/sbb-navigation-section/sbb-navigation-section.spec.ts
@@ -15,7 +15,7 @@ describe('sbb-navigation-section', () => {
               <dialog class="sbb-navigation-section" role="group" aria-labelledby="title">
                 <div class="sbb-navigation-section__wrapper">
                   <div class="sbb-navigation-section__content">
-                    <sbb-divider class="sbb-navigation-section__divider" negative orientation="vertical" />
+                    <sbb-divider class="sbb-navigation-section__divider" negative orientation="vertical"></sbb-divider>
                     <slot></slot>
                   </div>
                 </div>

--- a/src/components/sbb-navigation-section/sbb-navigation-section.spec.ts
+++ b/src/components/sbb-navigation-section/sbb-navigation-section.spec.ts
@@ -15,6 +15,7 @@ describe('sbb-navigation-section', () => {
               <dialog class="sbb-navigation-section" role="group" aria-labelledby="title">
                 <div class="sbb-navigation-section__wrapper">
                   <div class="sbb-navigation-section__content">
+                    <sbb-divider class="sbb-navigation-section__divider" negative orientation="vertical"></sbb-divider>
                     <slot></slot>
                   </div>
                 </div>

--- a/src/components/sbb-navigation-section/sbb-navigation-section.spec.ts
+++ b/src/components/sbb-navigation-section/sbb-navigation-section.spec.ts
@@ -15,7 +15,7 @@ describe('sbb-navigation-section', () => {
               <dialog class="sbb-navigation-section" role="group" aria-labelledby="title">
                 <div class="sbb-navigation-section__wrapper">
                   <div class="sbb-navigation-section__content">
-                    <sbb-divider class="sbb-navigation-section__divider" negative orientation="vertical"></sbb-divider>
+                    <sbb-divider class="sbb-navigation-section__divider" negative orientation="vertical" />
                     <slot></slot>
                   </div>
                 </div>

--- a/src/components/sbb-navigation-section/sbb-navigation-section.tsx
+++ b/src/components/sbb-navigation-section/sbb-navigation-section.tsx
@@ -387,6 +387,11 @@ export class SbbNavigationSection implements ComponentInterface {
           >
             <div class="sbb-navigation-section__wrapper">
               <div class="sbb-navigation-section__content">
+                <sbb-divider
+                  class="sbb-navigation-section__divider"
+                  orientation="vertical"
+                  negative
+                />
                 {(!!this.titleContent || this._namedSlots.title) && labelElement}
                 <slot />
               </div>


### PR DESCRIPTION
Closes #1934 

Has a one pixel shift of whole navigation section, but seems like designed in Figma