### PR TITLE
chore: mitigate phishing attacks

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -30,3 +30,46 @@
     }
   }
 </style>
+
+<script>
+  const windowRef = typeof window !== 'undefined' && window;
+  if (!inIframe() && !isChromatic() && !isDev()) {
+    setTimeout(() => {
+      const div = document.createElement('div');
+      div.textContent = 'EXAMPLE / BEISPIEL / EXEMPLE / ESEMPIO ';
+      div.style.cssText = `
+        position: fixed;
+        display: inline-block;
+        border: 1px solid red;
+        border-radius: 0.25rem;
+        background-color: yellow;
+        padding-inline: 0.5rem;
+        inset: 0.5rem auto auto 50%;
+        transform: translateX(-50%);
+      `;
+      const a = document.createElement('a');
+      a.href = 'https://lyne-storybook.app.sbb.ch/';
+      a.textContent = '(Create your own)';
+      div.append(a);
+      document.body.append(div);
+    });
+  }
+
+  function inIframe() {
+    try {
+      return windowRef.self !== windowRef.top;
+    } catch (e) {
+      return true;
+    }
+  }
+  function isChromatic() {
+    return !!(
+      windowRef &&
+      (windowRef.navigator.userAgent.match(/Chromatic/) ||
+        windowRef.location.href.match(/chromatic=true/))
+    );
+  }
+  function isDev() {
+    return window.location.hostname === 'localhost';
+  }
+</script>

--- a/src/components/sbb-alert/sbb-alert.stories.tsx
+++ b/src/components/sbb-alert/sbb-alert.stories.tsx
@@ -90,9 +90,16 @@ const linkContent: InputType = {
   },
 };
 
