### PR TITLE
fix(sbb-selection-panel): remove wrongly announced expanded state for nested radios and checkboxes

### DIFF
--- a/src/components/sbb-checkbox/sbb-checkbox.e2e.ts
+++ b/src/components/sbb-checkbox/sbb-checkbox.e2e.ts
@@ -14,6 +14,11 @@ describe('sbb-checkbox', () => {
     expect(element).toHaveClass('hydrated');
   });
 
+  it('should not render accessibility label containing expanded state', async () => {
+    element = await page.find('sbb-checkbox >>> .sbb-checkbox__expanded-label');
+    expect(element).toBeFalsy();
+  });
+
   describe('events', () => {
     it('emit event on click', async () => {
       await page.waitForChanges();

--- a/src/components/sbb-checkbox/sbb-checkbox.tsx
+++ b/src/components/sbb-checkbox/sbb-checkbox.tsx
@@ -119,7 +119,7 @@ export class SbbCheckbox implements ComponentInterface {
   public handleCheckedChange(currentValue: boolean, previousValue: boolean): void {
     if (this._isSelectionPanelInput && currentValue !== previousValue) {
       this.stateChange.emit({ type: 'checked', checked: currentValue });
-      !!this._selectionPanelElement && this._updateExpandedLabel();
+      this._updateExpandedLabel();
     }
   }
 
@@ -171,7 +171,7 @@ export class SbbCheckbox implements ComponentInterface {
   }
 
   public componentDidLoad(): void {
-    !!this._selectionPanelElement && this._updateExpandedLabel();
+    this._isSelectionPanelInput && this._updateExpandedLabel();
   }
 
   public disconnectedCallback(): void {
@@ -216,6 +216,7 @@ export class SbbCheckbox implements ComponentInterface {
 
   private _updateExpandedLabel(): void {
     if (!this._selectionPanelElement.hasAttribute('data-has-content')) {
+      this._selectionPanelExpandedLabel = '';
       return;
     }
 
@@ -278,7 +279,7 @@ export class SbbCheckbox implements ComponentInterface {
             {!!this._selectionPanelElement && this._namedSlots['subtext'] && (
               <slot name="subtext" />
             )}
-            {!!this._selectionPanelElement && this._selectionPanelExpandedLabel && (
+            {this._isSelectionPanelInput && this._selectionPanelExpandedLabel && (
               /* For screen readers only */
               <span class="sbb-checkbox__expanded-label">{this._selectionPanelExpandedLabel}</span>
             )}

--- a/src/components/sbb-radio-button/sbb-radio-button.e2e.ts
+++ b/src/components/sbb-radio-button/sbb-radio-button.e2e.ts
@@ -16,6 +16,11 @@ describe('sbb-radio-button', () => {
     expect(element).toHaveClass('hydrated');
   });
 
+  it('should not render accessibility label about containing state', async () => {
+    element = await page.find('sbb-radio-button >>> .sbb-radio-button__expanded-label');
+    expect(element).toBeFalsy();
+  });
+
   it('selects radio on click', async () => {
     const stateChange = await page.spyOnEvent(events.stateChange);
 

--- a/src/components/sbb-radio-button/sbb-radio-button.tsx
+++ b/src/components/sbb-radio-button/sbb-radio-button.tsx
@@ -124,7 +124,7 @@ export class SbbRadioButton implements ComponentInterface {
   public handleCheckedChange(currentValue: boolean, previousValue: boolean): void {
     if (currentValue !== previousValue) {
       this.stateChange.emit({ type: 'checked', checked: currentValue });
-      !!this._selectionPanelElement && this._updateExpandedLabel();
+      this._isSelectionPanelInput && this._updateExpandedLabel();
     }
   }
 
@@ -172,7 +172,7 @@ export class SbbRadioButton implements ComponentInterface {
   }
 
   public componentDidLoad(): void {
-    !!this._selectionPanelElement && this._updateExpandedLabel();
+    this._isSelectionPanelInput && this._updateExpandedLabel();
   }
 
   public disconnectedCallback(): void {
@@ -212,6 +212,7 @@ export class SbbRadioButton implements ComponentInterface {
 
   private _updateExpandedLabel(): void {
     if (!this._selectionPanelElement.hasAttribute('data-has-content')) {
+      this._selectionPanelExpandedLabel = '';
       return;
     }
 
@@ -246,7 +247,7 @@ export class SbbRadioButton implements ComponentInterface {
             {!!this._selectionPanelElement && this._namedSlots['suffix'] && <slot name="suffix" />}
           </span>
           {!!this._selectionPanelElement && this._namedSlots['subtext'] && <slot name="subtext" />}
-          {!!this._selectionPanelElement && this._selectionPanelExpandedLabel && (
+          {this._isSelectionPanelInput && this._selectionPanelExpandedLabel && (
             /* For screen readers only */
             <span class="sbb-radio-button__expanded-label">
               {this._selectionPanelExpandedLabel}

--- a/src/components/sbb-selection-panel/sbb-selection-panel.e2e.ts
+++ b/src/components/sbb-selection-panel/sbb-selection-panel.e2e.ts
@@ -290,6 +290,33 @@ describe('sbb-selection-panel', () => {
       await page.waitForChanges();
     });
 
+    it('should display expanded label correctly', async () => {
+      await page.waitForChanges();
+
+      const mainRadioButton1 = await page.find(
+        "sbb-radio-button[value='main1'] >>> .sbb-radio-button__expanded-label",
+      );
+      const mainRadioButton2 = await page.find(
+        "sbb-radio-button[value='main2'] >>> .sbb-radio-button__expanded-label",
+      );
+      const subRadioButton1 = await page.find(
+        "sbb-radio-button[value='sub1'] >>> .sbb-radio-button__expanded-label",
+      );
+
+      expect(mainRadioButton1.textContent).toBe(', expanded');
+      expect(mainRadioButton2.textContent).toBe(', collapsed');
+      expect(subRadioButton1).toBeFalsy();
+
+      // Activate main option 2
+      await mainRadioButton2.click();
+
+      await page.waitForChanges();
+
+      expect(mainRadioButton1.textContent).toBe(', collapsed');
+      expect(mainRadioButton2.textContent).toBe(', expanded');
+      expect(subRadioButton1).toBeFalsy();
+    });
+
     it('should mark only outer group children as disabled', async () => {
       element.setAttribute('disabled', '');
 
@@ -556,6 +583,36 @@ describe('sbb-selection-panel', () => {
       element = await page.find('sbb-checkbox-group');
 
       await page.waitForChanges();
+    });
+
+    it('should display expanded label correctly', async () => {
+      await page.waitForChanges();
+
+      const mainCheckbox1 = await page.find(
+        "sbb-checkbox[value='main1'] >>> .sbb-checkbox__expanded-label",
+      );
+      const mainCheckbox2 = await page.find(
+        "sbb-checkbox[value='main2'] >>> .sbb-checkbox__expanded-label",
+      );
+      const subCheckbox1 = await page.find(
+        "sbb-checkbox[value='sub1'] >>> .sbb-checkbox__expanded-label",
+      );
+
+      expect(mainCheckbox1.textContent).toBe(', expanded');
+      expect(mainCheckbox2.textContent).toBe(', collapsed');
+      expect(subCheckbox1).toBeFalsy();
+
+      // Deactivate main option 1
+      await mainCheckbox1.click();
+
+      // Activate main option 2
+      await mainCheckbox2.click();
+
+      await page.waitForChanges();
+
+      expect(mainCheckbox1.textContent).toBe(', collapsed');
+      expect(mainCheckbox2.textContent).toBe(', expanded');
+      expect(subCheckbox1).toBeFalsy();
     });
 
     it('should mark only outer group children as disabled', async () => {


### PR DESCRIPTION
Closes #2017 