### PR TITLE
fix(sbb-dialog): open/close methods exit conditions

### DIFF
--- a/src/components/sbb-dialog/sbb-dialog.scss
+++ b/src/components/sbb-dialog/sbb-dialog.scss
@@ -181,6 +181,7 @@
 
 .sbb-dialog__header {
   display: flex;
+  pointer-events: none;
   gap: var(--sbb-spacing-fixed-6x);
   align-items: start;
   justify-content: space-between;
@@ -188,6 +189,10 @@
   padding-block: var(--sbb-dialog-header-padding-block);
   background-color: var(--sbb-dialog-background-color);
   z-index: var(--sbb-dialog-z-index, var(--sbb-overlay-z-index));
+
+  * {
+    pointer-events: all;
+  }
 
   :host([data-fullscreen]) & {
     position: fixed;

--- a/src/components/sbb-dialog/sbb-dialog.tsx
+++ b/src/components/sbb-dialog/sbb-dialog.tsx
@@ -185,7 +185,7 @@ export class SbbDialog implements ComponentInterface {
    */
   @Method()
   public async open(): Promise<void> {
-    if (this._state === 'closing' || !this._dialog) {
+    if (this._state !== 'closed' || !this._dialog) {
       return;
     }
     this._lastFocusedElement = document.activeElement as HTMLElement;
@@ -204,7 +204,7 @@ export class SbbDialog implements ComponentInterface {
    */
   @Method()
   public async close(result?: any, target?: HTMLElement): Promise<any> {
-    if (this._state === 'opening') {
+    if (this._state !== 'opened') {
       return;
     }
 


### PR DESCRIPTION
Fixes open/close method exit conditions and allows interactive elements under the header to be clicked.