### PR TITLE
fix(sbb-menu): menu action focus on mobile

### DIFF
--- a/src/components/sbb-menu/sbb-menu.tsx
+++ b/src/components/sbb-menu/sbb-menu.tsx
@@ -344,12 +344,17 @@ export class SbbMenu implements ComponentInterface {
 
   // Set focus on the first focusable element.
   private _setDialogFocus(): void {
-    if (sbbInputModalityDetector.mostRecentModality === 'keyboard') {
-      getFirstFocusableElement(
+    if (
+      sbbInputModalityDetector.mostRecentModality === 'keyboard' ||
+      sbbInputModalityDetector.mostRecentModality === 'touch'
+    ) {
+      const firstFocusable = getFirstFocusableElement(
         Array.from(this._element.children).filter(
           (e): e is HTMLElement => e instanceof window.HTMLElement,
         ),
-      )?.focus();
+      );
+      firstFocusable?.focus();
+      setModalityOnNextFocus(firstFocusable);
     } else {
       // Focusing sbb-menu__content in order to provide a consistent behavior in Safari where else
       // the focus-visible styles would be incorrectly applied

--- a/src/components/sbb-menu/sbb-menu.tsx
+++ b/src/components/sbb-menu/sbb-menu.tsx
@@ -353,8 +353,8 @@ export class SbbMenu implements ComponentInterface {
           (e): e is HTMLElement => e instanceof window.HTMLElement,
         ),
       );
-      firstFocusable?.focus();
       setModalityOnNextFocus(firstFocusable);
+      firstFocusable?.focus();
     } else {
       // Focusing sbb-menu__content in order to provide a consistent behavior in Safari where else
       // the focus-visible styles would be incorrectly applied


### PR DESCRIPTION
Sets the focus on the first focusable inside the menu on open (mobile).