+const hrefs = ['https://www.sbb.ch', 'https://github.com/lyne-design-system/lyne-components'];
 const href: InputType = {
+  options: Object.keys(hrefs),
+  mapping: hrefs,
   control: {
-    type: 'text',
+    type: 'select',
+    labels: {
+      0: 'sbb.ch',
+      1: 'GitHub Lyne Components',
+    },
   },
   table: {
     category: 'Link',
@@ -151,7 +158,7 @@ const defaultArgs: Args = {
   'content-slot-text':
     "Between Berne and Olten from 03.11.2021 to 05.12.2022 each time from 22:30 to 06:00 o'clock construction work will take place. You have to expect changed travel times and changed connections.",
   'link-content': undefined,
-  href: 'https://www.sbb.ch',
+  href: href.options[0],
   target: undefined,
   rel: undefined,
   'accessibility-label': undefined,

--- a/src/components/sbb-breadcrumb-group/sbb-breadcrumb-group.stories.tsx
+++ b/src/components/sbb-breadcrumb-group/sbb-breadcrumb-group.stories.tsx
@@ -34,9 +34,16 @@ const text: InputType = {
   },
 };
 
+const hrefs = ['https://www.sbb.ch', 'https://github.com/lyne-design-system/lyne-components'];
 const href: InputType = {
+  options: Object.keys(hrefs),
+  mapping: hrefs,
   control: {
-    type: 'text',
+    type: 'select',
+    labels: {
+      0: 'sbb.ch',
+      1: 'GitHub Lyne Components',
+    },
   },
   table: {
     category: 'Breadcrumb',

--- a/src/components/sbb-breadcrumb/sbb-breadcrumb.stories.tsx
+++ b/src/components/sbb-breadcrumb/sbb-breadcrumb.stories.tsx
@@ -10,9 +10,19 @@ const text: InputType = {
   },
 };
 
+const hrefs = ['https://www.sbb.ch', 'https://github.com/lyne-design-system/lyne-components'];
 const href: InputType = {
+  options: Object.keys(hrefs),
+  mapping: hrefs,
   control: {
-    type: 'text',
+    type: 'select',
+    labels: {
+      0: 'sbb.ch',
+      1: 'GitHub Lyne Components',
+    },
+  },
+  table: {
+    category: 'Link',
   },
 };
 
@@ -51,7 +61,7 @@ const defaultArgTypes: ArgTypes = {
 
 const defaultArgs: Args = {
   text: 'Breadcrumb',
-  href: 'https://github.com/lyne-design-system/lyne-components',
+  href: href.options[0],
   target: '_blank',
   rel: undefined,
   download: false,

--- a/src/components/sbb-button/sbb-button.stories.tsx
+++ b/src/components/sbb-button/sbb-button.stories.tsx
@@ -128,9 +128,16 @@ const iconName: InputType = {
   },
 };
 
+const hrefs = ['https://www.sbb.ch', 'https://github.com/lyne-design-system/lyne-components'];
 const href: InputType = {
+  options: Object.keys(hrefs),
+  mapping: hrefs,
   control: {
-    type: 'text',
+    type: 'select',
+    labels: {
+      0: 'sbb.ch',
+      1: 'GitHub Lyne Components',
+    },
   },
   table: {
     category: 'Link',
@@ -474,7 +481,7 @@ export const LinkOpensInNewWindow: StoryObj = {
   argTypes: defaultArgTypes,
   args: {
     ...defaultArgs,
-    href: 'https://www.sbb.ch',
+    href: href.options[0],
     'icon-name': 'chevron-small-right-small',
     target: '_blank',
     'aria-label': undefined,

--- a/src/components/sbb-card/sbb-card.stories.tsx
+++ b/src/components/sbb-card/sbb-card.stories.tsx
@@ -108,9 +108,16 @@ const label: InputType = {
   },
 };
 
+const hrefs = ['https://www.sbb.ch', 'https://github.com/lyne-design-system/lyne-components'];
 const href: InputType = {
+  options: Object.keys(hrefs),
+  mapping: hrefs,
   control: {
-    type: 'text',
+    type: 'select',
+    labels: {
+      0: 'sbb.ch',
+      1: 'GitHub Lyne Components',
+    },
   },
   table: {
     category: 'Card Action Link',
@@ -209,7 +216,7 @@ const defaultArgsAction = {
   ...defaultArgs,
   active: false,
   label: 'Click this card to follow the action.',
-  href: 'https://github.com/lyne-design-system/lyne-components',
+  href: href.options[1],
   download: false,
   target: '_blank',
   rel: undefined,

--- a/src/components/sbb-header-action/sbb-header-action.stories.tsx
+++ b/src/components/sbb-header-action/sbb-header-action.stories.tsx
@@ -36,9 +36,16 @@ const iconName: InputType = {
   },
 };
 
+const hrefs = ['https://www.sbb.ch', 'https://github.com/lyne-design-system/lyne-components'];
 const href: InputType = {
+  options: Object.keys(hrefs),
+  mapping: hrefs,
   control: {
-    type: 'text',
+    type: 'select',
+    labels: {
+      0: 'sbb.ch',
+      1: 'GitHub Lyne Components',
+    },
   },
   table: {
     category: 'Link',
@@ -132,7 +139,7 @@ const basicArgs: Args = {
   text: 'Menu',
   'expand-from': expandFrom.options[0],
   'icon-name': 'hamburger-menu-small',
-  href: 'https://github.com/lyne-design-system/lyne-components',
+  href: href.options[1],
   target: '_blank',
   rel: undefined,
   download: false,

--- a/src/components/sbb-link/sbb-link.stories.tsx
+++ b/src/components/sbb-link/sbb-link.stories.tsx
@@ -88,9 +88,16 @@ const iconPlacement: InputType = {
   },
 };
 
+const hrefs = ['https://www.sbb.ch', 'https://github.com/lyne-design-system/lyne-components'];
 const href: InputType = {
+  options: Object.keys(hrefs),
+  mapping: hrefs,
   control: {
-    type: 'text',
+    type: 'select',
+    labels: {
+      0: 'sbb.ch',
+      1: 'GitHub Lyne Components',
+    },
   },
   table: {
     category: 'Link',
@@ -204,7 +211,7 @@ const defaultArgs: Args = {
   static: false,
   'icon-name': undefined,
   'icon-placement': iconPlacement.options[0],
-  href: 'https://github.com/lyne-design-system/lyne-components',
+  href: href.options[1],
   target: undefined,
   rel: undefined,
   download: false,

--- a/src/components/sbb-menu-action/sbb-menu-action.stories.tsx
+++ b/src/components/sbb-menu-action/sbb-menu-action.stories.tsx
@@ -49,9 +49,16 @@ const iconName: InputType = {
   },
 };
 
+const hrefs = ['https://www.sbb.ch', 'https://github.com/lyne-design-system/lyne-components'];
 const href: InputType = {
+  options: Object.keys(hrefs),
+  mapping: hrefs,
   control: {
-    type: 'text',
+    type: 'select',
+    labels: {
+      0: 'sbb.ch',
+      1: 'GitHub Lyne Components',
+    },
   },
   table: {
     category: 'Link',
@@ -157,7 +164,7 @@ const defaultArgs: Args = {
   text: 'Details',
   amount: '99',
   'icon-name': 'tick-small',
-  href: 'https://www.sbb.ch/en',
+  href: href.options[0],
   target: '_blank',
   rel: undefined,
   download: false,

--- a/src/components/sbb-navigation-action/sbb-navigation-action.stories.tsx
+++ b/src/components/sbb-navigation-action/sbb-navigation-action.stories.tsx
@@ -17,9 +17,19 @@ const ariaLabel: InputType = {
   },
 };
 
+const hrefs = ['https://www.sbb.ch', 'https://github.com/lyne-design-system/lyne-components'];
 const href: InputType = {
+  options: Object.keys(hrefs),
+  mapping: hrefs,
   control: {
-    type: 'text',
+    type: 'select',
+    labels: {
+      0: 'sbb.ch',
+      1: 'GitHub Lyne Components',
+    },
+  },
+  table: {
+    category: 'Link',
   },
 };
 
@@ -66,7 +76,7 @@ export const SizeS: StoryObj = {
 export const Link: StoryObj = {
   render: Template,
   argTypes: defaultArgTypes,
-  args: { ...defaultArgs, href: 'https://www.sbb.ch' },
+  args: { ...defaultArgs, href: href.options[1] },
 };
 
 const meta: Meta = {

--- a/src/components/sbb-skiplink-list/sbb-skiplink-list.stories.tsx
+++ b/src/components/sbb-skiplink-list/sbb-skiplink-list.stories.tsx
@@ -21,6 +21,11 @@ const titleLevel: InputType = {
   options: [2, 3, 4, 5, 6],
 };
 
+const hrefs = [
+  'https://www.sbb.ch',
+  'https://www.sbb.ch/en/help-and-contact.html',
+  'https://github.com/lyne-design-system/lyne-components',
+];
 const labelFirstLink: InputType = {
   control: {
     type: 'text',
@@ -31,8 +36,14 @@ const labelFirstLink: InputType = {
 };
 
 const hrefFirstLink: InputType = {
+  options: Object.keys(hrefs),
+  mapping: hrefs,
   control: {
-    type: 'text',
+    type: 'select',
+    labels: {
+      0: 'sbb.ch',
+      1: 'GitHub Lyne Components',
+    },
   },
   table: {
     category: 'Links',
@@ -49,8 +60,14 @@ const labelSecondLink: InputType = {
 };
 
 const hrefSecondLink: InputType = {
+  options: Object.keys(hrefs),
+  mapping: hrefs,
   control: {
-    type: 'text',
+    type: 'select',
+    labels: {
+      0: 'sbb.ch',
+      1: 'GitHub Lyne Components',
+    },
   },
   table: {
     category: 'Links',
@@ -70,9 +87,9 @@ const defaultArgs: Args = {
   'title-level': undefined,
   'title-content': undefined,
   labelFirstLink: 'To content',
-  hrefFirstLink: 'https://www.sbb.ch/',
+  hrefFirstLink: hrefFirstLink.options[0],
   labelSecondLink: 'To help',
-  hrefSecondLink: 'https://www.sbb.ch/en/help-and-contact.html',
+  hrefSecondLink: hrefSecondLink.options[1],
 };
 
 // Story interaction executed after the story renders

--- a/src/components/sbb-teaser-hero/sbb-teaser-hero.stories.tsx
+++ b/src/components/sbb-teaser-hero/sbb-teaser-hero.stories.tsx
@@ -15,12 +15,19 @@ const ariaLabel: InputType = {
   },
 };
 
+const hrefs = ['https://www.sbb.ch', 'https://github.com/lyne-design-system/lyne-components'];
 const href: InputType = {
+  options: Object.keys(hrefs),
+  mapping: hrefs,
   control: {
-    type: 'text',
+    type: 'select',
+    labels: {
+      0: 'sbb.ch',
+      1: 'GitHub Lyne Components',
+    },
   },
   table: {
-    category: 'link',
+    category: 'Link',
   },
 };
 
@@ -79,7 +86,7 @@ const defaultArgTypes: ArgTypes = {
 
 const defaultArgs: Args = {
   'aria-label': undefined,
-  href: 'https://www.sbb.ch',
+  href: href.options[0],
   rel: undefined,
   target: undefined,
   content: 'Break out and explore castles and palaces.',

--- a/src/components/sbb-teaser/sbb-teaser.stories.tsx
+++ b/src/components/sbb-teaser/sbb-teaser.stories.tsx
@@ -50,9 +50,16 @@ const isStacked: InputType = {
 
 /* --- Link ---------------------------------------- */
 
+const hrefs = ['https://www.sbb.ch', 'https://github.com/lyne-design-system/lyne-components'];
 const href: InputType = {
+  options: Object.keys(hrefs),
+  mapping: hrefs,
   control: {
-    type: 'text',
+    type: 'select',
+    labels: {
+      0: 'sbb.ch',
+      1: 'GitHub Lyne Components',
+    },
   },
   table: {
     category: 'Link',
@@ -76,7 +83,7 @@ const defaultArgs: Args = {
   'aria-label':
     'The text which gets exposed to screen reader users. The text should reflect all the information which gets passed into the components slots and which is visible in the Teaser, either through text or iconography',
   'is-stacked': true,
-  href: 'https://github.com/lyne-design-system/lyne-components',
+  href: href.options[1],
 };
 
 /* ************************************************* */


### PR DESCRIPTION
This PR adds a banner to the Storybook preview page, if viewed directly in the iframe. This is only visible in deployed versions.

![image](https://github.com/lyne-design-system/lyne-components/assets/594745/286b3e58-6ba0-4db8-b96d-d5e4de8ffdad)
