### PR TITLE
fix(sbb-card): allow placing tooltips inside non-interactive cards

### DIFF
--- a/src/components/sbb-card/sbb-card.scss
+++ b/src/components/sbb-card/sbb-card.scss
@@ -99,6 +99,8 @@
 
   :host([data-has-action]) & {
     pointer-events: none;
+    transform: translateY(var(--sbb-card-hover-shift));
+    transition: transform var(--sbb-card-animation-duration) var(--sbb-card-animation-easing);
   }
 }
 

--- a/src/global/styles/mixins/card.scss
+++ b/src/global/styles/mixins/card.scss
@@ -169,6 +169,4 @@
 @mixin card--wrapper {
   display: block;
   height: 100%;
-  transition: transform var(--sbb-card-animation-duration) var(--sbb-card-animation-easing);
-  transform: translateY(var(--sbb-card-hover-shift));
 }


### PR DESCRIPTION
Partially fixes #1982 