### PR TITLE
fix(sbb-breadcrumb): reliably detect text/content changes

### DIFF
--- a/src/components/sbb-breadcrumb/sbb-breadcrumb.spec.ts
+++ b/src/components/sbb-breadcrumb/sbb-breadcrumb.spec.ts
@@ -42,6 +42,9 @@ describe('sbb-breadcrumb', () => {
                 <sbb-icon name="house-small"></sbb-icon>
               </slot>
             </span>
+            <span hidden>
+              <slot></slot>
+            </span>
           </a>
         </mock:shadow-root>
       </sbb-breadcrumb>

--- a/src/components/sbb-breadcrumb/sbb-breadcrumb.tsx
+++ b/src/components/sbb-breadcrumb/sbb-breadcrumb.tsx
@@ -102,6 +102,11 @@ export class SbbBreadcrumb implements ComponentInterface, LinkProperties {
               )}
             </span>
           )}
+          {!this._hasText && (
+            <span hidden>
+              <slot onSlotchange={(event): void => this._onLabelSlotChange(event)}></slot>
+            </span>
+          )}
         </TAG_NAME>
       </Host>
     );


### PR DESCRIPTION
This PR fixes an issue with the rendering, when text or content is being added asynchronously after connecting the `<sbb-breadcrumb>` to the DOM.