### PR TITLE
refactor: inline event name map in components

### DIFF
--- a/ci/inline-events.mts
+++ b/ci/inline-events.mts
@@ -1,0 +1,121 @@
+import MagicString from 'magic-string';
+import glob from 'glob';
+import { readFileSync, writeFileSync } from 'fs';
+import { basename } from 'path';
+import ts from 'typescript';
+
+const componentsRoot = new URL('../src/components', import.meta.url);
+const files = glob.sync('**/*.tsx', { absolute: true, cwd: componentsRoot.pathname });
+
+for (const file of files.filter((f) => !f.includes('.stories.tsx'))) {
+  const content = readFileSync(file, 'utf8');
+  const magicString = new MagicString(content, { filename: file });
+  const sourceFile = ts.createSourceFile(file, content, ts.ScriptTarget.ES2021, true);
+
+  const className = basename(file, '.tsx')
+    .replace(/^\w/, (m) => m.toUpperCase())
+    .replace(/-\w/g, (m) => m[1].toUpperCase());
+
+  let events: ts.VariableDeclaration | null = null;
+  const eventUsages: ts.PropertyAccessExpression[] = [];
+  let styles: ts.PropertyDeclaration | null = null;
+  for (const node of iterateNodes(sourceFile)) {
+    if (ts.isVariableDeclaration(node) && node.name.getText() === 'events') {
+      events = node;
+    } else if (ts.isPropertyDeclaration(node) && node.name.getText() === 'styles') {
+      styles = node;
+    } else if (ts.isPropertyAccessExpression(node) && node.expression.getText() === 'events') {
+      eventUsages.push(node);
+    }
+  }
+
+  if (!events) {
+    console.log(file);
+    continue;
+  }
+
+  magicString.remove(events.parent.getStart(), events.parent.getStart() + events.parent.getWidth());
+  const exportKeyword = (events.parent.parent as ts.VariableStatement).modifiers![0]!;
+  magicString.remove(exportKeyword.getStart(), exportKeyword.getStart() + exportKeyword.getWidth());
+  magicString.appendRight(
+    styles!.getStart() + styles!.getWidth(),
+    `\n  public static readonly ${events.getText()} as const`,
+  );
+  for (const node of eventUsages) {
+    magicString.appendRight(node.getStart(), `${className}.`);
+  }
+
+  writeFileSync(file, magicString.toString(), 'utf8');
+
+  for (const fileEnding of ['.stories.tsx', '.spec.ts', '.e2e.ts']) {
+    const relFile = file.replace(/.tsx$/, fileEnding);
+    const relContent = readFileSync(relFile, 'utf8');
+    const relMagicString = new MagicString(relContent, { filename: relFile });
+    const relSourceFile = ts.createSourceFile(relFile, relContent, ts.ScriptTarget.ES2021, true);
+
+    let eventsImport: ts.ImportSpecifier | null = null;
+    let bareImport: ts.ImportDeclaration | null = null;
+    let hasClassImport = false;
+    const storiesEventUsages: ts.PropertyAccessExpression[] = [];
+    for (const node of iterateNodes(relSourceFile)) {
+      if (
+        ts.isImportSpecifier(node) &&
+        node.name.getText() === 'events' &&
+        node.parent.parent.parent.moduleSpecifier.getText().startsWith(`'./`)
+      ) {
+        eventsImport = node;
+      } else if (
+        ts.isImportSpecifier(node) &&
+        node.name.getText() === className &&
+        node.parent.parent.parent.moduleSpecifier.getText().startsWith(`'./`)
+      ) {
+        hasClassImport = true;
+      } else if (
+        ts.isImportDeclaration(node) &&
+        !node.importClause &&
+        node.moduleSpecifier.getText().startsWith(`'./`)
+      ) {
+        bareImport = node;
+      } else if (ts.isPropertyAccessExpression(node) && node.expression.getText() === 'events') {
+        storiesEventUsages.push(node);
+      }
+    }
+
+    if (!eventsImport) {
+      continue;
+    }
+
+    if (hasClassImport) {
+      relMagicString.remove(
+        eventsImport.getStart(),
+        eventsImport.getStart() + eventsImport.getWidth(),
+      );
+    } else {
+      relMagicString.remove(
+        eventsImport.getStart(),
+        eventsImport.getStart() + eventsImport.getWidth(),
+      );
+      relMagicString.appendRight(eventsImport.getStart(), className);
+      if (bareImport) {
+        relMagicString.remove(bareImport.getStart(), bareImport.getStart() + bareImport.getWidth());
+      }
+    }
+    for (const node of storiesEventUsages) {
+      relMagicString.appendRight(node.getStart(), `${className}.`);
+    }
+
+    writeFileSync(relFile, relMagicString.toString(), 'utf8');
+  }
+}
+
+function* iterateNodes(originNode: ts.Node) {
+  const nodes: ts.Node[] = [];
+  ts.forEachChild(originNode, (n) => {
+    // Must not return a number, so this is wrapped in a function body.
+    nodes.push(n);
+  });
+  for (const node of nodes) {
+    yield node;
+    yield* iterateNodes(node);
+  }
+}

--- a/src/components/sbb-accordion/sbb-accordion.e2e.ts
+++ b/src/components/sbb-accordion/sbb-accordion.e2e.ts
@@ -1,14 +1,10 @@
 import { waitForCondition, waitForLitRender } from '../../global/testing';
-import {
-  SbbExpansionPanel,
-  events as sbbExpansionPanelEvents,
-} from '../sbb-expansion-panel/sbb-expansion-panel';
+import { SbbExpansionPanel } from '../sbb-expansion-panel';
 import { assert, expect, fixture } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
 import { EventSpy } from '../../global/testing/event-spy';
 import { SbbAccordion } from './sbb-accordion';
-import { SbbExpansionPanelHeader } from '../sbb-expansion-panel-header';
-import '../sbb-expansion-panel';
+import { type SbbExpansionPanelHeader } from '../sbb-expansion-panel-header';
 import '../sbb-expansion-panel-header';
 import '../sbb-expansion-panel-content';
 
@@ -106,7 +102,7 @@ describe('sbb-accordion', () => {
   });
 
   it('should close others when expanding and multi = false', async () => {
-    const willOpenEventSpy = new EventSpy(sbbExpansionPanelEvents.willOpen);
+    const willOpenEventSpy = new EventSpy(SbbExpansionPanel.events.willOpen);
     const panelOne: SbbExpansionPanel = element.querySelector('#panel-1');
     const headerOne: SbbExpansionPanelHeader = element.querySelector('#header-1');
     const panelTwo: SbbExpansionPanel = element.querySelector('#panel-2');
@@ -143,7 +139,7 @@ describe('sbb-accordion', () => {
   it('should not change others when expanding and multi = false', async () => {
     element.multi = true;
     await waitForLitRender(element);
-    const willOpenEventSpy = new EventSpy(sbbExpansionPanelEvents.willOpen);
+    const willOpenEventSpy = new EventSpy(SbbExpansionPanel.events.willOpen);
     const panelOne: SbbExpansionPanel = element.querySelector('#panel-1');
     const headerOne: SbbExpansionPanelHeader = element.querySelector('#header-1');
     const panelTwo: SbbExpansionPanel = element.querySelector('#panel-2');
@@ -190,7 +186,7 @@ describe('sbb-accordion', () => {
       expect(panel.expanded).to.be.equal(false);
     }
 
-    const willOpenEventSpy = new EventSpy(sbbExpansionPanelEvents.willOpen);
+    const willOpenEventSpy = new EventSpy(SbbExpansionPanel.events.willOpen);
 
     headerTwo.click();
     await waitForCondition(() => willOpenEventSpy.events.length === 1);

--- a/src/components/sbb-accordion/sbb-accordion.stories.tsx
+++ b/src/components/sbb-accordion/sbb-accordion.stories.tsx
@@ -3,11 +3,10 @@ import { h, JSX } from 'jsx-dom';
 import readme from './readme.md?raw';
 import type { Meta, StoryObj, ArgTypes, Args } from '@storybook/web-components';
 import { InputType, StoryContext } from '@storybook/types';
-import { events as sbbExpansionPanelEvents } from '../sbb-expansion-panel/sbb-expansion-panel';
+import { SbbExpansionPanel } from '../sbb-expansion-panel';
 import { withActions } from '@storybook/addon-actions/decorator';
 import { Decorator } from '@storybook/web-components';
 import './sbb-accordion';
-import '../sbb-expansion-panel';
 import '../sbb-expansion-panel-header';
 import '../sbb-expansion-panel-content';
 import '../sbb-icon';
@@ -264,10 +263,10 @@ const meta: Meta = {
     },
     actions: {
       handles: [
-        sbbExpansionPanelEvents.willOpen,
-        sbbExpansionPanelEvents.didOpen,
-        sbbExpansionPanelEvents.willClose,
-        sbbExpansionPanelEvents.didClose,
+        SbbExpansionPanel.events.willOpen,
+        SbbExpansionPanel.events.didOpen,
+        SbbExpansionPanel.events.willClose,
+        SbbExpansionPanel.events.didClose,
       ],
     },
     docs: {

--- a/src/components/sbb-action-group/sbb-action-group.tsx
+++ b/src/components/sbb-action-group/sbb-action-group.tsx
@@ -8,7 +8,6 @@ import Style from './sbb-action-group.scss?lit&inline';
 /**
  * @slot unnamed - Slot to render the content inside the container.
  */
-
 @customElement('sbb-action-group')
 export class SbbActionGroup extends LitElement {
   public static override styles: CSSResult = Style;

--- a/src/components/sbb-alert-group/sbb-alert-group.e2e.ts
+++ b/src/components/sbb-alert-group/sbb-alert-group.e2e.ts
@@ -1,4 +1,3 @@
-import { events } from './sbb-alert-group';
 import { waitForCondition } from '../../global/testing';
 import { expect, fixture } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
@@ -27,8 +26,8 @@ describe('sbb-alert-group', () => {
         <sbb-alert title-content="Interruption" href="www.sbb.ch">Second</sbb-alert>
       </sbb-alert-group>
     `);
-    const didDismissAlertSpy = new EventSpy(events.didDismissAlert);
-    const emptySpy = new EventSpy(events.empty);
+    const didDismissAlertSpy = new EventSpy(SbbAlertGroup.events.didDismissAlert);
+    const emptySpy = new EventSpy(SbbAlertGroup.events.empty);
 
     // When rendering initially
     await waitForLitRender(element);
@@ -94,7 +93,7 @@ describe('sbb-alert-group', () => {
     element = await fixture(
       html`<sbb-alert-group accessibility-title="Disruptions"></sbb-alert-group>`,
     );
-    const emptySpy = new EventSpy(events.empty);
+    const emptySpy = new EventSpy(SbbAlertGroup.events.empty);
 
     // Then no title should be rendered and no empty event fired
     expect(element.shadowRoot.querySelector('.sbb-alert-group__title')).to.be.null;

--- a/src/components/sbb-alert-group/sbb-alert-group.stories.tsx
+++ b/src/components/sbb-alert-group/sbb-alert-group.stories.tsx
@@ -1,11 +1,11 @@
 /** @jsx h */
 import { h, JSX } from 'jsx-dom';
 import readme from './readme.md?raw';
-import { events } from './sbb-alert-group';
+import { SbbAlertGroup } from './sbb-alert-group';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/web-components';
 import type { InputType } from '@storybook/types';
-import './sbb-alert-group';
+
 import '../sbb-alert';
 
 const Template = (args): JSX.Element => (
@@ -82,7 +82,7 @@ const meta: Meta = {
   ],
   parameters: {
     actions: {
-      handles: [events.didDismissAlert, events.empty],
+      handles: [SbbAlertGroup.events.didDismissAlert, SbbAlertGroup.events.empty],
     },
     backgrounds: {
       disable: true,

--- a/src/components/sbb-alert-group/sbb-alert-group.tsx
+++ b/src/components/sbb-alert-group/sbb-alert-group.tsx
@@ -8,19 +8,17 @@ import { SbbAlert } from '../sbb-alert';
 import { setAttribute } from '../../global/dom';
 import Style from './sbb-alert-group.scss?lit&inline';
 
-export const events = {
-  didDismissAlert: 'did-dismiss-alert',
-  empty: 'empty',
-};
-
 /**
  * @slot unnamed - content slot, should be filled with `sbb-alert` items.
  * @slot accessibility-title - title for this sbb-alert-group which is only visible for screen reader users.
  */
-
 @customElement('sbb-alert-group')
 export class SbbAlertGroup extends LitElement {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    didDismissAlert: 'did-dismiss-alert',
+    empty: 'empty',
+  } as const;
 
   /**
    * The role attribute defines how to announce alerts to the user.
@@ -42,10 +40,13 @@ export class SbbAlertGroup extends LitElement {
   @state() private _hasAlerts: boolean;
 
   /** Emits when an alert was removed from DOM. */
-  private _didDismissAlert: EventEmitter<SbbAlert> = new EventEmitter(this, events.didDismissAlert);
+  private _didDismissAlert: EventEmitter<SbbAlert> = new EventEmitter(
+    this,
+    SbbAlertGroup.events.didDismissAlert,
+  );
 
   /** Emits when `sbb-alert-group` becomes empty. */
-  private _empty: EventEmitter<void> = new EventEmitter(this, events.empty);
+  private _empty: EventEmitter<void> = new EventEmitter(this, SbbAlertGroup.events.empty);
 
   private _abort = new ConnectedAbortController(this);
 

--- a/src/components/sbb-alert/sbb-alert.e2e.ts
+++ b/src/components/sbb-alert/sbb-alert.e2e.ts
@@ -1,4 +1,3 @@
-import { events } from './sbb-alert';
 import { waitForCondition } from '../../global/testing';
 import { assert, expect, fixture } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
@@ -14,8 +13,8 @@ describe('sbb-alert', () => {
   });
 
   it('should fire animation events', async () => {
-    const willPresentSpy = new EventSpy(events.willPresent);
-    const didPresentSpy = new EventSpy(events.didPresent);
+    const willPresentSpy = new EventSpy(SbbAlert.events.willPresent);
+    const didPresentSpy = new EventSpy(SbbAlert.events.didPresent);
 
     await fixture(html`<sbb-alert title-content="disruption">Interruption</sbb-alert>`);
 

--- a/src/components/sbb-alert/sbb-alert.stories.tsx
+++ b/src/components/sbb-alert/sbb-alert.stories.tsx
@@ -1,11 +1,10 @@
 /** @jsx h */
-import { events } from './sbb-alert';
+import { SbbAlert } from './sbb-alert';
 import readme from './readme.md?raw';
 import { h, JSX } from 'jsx-dom';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/web-components';
 import type { InputType } from '@storybook/types';
-import './sbb-alert';
 
 const Default = ({ 'content-slot-text': contentSlotText, ...args }): JSX.Element => (
   <sbb-alert {...args}>{contentSlotText}</sbb-alert>
@@ -224,7 +223,11 @@ const meta: Meta = {
   ],
   parameters: {
     actions: {
-      handles: [events.willPresent, events.didPresent, events.dismissalRequested],
+      handles: [
+        SbbAlert.events.willPresent,
+        SbbAlert.events.didPresent,
+        SbbAlert.events.dismissalRequested,
+      ],
     },
     backgrounds: {
       disable: true,

--- a/src/components/sbb-alert/sbb-alert.tsx
+++ b/src/components/sbb-alert/sbb-alert.tsx
@@ -18,21 +18,19 @@ import '../sbb-divider';
 import '../sbb-link';
 import '../sbb-button';
 
-export const events = {
-  willPresent: 'will-present',
-  didPresent: 'did-present',
-  dismissalRequested: 'dismissal-requested',
-};
-
 /**
  * @slot icon - Should be a sbb-icon which is displayed next to the title. Styling is optimized for icons of type HIM-CUS.
  * @slot title - Title content.
  * @slot unnamed - Content of the alert.
  */
-
 @customElement('sbb-alert')
 export class SbbAlert extends LitElement implements LinkProperties {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    willPresent: 'will-present',
+    didPresent: 'did-present',
+    dismissalRequested: 'dismissal-requested',
+  } as const;
 
   /**
    * Whether the alert is readonly.
@@ -75,15 +73,15 @@ export class SbbAlert extends LitElement implements LinkProperties {
   @property({ attribute: 'accessibility-label' }) public accessibilityLabel: string | undefined;
 
   /** Emits when the fade in animation starts. */
-  private _willPresent: EventEmitter<void> = new EventEmitter(this, events.willPresent);
+  private _willPresent: EventEmitter<void> = new EventEmitter(this, SbbAlert.events.willPresent);
 
   /** Emits when the fade in animation ends and the button is displayed. */
-  private _didPresent: EventEmitter<void> = new EventEmitter(this, events.didPresent);
+  private _didPresent: EventEmitter<void> = new EventEmitter(this, SbbAlert.events.didPresent);
 
   /** Emits when dismissal of an alert was requested. */
   private _dismissalRequested: EventEmitter<void> = new EventEmitter(
     this,
-    events.dismissalRequested,
+    SbbAlert.events.dismissalRequested,
   );
 
   @state() private _currentLanguage = documentLanguage();

--- a/src/components/sbb-autocomplete/sbb-autocomplete.e2e.ts
+++ b/src/components/sbb-autocomplete/sbb-autocomplete.e2e.ts
@@ -1,5 +1,4 @@
-import { events } from './sbb-autocomplete';
-import { events as optionEvents } from '../sbb-option';
+import { SbbOption } from '../sbb-option';
 import { waitForCondition, waitForLitRender } from '../../global/testing';
 import { assert, expect, fixture } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
@@ -44,10 +43,10 @@ describe('sbb-autocomplete', () => {
   });
 
   it('opens and closes with mouse and keyboard', async () => {
-    const willOpenEventSpy = new EventSpy(events.willOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const willCloseEventSpy = new EventSpy(events.willClose);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const willOpenEventSpy = new EventSpy(SbbAutocomplete.events.willOpen);
+    const didOpenEventSpy = new EventSpy(SbbAutocomplete.events.didOpen);
+    const willCloseEventSpy = new EventSpy(SbbAutocomplete.events.willClose);
+    const didCloseEventSpy = new EventSpy(SbbAutocomplete.events.didClose);
 
     input.click();
     await waitForCondition(() => willOpenEventSpy.events.length === 1);
@@ -96,9 +95,9 @@ describe('sbb-autocomplete', () => {
   });
 
   it('select by mouse', async () => {
-    const willOpenEventSpy = new EventSpy(events.willOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const optionSelectedEventSpy = new EventSpy(optionEvents.optionSelected);
+    const willOpenEventSpy = new EventSpy(SbbAutocomplete.events.willOpen);
+    const didOpenEventSpy = new EventSpy(SbbAutocomplete.events.didOpen);
+    const optionSelectedEventSpy = new EventSpy(SbbOption.events.optionSelected);
 
     input.focus();
     await waitForCondition(() => willOpenEventSpy.events.length === 1);
@@ -116,9 +115,9 @@ describe('sbb-autocomplete', () => {
   });
 
   it('opens and select with keyboard', async () => {
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const didCloseEventSpy = new EventSpy(events.didClose);
-    const optionSelectedEventSpy = new EventSpy(optionEvents.optionSelected);
+    const didOpenEventSpy = new EventSpy(SbbAutocomplete.events.didOpen);
+    const didCloseEventSpy = new EventSpy(SbbAutocomplete.events.didClose);
+    const optionSelectedEventSpy = new EventSpy(SbbOption.events.optionSelected);
     const optOne = element.querySelector('#option-1');
     const optTwo = element.querySelector('#option-2');
     input.focus();

--- a/src/components/sbb-autocomplete/sbb-autocomplete.stories.tsx
+++ b/src/components/sbb-autocomplete/sbb-autocomplete.stories.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { h, JSX } from 'jsx-dom';
-import { events } from './sbb-autocomplete';
-import { events as optionEvents } from '../sbb-option';
+import { SbbAutocomplete } from './sbb-autocomplete';
+import { SbbOption } from '../sbb-option';
 import readme from './readme.md?raw';
 import { userEvent, within } from '@storybook/testing-library';
 import { waitForComponentsReady } from '../../global/testing/wait-for-components-ready';
@@ -18,7 +18,6 @@ import type {
 import type { InputType } from '@storybook/types';
 import { withActions } from '@storybook/addon-actions/decorator';
 import '../sbb-form-field';
-import './sbb-autocomplete';
 
 const wrapperStyle = (context: StoryContext): Record<string, string> => ({
   'background-color': context.args.negative
@@ -518,12 +517,12 @@ const meta: Meta = {
     chromatic: { disableSnapshot: false },
     actions: {
       handles: [
-        events.willOpen,
-        events.didOpen,
-        events.didClose,
-        events.willClose,
+        SbbAutocomplete.events.willOpen,
+        SbbAutocomplete.events.didOpen,
+        SbbAutocomplete.events.didClose,
+        SbbAutocomplete.events.willClose,
         'change',
-        optionEvents.optionSelected,
+        SbbOption.events.optionSelected,
       ],
     },
     backgrounds: {

--- a/src/components/sbb-autocomplete/sbb-autocomplete.tsx
+++ b/src/components/sbb-autocomplete/sbb-autocomplete.tsx
@@ -24,19 +24,18 @@ import Style from './sbb-autocomplete.scss?lit&inline';
 
 let nextId = 0;
 
-export const events = {
-  willOpen: 'will-open',
-  didOpen: 'did-open',
-  willClose: 'will-close',
-  didClose: 'did-close',
-};
-
 /**
  * @slot unnamed - Use this slot to project options.
  */
 @customElement('sbb-autocomplete')
 export class SbbAutocomplete extends LitElement {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    willOpen: 'will-open',
+    didOpen: 'did-open',
+    willClose: 'will-close',
+    didClose: 'did-close',
+  } as const;
 
   /**
    * The element where the autocomplete will attach; accepts both an element's id or an HTMLElement.
@@ -66,16 +65,16 @@ export class SbbAutocomplete extends LitElement {
   @state() private _state: SbbOverlayState = 'closed';
 
   /** Emits whenever the autocomplete starts the opening transition. */
-  private _willOpen: EventEmitter = new EventEmitter(this, events.willOpen);
+  private _willOpen: EventEmitter = new EventEmitter(this, SbbAutocomplete.events.willOpen);
 
   /** Emits whenever the autocomplete is opened. */
-  private _didOpen: EventEmitter = new EventEmitter(this, events.didOpen);
+  private _didOpen: EventEmitter = new EventEmitter(this, SbbAutocomplete.events.didOpen);
 
   /** Emits whenever the autocomplete begins the closing transition. */
-  private _willClose: EventEmitter = new EventEmitter(this, events.willClose);
+  private _willClose: EventEmitter = new EventEmitter(this, SbbAutocomplete.events.willClose);
 
   /** Emits whenever the autocomplete is closed. */
-  private _didClose: EventEmitter = new EventEmitter(this, events.didClose);
+  private _didClose: EventEmitter = new EventEmitter(this, SbbAutocomplete.events.didClose);
 
   private _overlay: HTMLElement;
   private _optionContainer: HTMLElement;

--- a/src/components/sbb-calendar/sbb-calendar.tsx
+++ b/src/components/sbb-calendar/sbb-calendar.tsx
@@ -57,13 +57,12 @@ interface CalendarKeyboardNavigationParameters {
   verticalOffset: number;
 }
 
-export const events = {
-  dateSelected: 'date-selected',
-};
-
 @customElement('sbb-calendar')
 export class SbbCalendar extends LitElement {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    dateSelected: 'date-selected',
+  } as const;
 
   /** If set to true, two months are displayed */
   @property({ type: Boolean }) public wide = false;
@@ -81,7 +80,10 @@ export class SbbCalendar extends LitElement {
   @property({ attribute: 'selected-date' }) public selectedDate: Date | string | number;
 
   /** Event emitted on date selection. */
-  private _dateSelected: EventEmitter<Date> = new EventEmitter(this, events.dateSelected);
+  private _dateSelected: EventEmitter<Date> = new EventEmitter(
+    this,
+    SbbCalendar.events.dateSelected,
+  );
 
   /** The currently active date. */
   @state() private _activeDate: Date;

--- a/src/components/sbb-card-badge/sbb-card-badge.tsx
+++ b/src/components/sbb-card-badge/sbb-card-badge.tsx
@@ -9,7 +9,6 @@ import Style from './sbb-card-badge.scss?lit&inline';
  * @slot unnamed - Content of the badge.
  * Content parts should be wrapped in `<span>` tags to achieve correct spacings.
  */
-
 @customElement('sbb-card-badge')
 export class SbbCardBadge extends LitElement {
   public static override styles: CSSResult = Style;

--- a/src/components/sbb-checkbox/sbb-checkbox.tsx
+++ b/src/components/sbb-checkbox/sbb-checkbox.tsx
@@ -27,11 +27,6 @@ const checkboxObserverConfig: MutationObserverInit = {
   attributeFilter: ['data-group-required', 'data-group-disabled'],
 };
 
-export const events = {
-  didChange: 'did-change',
-  stateChange: 'state-change',
-};
-
 /**
  * @slot unnamed - Slot used to render the checkbox label's text.
  * @slot icon - Slot used to render the checkbox icon (disabled inside a selection panel).
@@ -41,6 +36,10 @@ export const events = {
 @customElement('sbb-checkbox')
 export class SbbCheckbox extends LitElement {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    didChange: 'did-change',
+    stateChange: 'state-change',
+  } as const;
 
   /** Value of checkbox. */
   @property() public value?: string;
@@ -99,7 +98,7 @@ export class SbbCheckbox extends LitElement {
   /**
    * @deprecated only used for React. Will probably be removed once React 19 is available.
    */
-  private _didChange: EventEmitter = new EventEmitter(this, events.didChange, {
+  private _didChange: EventEmitter = new EventEmitter(this, SbbCheckbox.events.didChange, {
     bubbles: true,
     cancelable: true,
   });
@@ -112,7 +111,7 @@ export class SbbCheckbox extends LitElement {
 
   private _stateChange: EventEmitter<CheckboxStateChange> = new EventEmitter(
     this,
-    events.stateChange,
+    SbbCheckbox.events.stateChange,
     { bubbles: true },
   );
 

--- a/src/components/sbb-dialog/sbb-dialog.e2e.ts
+++ b/src/components/sbb-dialog/sbb-dialog.e2e.ts
@@ -1,4 +1,3 @@
-import { events } from './sbb-dialog';
 import { assert, expect, fixture } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
 import { sendKeys, setViewport } from '@web/test-runner-commands';
@@ -27,8 +26,8 @@ describe('sbb-dialog', () => {
 
   it('opens the dialog', async () => {
     const dialog = element.shadowRoot.querySelector('dialog');
-    const willOpen = new EventSpy(events.willOpen);
-    const didOpen = new EventSpy(events.didOpen);
+    const willOpen = new EventSpy(SbbDialog.events.willOpen);
+    const didOpen = new EventSpy(SbbDialog.events.didOpen);
 
     element.open();
     await waitForLitRender(element);
@@ -46,10 +45,10 @@ describe('sbb-dialog', () => {
   });
 
   it('closes the dialog', async () => {
-    const willOpen = new EventSpy(events.willOpen);
-    const didOpen = new EventSpy(events.didOpen);
-    const willClose = new EventSpy(events.willClose);
-    const didClose = new EventSpy(events.didClose);
+    const willOpen = new EventSpy(SbbDialog.events.willOpen);
+    const didOpen = new EventSpy(SbbDialog.events.didOpen);
+    const willClose = new EventSpy(SbbDialog.events.willClose);
+    const didClose = new EventSpy(SbbDialog.events.didClose);
     const dialog = element.shadowRoot.querySelector('dialog');
 
     element.open();
@@ -83,10 +82,10 @@ describe('sbb-dialog', () => {
   });
 
   it('closes the dialog on backdrop click', async () => {
-    const willOpen = new EventSpy(events.willOpen);
-    const didOpen = new EventSpy(events.didOpen);
-    const willClose = new EventSpy(events.willClose);
-    const didClose = new EventSpy(events.didClose);
+    const willOpen = new EventSpy(SbbDialog.events.willOpen);
+    const didOpen = new EventSpy(SbbDialog.events.didOpen);
+    const willClose = new EventSpy(SbbDialog.events.willClose);
+    const didClose = new EventSpy(SbbDialog.events.didClose);
     const dialog = element.shadowRoot.querySelector('dialog');
 
     element.open();
@@ -122,10 +121,10 @@ describe('sbb-dialog', () => {
   });
 
   it('does not close the dialog on backdrop click', async () => {
-    const willOpen = new EventSpy(events.willOpen);
-    const didOpen = new EventSpy(events.didOpen);
-    const willClose = new EventSpy(events.willClose);
-    const didClose = new EventSpy(events.didClose);
+    const willOpen = new EventSpy(SbbDialog.events.willOpen);
+    const didOpen = new EventSpy(SbbDialog.events.didOpen);
+    const willClose = new EventSpy(SbbDialog.events.willClose);
+    const didClose = new EventSpy(SbbDialog.events.didClose);
     const dialog = element.shadowRoot.querySelector('dialog');
 
     element.backdropAction = 'none';
@@ -163,10 +162,10 @@ describe('sbb-dialog', () => {
   it('closes the dialog on close button click', async () => {
     const dialog = element.shadowRoot.querySelector('dialog');
     const closeButton = element.shadowRoot.querySelector('[sbb-dialog-close]') as HTMLElement;
-    const willOpen = new EventSpy(events.willOpen);
-    const didOpen = new EventSpy(events.didOpen);
-    const willClose = new EventSpy(events.willClose);
-    const didClose = new EventSpy(events.didClose);
+    const willOpen = new EventSpy(SbbDialog.events.willOpen);
+    const didOpen = new EventSpy(SbbDialog.events.didOpen);
+    const willClose = new EventSpy(SbbDialog.events.willClose);
+    const didClose = new EventSpy(SbbDialog.events.didClose);
 
     element.open();
     await waitForLitRender(element);
@@ -198,10 +197,10 @@ describe('sbb-dialog', () => {
 
   it('closes the dialog on Esc key press', async () => {
     const dialog = element.shadowRoot.querySelector('dialog');
-    const willOpen = new EventSpy(events.willOpen);
-    const didOpen = new EventSpy(events.didOpen);
-    const willClose = new EventSpy(events.willClose);
-    const didClose = new EventSpy(events.didClose);
+    const willOpen = new EventSpy(SbbDialog.events.willOpen);
+    const didOpen = new EventSpy(SbbDialog.events.didOpen);
+    const willClose = new EventSpy(SbbDialog.events.willClose);
+    const didClose = new EventSpy(SbbDialog.events.didClose);
 
     element.open();
     await waitForLitRender(element);
@@ -236,10 +235,10 @@ describe('sbb-dialog', () => {
 
   it('does not have the fullscreen attribute', async () => {
     const dialog = element.shadowRoot.querySelector('dialog');
-    const willOpen = new EventSpy(events.willOpen);
-    const didOpen = new EventSpy(events.didOpen);
-    const willClose = new EventSpy(events.willClose);
-    const didClose = new EventSpy(events.didClose);
+    const willOpen = new EventSpy(SbbDialog.events.willOpen);
+    const didOpen = new EventSpy(SbbDialog.events.didOpen);
+    const willClose = new EventSpy(SbbDialog.events.willClose);
+    const didClose = new EventSpy(SbbDialog.events.didClose);
 
     element.open();
     await waitForLitRender(element);
@@ -283,10 +282,10 @@ describe('sbb-dialog', () => {
     `);
 
     const dialog = element.shadowRoot.querySelector('dialog');
-    const willOpen = new EventSpy(events.willOpen);
-    const didOpen = new EventSpy(events.didOpen);
-    const willClose = new EventSpy(events.willClose);
-    const didClose = new EventSpy(events.didClose);
+    const willOpen = new EventSpy(SbbDialog.events.willOpen);
+    const didOpen = new EventSpy(SbbDialog.events.didOpen);
+    const willClose = new EventSpy(SbbDialog.events.willClose);
+    const didClose = new EventSpy(SbbDialog.events.didClose);
 
     element.open();
     await waitForLitRender(element);
@@ -334,10 +333,10 @@ describe('sbb-dialog', () => {
     `);
 
     const dialog = element.shadowRoot.querySelector('dialog');
-    const willOpen = new EventSpy(events.willOpen);
-    const didOpen = new EventSpy(events.didOpen);
-    const willClose = new EventSpy(events.willClose);
-    const didClose = new EventSpy(events.didClose);
+    const willOpen = new EventSpy(SbbDialog.events.willOpen);
+    const didOpen = new EventSpy(SbbDialog.events.didOpen);
+    const willClose = new EventSpy(SbbDialog.events.willClose);
+    const didClose = new EventSpy(SbbDialog.events.didClose);
 
     element.open();
     await waitForLitRender(element);
@@ -419,10 +418,10 @@ describe('sbb-dialog', () => {
         </sbb-dialog>
       </sbb-dialog>
     `);
-    const willOpen = new EventSpy(events.willOpen);
-    const didOpen = new EventSpy(events.didOpen);
-    const willClose = new EventSpy(events.willClose);
-    const didClose = new EventSpy(events.didClose);
+    const willOpen = new EventSpy(SbbDialog.events.willOpen);
+    const didOpen = new EventSpy(SbbDialog.events.didOpen);
+    const willClose = new EventSpy(SbbDialog.events.willClose);
+    const didClose = new EventSpy(SbbDialog.events.didClose);
     const outerDialog = element.shadowRoot.querySelector('dialog');
     const innerElement = element.querySelector('sbb-dialog') as SbbDialog;
     const innerDialog = element.querySelector('sbb-dialog').shadowRoot.querySelector('dialog');

--- a/src/components/sbb-dialog/sbb-dialog.stories.tsx
+++ b/src/components/sbb-dialog/sbb-dialog.stories.tsx
@@ -1,5 +1,5 @@
 /** @jsx h */
-import { events } from './sbb-dialog';
+import { SbbDialog } from './sbb-dialog';
 import { Fragment, h, JSX } from 'jsx-dom';
 import readme from './readme.md?raw';
 import sampleImages from '../../global/images';
@@ -10,7 +10,7 @@ import { waitForStablePosition } from '../../global/testing/wait-for-stable-posi
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/web-components';
 import type { InputType } from '@storybook/types';
-import './sbb-dialog';
+
 import '../sbb-button';
 import '../sbb-link';
 import '../sbb-title';
@@ -417,11 +417,11 @@ const meta: Meta = {
     chromatic: { disableSnapshot: false },
     actions: {
       handles: [
-        events.willOpen,
-        events.didOpen,
-        events.willClose,
-        events.didClose,
-        events.backClick,
+        SbbDialog.events.willOpen,
+        SbbDialog.events.didOpen,
+        SbbDialog.events.willClose,
+        SbbDialog.events.didClose,
+        SbbDialog.events.backClick,
       ],
     },
     backgrounds: {

--- a/src/components/sbb-dialog/sbb-dialog.tsx
+++ b/src/components/sbb-dialog/sbb-dialog.tsx
@@ -38,18 +38,16 @@ let nextId = 0;
  * @slot title - Use this slot to provide a title.
  * @slot action-group - Use this slot to display an action group in the footer.
  */
-
-export const events = {
-  willOpen: 'will-open',
-  didOpen: 'did-open',
-  willClose: 'will-close',
-  didClose: 'did-close',
-  backClick: 'request-back-action',
-};
-
 @customElement('sbb-dialog')
 export class SbbDialog extends LitElement {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    willOpen: 'will-open',
+    didOpen: 'did-open',
+    willClose: 'will-close',
+    didClose: 'did-close',
+    backClick: 'request-back-action',
+  } as const;
 
   /**
    * Dialog title.
@@ -125,27 +123,27 @@ export class SbbDialog extends LitElement {
   /**
    * Emits whenever the dialog starts the opening transition.
    */
-  private _willOpen: EventEmitter<void> = new EventEmitter(this, events.willOpen);
+  private _willOpen: EventEmitter<void> = new EventEmitter(this, SbbDialog.events.willOpen);
 
   /**
    * Emits whenever the dialog is opened.
    */
-  private _didOpen: EventEmitter<void> = new EventEmitter(this, events.didOpen);
+  private _didOpen: EventEmitter<void> = new EventEmitter(this, SbbDialog.events.didOpen);
 
   /**
    * Emits whenever the dialog begins the closing transition.
    */
-  private _willClose: EventEmitter = new EventEmitter(this, events.willClose);
+  private _willClose: EventEmitter = new EventEmitter(this, SbbDialog.events.willClose);
 
   /**
    * Emits whenever the dialog is closed.
    */
-  private _didClose: EventEmitter = new EventEmitter(this, events.didClose);
+  private _didClose: EventEmitter = new EventEmitter(this, SbbDialog.events.didClose);
 
   /**
    * Emits whenever the back button is clicked.
    */
-  private _backClick: EventEmitter<void> = new EventEmitter(this, events.backClick);
+  private _backClick: EventEmitter<void> = new EventEmitter(this, SbbDialog.events.backClick);
 
   private _dialog: HTMLDialogElement;
   private _dialogWrapperElement: HTMLElement;

--- a/src/components/sbb-expansion-panel-header/sbb-expansion-panel-header.tsx
+++ b/src/components/sbb-expansion-panel-header/sbb-expansion-panel-header.tsx
@@ -18,13 +18,12 @@ import '../sbb-icon';
  * @slot icon - Slot used to render the panel header icon.
  * @slot unnamed - Slot used to render the panel header text.
  */
-export const events = {
-  toggleExpanded: 'toggle-expanded',
-};
-
 @customElement('sbb-expansion-panel-header')
 export class SbbExpansionPanelHeader extends LitElement {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    toggleExpanded: 'toggle-expanded',
+  } as const;
 
   /**
    * The icon name we want to use, choose from the small icon variants
@@ -39,9 +38,13 @@ export class SbbExpansionPanelHeader extends LitElement {
   /** State of listed named slots, by indicating whether any element for a named slot is defined. */
   @state() private _namedSlots = createNamedSlotState('icon');
 
-  private _toggleExpanded: EventEmitter = new EventEmitter(this, events.toggleExpanded, {
-    bubbles: true,
-  });
+  private _toggleExpanded: EventEmitter = new EventEmitter(
+    this,
+    SbbExpansionPanelHeader.events.toggleExpanded,
+    {
+      bubbles: true,
+    },
+  );
   private _abort = new ConnectedAbortController(this);
 
   private _handlerRepository = new HandlerRepository(

--- a/src/components/sbb-expansion-panel/sbb-expansion-panel.e2e.ts
+++ b/src/components/sbb-expansion-panel/sbb-expansion-panel.e2e.ts
@@ -1,15 +1,10 @@
 import { waitForCondition, waitForLitRender } from '../../global/testing';
-import {
-  SbbExpansionPanelHeader,
-  events as sbbExpansionPanelHeaderEvents,
-} from '../sbb-expansion-panel-header/sbb-expansion-panel-header';
-import { events as sbbExpansionPanelEvents } from './sbb-expansion-panel';
+import { SbbExpansionPanelHeader } from '../sbb-expansion-panel-header';
 import { assert, expect, fixture } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
 import { EventSpy } from '../../global/testing/event-spy';
 import { SbbExpansionPanel } from './sbb-expansion-panel';
 import { SbbExpansionPanelContent } from '../sbb-expansion-panel-content';
-import '../sbb-expansion-panel-header';
 import '../sbb-expansion-panel-content';
 
 describe('sbb-expansion-panel', () => {
@@ -61,11 +56,11 @@ describe('sbb-expansion-panel', () => {
     expect(header.getAttribute('aria-expanded')).to.be.equal('false');
     expect(content.getAttribute('aria-hidden')).to.be.equal('true');
 
-    const toggleExpandedEventSpy = new EventSpy(sbbExpansionPanelHeaderEvents.toggleExpanded);
-    const willOpenEventSpy = new EventSpy(sbbExpansionPanelEvents.willOpen);
-    const willCloseEventSpy = new EventSpy(sbbExpansionPanelEvents.willClose);
-    const didOpenEventSpy = new EventSpy(sbbExpansionPanelEvents.didOpen);
-    const didCloseEventSpy = new EventSpy(sbbExpansionPanelEvents.didClose);
+    const toggleExpandedEventSpy = new EventSpy(SbbExpansionPanelHeader.events.toggleExpanded);
+    const willOpenEventSpy = new EventSpy(SbbExpansionPanel.events.willOpen);
+    const willCloseEventSpy = new EventSpy(SbbExpansionPanel.events.willClose);
+    const didOpenEventSpy = new EventSpy(SbbExpansionPanel.events.didOpen);
+    const didCloseEventSpy = new EventSpy(SbbExpansionPanel.events.didClose);
 
     header.click();
     await waitForCondition(() => toggleExpandedEventSpy.events.length === 1);

--- a/src/components/sbb-expansion-panel/sbb-expansion-panel.stories.tsx
+++ b/src/components/sbb-expansion-panel/sbb-expansion-panel.stories.tsx
@@ -1,13 +1,12 @@
 /** @jsx h */
-import { events } from './sbb-expansion-panel';
-import { events as panelHeaderEvents } from '../sbb-expansion-panel-header/sbb-expansion-panel-header';
+import { SbbExpansionPanel } from './sbb-expansion-panel';
+import { SbbExpansionPanelHeader } from '../sbb-expansion-panel-header';
 import { h, JSX } from 'jsx-dom';
 import readme from './readme.md?raw';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/web-components';
 import { InputType, StoryContext } from '@storybook/types';
-import './sbb-expansion-panel';
-import '../sbb-expansion-panel-header';
+
 import '../sbb-expansion-panel-content';
 import '../sbb-icon';
 
@@ -208,11 +207,11 @@ const meta: Meta = {
   parameters: {
     actions: {
       handles: [
-        events.willOpen,
-        events.didOpen,
-        events.willClose,
-        events.didClose,
-        panelHeaderEvents.toggleExpanded,
+        SbbExpansionPanel.events.willOpen,
+        SbbExpansionPanel.events.didOpen,
+        SbbExpansionPanel.events.willClose,
+        SbbExpansionPanel.events.didClose,
+        SbbExpansionPanelHeader.events.toggleExpanded,
       ],
     },
     backgrounds: {

--- a/src/components/sbb-expansion-panel/sbb-expansion-panel.tsx
+++ b/src/components/sbb-expansion-panel/sbb-expansion-panel.tsx
@@ -16,16 +16,15 @@ let nextId = 0;
  * @slot header - Use this to render the sbb-expansion-panel-header.
  * @slot content - Use this to render the sbb-expansion-panel-content.
  */
-export const events = {
-  willOpen: 'will-open',
-  didOpen: 'did-open',
-  willClose: 'will-close',
-  didClose: 'did-close',
-};
-
 @customElement('sbb-expansion-panel')
 export class SbbExpansionPanel extends LitElement {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    willOpen: 'will-open',
+    didOpen: 'did-open',
+    willClose: 'will-close',
+    didClose: 'did-close',
+  } as const;
 
   /** Heading level; if unset, a `div` will be rendered. */
   @property({ attribute: 'title-level' }) public titleLevel?: TitleLevel;
@@ -67,16 +66,19 @@ export class SbbExpansionPanel extends LitElement {
   public disableAnimation = false;
 
   /** Emits whenever the sbb-expansion-panel starts the opening transition. */
-  private _willOpen: EventEmitter<void> = new EventEmitter(this, events.willOpen);
+  private _willOpen: EventEmitter<void> = new EventEmitter(this, SbbExpansionPanel.events.willOpen);
 
   /** Emits whenever the sbb-expansion-panel is opened. */
-  private _didOpen: EventEmitter<void> = new EventEmitter(this, events.didOpen);
+  private _didOpen: EventEmitter<void> = new EventEmitter(this, SbbExpansionPanel.events.didOpen);
 
   /** Emits whenever the sbb-expansion-panel begins the closing transition. */
-  private _willClose: EventEmitter<void> = new EventEmitter(this, events.willClose);
+  private _willClose: EventEmitter<void> = new EventEmitter(
+    this,
+    SbbExpansionPanel.events.willClose,
+  );
 
   /** Emits whenever the sbb-expansion-panel is closed. */
-  private _didClose: EventEmitter<void> = new EventEmitter(this, events.didClose);
+  private _didClose: EventEmitter<void> = new EventEmitter(this, SbbExpansionPanel.events.didClose);
 
   private _abort = new ConnectedAbortController(this);
   private _state: SbbOverlayState = 'closed';

--- a/src/components/sbb-file-selector/sbb-file-selector.e2e.ts
+++ b/src/components/sbb-file-selector/sbb-file-selector.e2e.ts
@@ -1,7 +1,7 @@
 import { assert, expect, fixture } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
 import { EventSpy, waitForLitRender } from '../../global/testing';
-import { SbbFileSelector, events } from './sbb-file-selector';
+import { SbbFileSelector } from './sbb-file-selector';
 import { SbbButton } from '../sbb-button';
 
 function addFilesToComponentInput(
@@ -36,7 +36,7 @@ describe('sbb-file-selector', () => {
   });
 
   it('loads a file, then deletes it', async () => {
-    const fileChangedSpy = new EventSpy(events.fileChangedEvent);
+    const fileChangedSpy = new EventSpy(SbbFileSelector.events.fileChangedEvent);
     addFilesToComponentInput(element, 1);
     await waitForLitRender(element);
 
@@ -71,7 +71,7 @@ describe('sbb-file-selector', () => {
   });
 
   it('loads more than one file in multiple mode', async () => {
-    const fileChangedSpy = new EventSpy(events.fileChangedEvent);
+    const fileChangedSpy = new EventSpy(SbbFileSelector.events.fileChangedEvent);
     element.multiple = true;
     await waitForLitRender(element);
     addFilesToComponentInput(element, 2);
@@ -92,7 +92,7 @@ describe('sbb-file-selector', () => {
   });
 
   it('loads files in multiple persistent mode', async () => {
-    const fileChangedSpy = new EventSpy(events.fileChangedEvent);
+    const fileChangedSpy = new EventSpy(SbbFileSelector.events.fileChangedEvent);
     element.multiple = true;
     element.multipleMode = 'persistent';
     await waitForLitRender(element);

--- a/src/components/sbb-file-selector/sbb-file-selector.stories.tsx
+++ b/src/components/sbb-file-selector/sbb-file-selector.stories.tsx
@@ -1,12 +1,11 @@
 /** @jsx h */
-import { events } from './sbb-file-selector';
+import { SbbFileSelector } from './sbb-file-selector';
 import { h, JSX } from 'jsx-dom';
 import readme from './readme.md?raw';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/web-components';
 import { InputType } from '@storybook/types';
 import '../sbb-form-error';
-import './sbb-file-selector';
 
 const variant: InputType = {
   control: {
@@ -178,7 +177,7 @@ const meta: Meta = {
   ],
   parameters: {
     actions: {
-      handles: [events.fileChangedEvent],
+      handles: [SbbFileSelector.events.fileChangedEvent],
     },
     backgrounds: {
       disable: true,

--- a/src/components/sbb-file-selector/sbb-file-selector.tsx
+++ b/src/components/sbb-file-selector/sbb-file-selector.tsx
@@ -24,16 +24,15 @@ import '../sbb-icon';
 
 export type DOMEvent = globalThis.Event;
 
-export const events = {
-  fileChangedEvent: 'file-changed',
-};
-
 /**
  * @slot error - Use this to provide a `sbb-form-error` to show an error message.
  */
 @customElement('sbb-file-selector')
 export class SbbFileSelector extends LitElement {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    fileChangedEvent: 'file-changed',
+  } as const;
 
   /** Whether the component has a dropzone area or not. */
   @property() public variant: 'default' | 'dropzone' = 'default';
@@ -67,7 +66,10 @@ export class SbbFileSelector extends LitElement {
   @state() private _namedSlots = createNamedSlotState('error');
 
   /** An event which is emitted each time the file list changes. */
-  private _fileChangedEvent: EventEmitter<File[]> = new EventEmitter(this, events.fileChangedEvent);
+  private _fileChangedEvent: EventEmitter<File[]> = new EventEmitter(
+    this,
+    SbbFileSelector.events.fileChangedEvent,
+  );
 
   /**
    * Gets the currently selected files.

--- a/src/components/sbb-header-action/sbb-header-action.tsx
+++ b/src/components/sbb-header-action/sbb-header-action.tsx
@@ -27,7 +27,6 @@ import '../sbb-icon';
  * @slot icon - Slot used to render the action icon.
  * @slot unnamed - Slot used to render the action text.
  */
-
 @customElement('sbb-header-action')
 export class SbbHeaderAction extends LitElement implements LinkButtonProperties {
   public static override styles: CSSResult = Style;

--- a/src/components/sbb-header/sbb-header.e2e.ts
+++ b/src/components/sbb-header/sbb-header.e2e.ts
@@ -1,11 +1,10 @@
 import { assert, expect, fixture } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
 import { setViewport } from '@web/test-runner-commands';
-import { events } from '../sbb-menu';
+import { SbbMenu } from '../sbb-menu';
 import { EventSpy, waitForLitRender, mockScrollTo, waitForCondition } from '../../global/testing';
 import { SbbHeader } from './sbb-header';
 import '../sbb-header-action';
-import '../sbb-menu';
 import '../sbb-menu-action';
 
 describe('sbb-header', () => {
@@ -34,7 +33,7 @@ describe('sbb-header', () => {
 
   it('should hide/show on scroll', async () => {
     await fixture(html`
-      <sbb-header hide-on-scroll="true"></sbb-header>
+      <sbb-header hide-on-scroll></sbb-header>
       <div style="height: 2000px;"></div>
     `);
 
@@ -70,7 +69,7 @@ describe('sbb-header', () => {
 
   it('should close menu on scroll', async () => {
     await fixture(html`
-      <sbb-header hide-on-scroll="true">
+      <sbb-header hide-on-scroll>
         <sbb-header-action id="language-menu-trigger">English</sbb-header-action>
         <sbb-menu trigger="language-menu-trigger" disable-animation>
           <sbb-menu-action>Deutsch</sbb-menu-action>
@@ -92,8 +91,8 @@ describe('sbb-header', () => {
     expect(element).to.have.attribute('data-visible');
 
     // Open menu
-    const willOpenEventSpy = new EventSpy(events.willOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
+    const willOpenEventSpy = new EventSpy(SbbMenu.events.willOpen);
+    const didOpenEventSpy = new EventSpy(SbbMenu.events.didOpen);
     const menuTrigger = document.querySelector('sbb-header-action');
     menuTrigger.click();
     await waitForLitRender(element);

--- a/src/components/sbb-header/sbb-header.tsx
+++ b/src/components/sbb-header/sbb-header.tsx
@@ -10,7 +10,6 @@ const IS_MENU_OPENED_QUERY = "[aria-controls][aria-expanded='true']";
  * @slot unnamed - Slot used to render the actions on the left side.
  * @slot logo - Slot used to render the logo on the right side (sbb-logo as default).
  */
-
 @customElement('sbb-header')
 export class SbbHeader extends LitElement {
   public static override styles: CSSResult = Style;

--- a/src/components/sbb-menu/sbb-menu.e2e.ts
+++ b/src/components/sbb-menu/sbb-menu.e2e.ts
@@ -2,7 +2,7 @@ import { assert, expect, fixture } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
 import { sendKeys, setViewport } from '@web/test-runner-commands';
 import { EventSpy, waitForCondition, waitForLitRender } from '../../global/testing';
-import { SbbMenu, events } from './sbb-menu';
+import { SbbMenu } from './sbb-menu';
 import '../sbb-button';
 import '../sbb-menu-action';
 import '../sbb-link';
@@ -37,8 +37,8 @@ describe('sbb-menu', () => {
 
   it('opens on trigger click', async () => {
     const dialog = element.shadowRoot.querySelector('dialog');
-    const willOpenEventSpy = new EventSpy(events.willOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
+    const willOpenEventSpy = new EventSpy(SbbMenu.events.willOpen);
+    const didOpenEventSpy = new EventSpy(SbbMenu.events.didOpen);
 
     trigger.click();
     await waitForLitRender(element);
@@ -54,10 +54,10 @@ describe('sbb-menu', () => {
   });
 
   it('closes on Esc keypress', async () => {
-    const willOpenEventSpy = new EventSpy(events.willOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const willCloseEventSpy = new EventSpy(events.willClose);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const willOpenEventSpy = new EventSpy(SbbMenu.events.willOpen);
+    const didOpenEventSpy = new EventSpy(SbbMenu.events.didOpen);
+    const willCloseEventSpy = new EventSpy(SbbMenu.events.willClose);
+    const didCloseEventSpy = new EventSpy(SbbMenu.events.didClose);
     const dialog = element.shadowRoot.querySelector('dialog');
 
     trigger.click();
@@ -91,10 +91,10 @@ describe('sbb-menu', () => {
   });
 
   it('closes on menu action click', async () => {
-    const willOpenEventSpy = new EventSpy(events.willOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const willCloseEventSpy = new EventSpy(events.willClose);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const willOpenEventSpy = new EventSpy(SbbMenu.events.willOpen);
+    const didOpenEventSpy = new EventSpy(SbbMenu.events.didOpen);
+    const willCloseEventSpy = new EventSpy(SbbMenu.events.willClose);
+    const didCloseEventSpy = new EventSpy(SbbMenu.events.didClose);
     const dialog = element.shadowRoot.querySelector('dialog');
     const menuAction = document.querySelector('sbb-menu > sbb-menu-action') as HTMLElement;
 
@@ -126,10 +126,10 @@ describe('sbb-menu', () => {
   });
 
   it('closes on interactive element click', async () => {
-    const willOpenEventSpy = new EventSpy(events.willOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const willCloseEventSpy = new EventSpy(events.willClose);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const willOpenEventSpy = new EventSpy(SbbMenu.events.willOpen);
+    const didOpenEventSpy = new EventSpy(SbbMenu.events.didOpen);
+    const willCloseEventSpy = new EventSpy(SbbMenu.events.willClose);
+    const didCloseEventSpy = new EventSpy(SbbMenu.events.didClose);
     const dialog = element.shadowRoot.querySelector('dialog');
     const menuLink = document.querySelector('sbb-menu > sbb-link') as HTMLElement;
 
@@ -162,8 +162,8 @@ describe('sbb-menu', () => {
   });
 
   it('is correctly positioned on desktop', async () => {
-    const willOpenEventSpy = new EventSpy(events.willOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
+    const willOpenEventSpy = new EventSpy(SbbMenu.events.willOpen);
+    const didOpenEventSpy = new EventSpy(SbbMenu.events.didOpen);
     await setViewport({ width: 1200, height: 800 });
     const dialog = element.shadowRoot.querySelector('dialog');
 
@@ -196,8 +196,8 @@ describe('sbb-menu', () => {
   });
 
   it('is correctly positioned on mobile', async () => {
-    const willOpenEventSpy = new EventSpy(events.willOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
+    const willOpenEventSpy = new EventSpy(SbbMenu.events.willOpen);
+    const didOpenEventSpy = new EventSpy(SbbMenu.events.didOpen);
 
     await setViewport({ width: 800, height: 600 });
     const dialog = element.shadowRoot.querySelector('dialog');
@@ -223,8 +223,8 @@ describe('sbb-menu', () => {
   });
 
   it('sets the focus on the dialog content when the menu is opened by click', async () => {
-    const willOpenEventSpy = new EventSpy(events.willOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
+    const willOpenEventSpy = new EventSpy(SbbMenu.events.willOpen);
+    const didOpenEventSpy = new EventSpy(SbbMenu.events.didOpen);
     const dialog = element.shadowRoot.querySelector('dialog');
 
     trigger.click();
@@ -248,8 +248,8 @@ describe('sbb-menu', () => {
   });
 
   it('sets the focus to the first focusable element when the menu is opened by keyboard', async () => {
-    const willOpenEventSpy = new EventSpy(events.willOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
+    const willOpenEventSpy = new EventSpy(SbbMenu.events.willOpen);
+    const didOpenEventSpy = new EventSpy(SbbMenu.events.didOpen);
     const dialog = element.shadowRoot.querySelector('dialog');
 
     await sendKeys({ down: 'Tab' });

--- a/src/components/sbb-menu/sbb-menu.stories.tsx
+++ b/src/components/sbb-menu/sbb-menu.stories.tsx
@@ -1,5 +1,5 @@
 /** @jsx h */
-import { events } from './sbb-menu';
+import { SbbMenu } from './sbb-menu';
 import { Fragment, h, JSX } from 'jsx-dom';
 import readme from './readme.md?raw';
 import isChromatic from 'chromatic';
@@ -9,7 +9,7 @@ import { waitForStablePosition } from '../../global/testing/wait-for-stable-posi
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/web-components';
 import type { InputType } from '@storybook/types';
-import './sbb-menu';
+
 import '../sbb-button';
 
 // Story interaction executed after the story renders
@@ -279,7 +279,12 @@ const meta: Meta = {
   parameters: {
     chromatic: { disableSnapshot: false },
     actions: {
-      handles: [events.willOpen, events.didOpen, events.didClose, events.willClose],
+      handles: [
+        SbbMenu.events.willOpen,
+        SbbMenu.events.didOpen,
+        SbbMenu.events.didClose,
+        SbbMenu.events.willClose,
+      ],
     },
     backgrounds: {
       disable: true,

--- a/src/components/sbb-menu/sbb-menu.tsx
+++ b/src/components/sbb-menu/sbb-menu.tsx
@@ -37,16 +37,15 @@ let nextId = 0;
 /**
  * @slot unnamed - Use this slot to project any content inside the dialog.
  */
-export const events = {
-  willOpen: 'will-open',
-  didOpen: 'did-open',
-  willClose: 'will-close',
-  didClose: 'did-close',
-};
-
 @customElement('sbb-menu')
 export class SbbMenu extends LitElement {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    willOpen: 'will-open',
+    didOpen: 'did-open',
+    willClose: 'will-close',
+    didClose: 'did-close',
+  } as const;
 
   /**
    * The element that will trigger the menu dialog.
@@ -87,7 +86,7 @@ export class SbbMenu extends LitElement {
   /**
    * Emits whenever the menu starts the opening transition.
    */
-  private _willOpen: EventEmitter<void> = new EventEmitter(this, events.willOpen, {
+  private _willOpen: EventEmitter<void> = new EventEmitter(this, SbbMenu.events.willOpen, {
     bubbles: true,
     composed: true,
   });
@@ -95,7 +94,7 @@ export class SbbMenu extends LitElement {
   /**
    * Emits whenever the menu is opened.
    */
-  private _didOpen: EventEmitter<void> = new EventEmitter(this, events.didOpen, {
+  private _didOpen: EventEmitter<void> = new EventEmitter(this, SbbMenu.events.didOpen, {
     bubbles: true,
     composed: true,
   });
@@ -103,7 +102,7 @@ export class SbbMenu extends LitElement {
   /**
    * Emits whenever the menu begins the closing transition.
    */
-  private _willClose: EventEmitter<void> = new EventEmitter(this, events.willClose, {
+  private _willClose: EventEmitter<void> = new EventEmitter(this, SbbMenu.events.willClose, {
     bubbles: true,
     composed: true,
   });
@@ -111,7 +110,7 @@ export class SbbMenu extends LitElement {
   /**
    * Emits whenever the menu is closed.
    */
-  private _didClose: EventEmitter<void> = new EventEmitter(this, events.didClose, {
+  private _didClose: EventEmitter<void> = new EventEmitter(this, SbbMenu.events.didClose, {
     bubbles: true,
     composed: true,
   });

--- a/src/components/sbb-navigation-action/sbb-navigation-action.tsx
+++ b/src/components/sbb-navigation-action/sbb-navigation-action.tsx
@@ -25,7 +25,6 @@ import Style from './sbb-navigation-action.scss?lit&inline';
 /**
  * @slot unnamed - Use this slot to provide the navigation action label.
  */
-
 @customElement('sbb-navigation-action')
 export class SbbNavigationAction extends LitElement {
   public static override styles: CSSResult = Style;

--- a/src/components/sbb-navigation-list/sbb-navigation-list.tsx
+++ b/src/components/sbb-navigation-list/sbb-navigation-list.tsx
@@ -14,7 +14,6 @@ import Style from './sbb-navigation-list.scss?lit&inline';
  * @slot label - Use this to provide a label element.
  * @slot unnamed - Use this to provide content for sbb-navigation-list
  */
-
 @customElement('sbb-navigation-list')
 export class SbbNavigationList extends LitElement {
   public static override styles: CSSResult = Style;

--- a/src/components/sbb-navigation-marker/sbb-navigation-marker.tsx
+++ b/src/components/sbb-navigation-marker/sbb-navigation-marker.tsx
@@ -8,7 +8,6 @@ import Style from './sbb-navigation-marker.scss?lit&inline';
 /**
  * @slot unnamed - Use this slot to provide navigation actions into the sbb-navigation-marker.
  */
-
 @customElement('sbb-navigation-marker')
 export class SbbNavigationMarker extends LitElement {
   public static override styles: CSSResult = Style;

--- a/src/components/sbb-navigation-section/sbb-navigation-section.tsx
+++ b/src/components/sbb-navigation-section/sbb-navigation-section.tsx
@@ -33,7 +33,6 @@ let nextId = 0;
 /**
  * @slot unnamed - Use this to project any content inside the navigation section.
  */
-
 @customElement('sbb-navigation-section')
 export class SbbNavigationSection extends LitElement {
   public static override styles: CSSResult = Style;

--- a/src/components/sbb-navigation/sbb-navigation.e2e.ts
+++ b/src/components/sbb-navigation/sbb-navigation.e2e.ts
@@ -1,4 +1,3 @@
-import { events } from './sbb-navigation';
 import { waitForCondition, waitForLitRender } from '../../global/testing';
 import { aTimeout, assert, expect, fixture, nextFrame } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
@@ -40,7 +39,7 @@ describe('sbb-navigation', () => {
   });
 
   it('opens the navigation', async () => {
-    const didOpenEventSpy = new EventSpy(events.didOpen);
+    const didOpenEventSpy = new EventSpy(SbbNavigation.events.didOpen);
     const dialog = element.shadowRoot.querySelector('dialog');
 
     element.open();
@@ -55,8 +54,8 @@ describe('sbb-navigation', () => {
   });
 
   it('closes the navigation', async () => {
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const didOpenEventSpy = new EventSpy(SbbNavigation.events.didOpen);
+    const didCloseEventSpy = new EventSpy(SbbNavigation.events.didClose);
     const dialog = element.shadowRoot.querySelector('dialog');
 
     element.open();
@@ -79,8 +78,8 @@ describe('sbb-navigation', () => {
   });
 
   it('closes the navigation on close button click', async () => {
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const didOpenEventSpy = new EventSpy(SbbNavigation.events.didOpen);
+    const didCloseEventSpy = new EventSpy(SbbNavigation.events.didClose);
     const dialog = element.shadowRoot.querySelector('dialog');
     const closeButton = element.shadowRoot.querySelector('.sbb-navigation__close') as HTMLElement;
 
@@ -104,8 +103,8 @@ describe('sbb-navigation', () => {
   });
 
   it('closes the navigation on Esc key press', async () => {
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const didOpenEventSpy = new EventSpy(SbbNavigation.events.didOpen);
+    const didCloseEventSpy = new EventSpy(SbbNavigation.events.didClose);
     const dialog = element.shadowRoot.querySelector('dialog');
 
     element.open();
@@ -131,8 +130,8 @@ describe('sbb-navigation', () => {
   });
 
   it('closes navigation with sbb-navigation-close', async () => {
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const didOpenEventSpy = new EventSpy(SbbNavigation.events.didOpen);
+    const didCloseEventSpy = new EventSpy(SbbNavigation.events.didClose);
     const dialog = element.shadowRoot.querySelector('dialog');
     const sectionDialog = document
       .querySelector('sbb-navigation-section#first-section')
@@ -169,7 +168,7 @@ describe('sbb-navigation', () => {
   });
 
   it('opens navigation and opens section', async () => {
-    const didOpenEventSpy = new EventSpy(events.didOpen);
+    const didOpenEventSpy = new EventSpy(SbbNavigation.events.didOpen);
     const navDialog = element.shadowRoot.querySelector('dialog');
     const sectionDialog = document
       .querySelector('sbb-navigation-section#first-section')
@@ -196,7 +195,7 @@ describe('sbb-navigation', () => {
   });
 
   it('opens navigation and toggles sections', async () => {
-    const didOpenEventSpy = new EventSpy(events.didOpen);
+    const didOpenEventSpy = new EventSpy(SbbNavigation.events.didOpen);
     const navDialog = element.shadowRoot.querySelector('dialog');
     const firstSection = document.querySelector('#first-section');
     const secondSection = document.querySelector('#second-section');
@@ -235,8 +234,8 @@ describe('sbb-navigation', () => {
   });
 
   it('closes the navigation and the section on close button click', async () => {
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const didOpenEventSpy = new EventSpy(SbbNavigation.events.didOpen);
+    const didCloseEventSpy = new EventSpy(SbbNavigation.events.didClose);
     const dialog = element.shadowRoot.querySelector('dialog');
     const sectionDialog = document
       .querySelector('sbb-navigation-section#first-section')
@@ -273,8 +272,8 @@ describe('sbb-navigation', () => {
   });
 
   it('closes the navigation and the section on Esc key press', async () => {
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const didOpenEventSpy = new EventSpy(SbbNavigation.events.didOpen);
+    const didCloseEventSpy = new EventSpy(SbbNavigation.events.didClose);
     const dialog = element.shadowRoot.querySelector('dialog');
     const sectionDialog = document
       .querySelector('sbb-navigation-section#first-section')
@@ -311,7 +310,7 @@ describe('sbb-navigation', () => {
   });
 
   it('closes section with sbb-navigation-section-close', async () => {
-    const didOpenEventSpy = new EventSpy(events.didOpen);
+    const didOpenEventSpy = new EventSpy(SbbNavigation.events.didOpen);
     const dialog = element.shadowRoot.querySelector('dialog');
     const section = document.querySelector('#first-section');
     const sectionDialog = section.shadowRoot.querySelector('dialog');

--- a/src/components/sbb-navigation/sbb-navigation.stories.tsx
+++ b/src/components/sbb-navigation/sbb-navigation.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsx h */
 import { Fragment, h, JSX } from 'jsx-dom';
-import { events } from './sbb-navigation';
+import { SbbNavigation } from './sbb-navigation';
 import readme from './readme.md?raw';
 import isChromatic from 'chromatic';
 import { userEvent, waitFor, within } from '@storybook/testing-library';
@@ -9,7 +9,7 @@ import { waitForComponentsReady } from '../../global/testing/wait-for-components
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/web-components';
 import type { InputType } from '@storybook/types';
-import './sbb-navigation';
+
 import '../sbb-navigation-section';
 import '../sbb-navigation-marker';
 import '../sbb-navigation-list';
@@ -271,7 +271,12 @@ const meta: Meta = {
   parameters: {
     chromatic: { disableSnapshot: false },
     actions: {
-      handles: [events.willOpen, events.didOpen, events.didClose, events.willClose],
+      handles: [
+        SbbNavigation.events.willOpen,
+        SbbNavigation.events.didOpen,
+        SbbNavigation.events.didClose,
+        SbbNavigation.events.willClose,
+      ],
     },
     backgrounds: {
       disable: true,

--- a/src/components/sbb-navigation/sbb-navigation.tsx
+++ b/src/components/sbb-navigation/sbb-navigation.tsx
@@ -43,17 +43,15 @@ let nextId = 0;
 /**
  * @slot unnamed - Use this to project any content inside the navigation.
  */
-
-export const events = {
-  willOpen: 'will-open',
-  didOpen: 'did-open',
-  willClose: 'will-close',
-  didClose: 'did-close',
-};
-
 @customElement('sbb-navigation')
 export class SbbNavigation extends LitElement {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    willOpen: 'will-open',
+    didOpen: 'did-open',
+    willClose: 'will-close',
+    didClose: 'did-close',
+  } as const;
 
   /**
    * The element that will trigger the navigation.
@@ -104,22 +102,22 @@ export class SbbNavigation extends LitElement {
   /**
    * Emits whenever the navigation begins the opening transition.
    */
-  private _willOpen: EventEmitter<void> = new EventEmitter(this, events.willOpen);
+  private _willOpen: EventEmitter<void> = new EventEmitter(this, SbbNavigation.events.willOpen);
 
   /**
    * Emits whenever the navigation is opened.
    */
-  private _didOpen: EventEmitter<void> = new EventEmitter(this, events.didOpen);
+  private _didOpen: EventEmitter<void> = new EventEmitter(this, SbbNavigation.events.didOpen);
 
   /**
    * Emits whenever the navigation begins the closing transition.
    */
-  private _willClose: EventEmitter<void> = new EventEmitter(this, events.willClose);
+  private _willClose: EventEmitter<void> = new EventEmitter(this, SbbNavigation.events.willClose);
 
   /**
    * Emits whenever the navigation is closed.
    */
-  private _didClose: EventEmitter<void> = new EventEmitter(this, events.didClose);
+  private _didClose: EventEmitter<void> = new EventEmitter(this, SbbNavigation.events.didClose);
 
   private _navigation: HTMLDialogElement;
   private _navigationContainerElement: HTMLElement;

--- a/src/components/sbb-notification/sbb-notification.e2e.ts
+++ b/src/components/sbb-notification/sbb-notification.e2e.ts
@@ -1,5 +1,4 @@
 import { waitForCondition } from '../../global/testing';
-import { events } from './sbb-notification';
 import { assert, expect, fixture } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
 import { sendKeys } from '@web/test-runner-commands';
@@ -26,8 +25,8 @@ describe('sbb-notification', () => {
   });
 
   it('closes the notification and removes it from the DOM', async () => {
-    const willCloseEventSpy = new EventSpy(events.willClose);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const willCloseEventSpy = new EventSpy(SbbNotification.events.willClose);
+    const didCloseEventSpy = new EventSpy(SbbNotification.events.didClose);
 
     expect(element).not.to.be.null;
     expect(element).to.have.attribute('data-state', 'opened');
@@ -50,8 +49,8 @@ describe('sbb-notification', () => {
   });
 
   it('closes the notification and removes it from the DOM on close button click', async () => {
-    const willCloseEventSpy = new EventSpy(events.willClose);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const willCloseEventSpy = new EventSpy(SbbNotification.events.willClose);
+    const didCloseEventSpy = new EventSpy(SbbNotification.events.didClose);
     const closeButton = element.shadowRoot.querySelector('.sbb-notification__close') as SbbButton;
 
     expect(element).not.to.be.null;
@@ -75,8 +74,8 @@ describe('sbb-notification', () => {
   });
 
   it('closes the notification and removes it from the DOM on close button click by keyboard', async () => {
-    const willCloseEventSpy = new EventSpy(events.willClose);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const willCloseEventSpy = new EventSpy(SbbNotification.events.willClose);
+    const didCloseEventSpy = new EventSpy(SbbNotification.events.didClose);
     const closeButton = element.shadowRoot.querySelector('.sbb-notification__close') as SbbButton;
 
     expect(element).not.to.be.null;

--- a/src/components/sbb-notification/sbb-notification.stories.tsx
+++ b/src/components/sbb-notification/sbb-notification.stories.tsx
@@ -1,12 +1,12 @@
 /** @jsx h */
-import { events } from './sbb-notification';
+import { SbbNotification } from './sbb-notification';
 import { Fragment, h, JSX } from 'jsx-dom';
 import readme from './readme.md?raw';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/web-components';
 import type { InputType } from '@storybook/types';
 import isChromatic from 'chromatic/isChromatic';
-import './sbb-notification';
+
 import '../sbb-button';
 import '../sbb-link';
 
@@ -224,7 +224,12 @@ const meta: Meta = {
   ],
   parameters: {
     actions: {
-      handles: [events.didOpen, events.didClose, events.willOpen, events.willClose],
+      handles: [
+        SbbNotification.events.didOpen,
+        SbbNotification.events.didClose,
+        SbbNotification.events.willOpen,
+        SbbNotification.events.willClose,
+      ],
     },
     backgrounds: {
       disable: true,

--- a/src/components/sbb-notification/sbb-notification.tsx
+++ b/src/components/sbb-notification/sbb-notification.tsx
@@ -25,21 +25,19 @@ const notificationTypes = new Map([
   ['error', 'circle-cross-small'],
 ]);
 
-export const events = {
-  willOpen: 'will-open',
-  didOpen: 'did-open',
-  willClose: 'will-close',
-  didClose: 'did-close',
-};
-
 /**
  * @slot title - Use this to provide a notification title (optional).
  * @slot unnamed - Use this to provide the notification message.
  */
-
 @customElement('sbb-notification')
 export class SbbNotification extends LitElement {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    willOpen: 'will-open',
+    didOpen: 'did-open',
+    willClose: 'will-close',
+    didClose: 'did-close',
+  } as const;
 
   /**
    * The type of the notification.
@@ -89,22 +87,22 @@ export class SbbNotification extends LitElement {
   /**
    * Emits whenever the notification starts the opening transition.
    */
-  private _willOpen: EventEmitter<void> = new EventEmitter(this, events.willOpen);
+  private _willOpen: EventEmitter<void> = new EventEmitter(this, SbbNotification.events.willOpen);
 
   /**
    * Emits whenever the notification is opened.
    */
-  private _didOpen: EventEmitter<void> = new EventEmitter(this, events.didOpen);
+  private _didOpen: EventEmitter<void> = new EventEmitter(this, SbbNotification.events.didOpen);
 
   /**
    * Emits whenever the notification begins the closing transition.
    */
-  private _willClose: EventEmitter<void> = new EventEmitter(this, events.willClose);
+  private _willClose: EventEmitter<void> = new EventEmitter(this, SbbNotification.events.willClose);
 
   /**
    * Emits whenever the notification is closed.
    */
-  private _didClose: EventEmitter<void> = new EventEmitter(this, events.didClose);
+  private _didClose: EventEmitter<void> = new EventEmitter(this, SbbNotification.events.didClose);
 
   public close(): void {
     if (this._state === 'opened') {

--- a/src/components/sbb-option/sbb-option.e2e.ts
+++ b/src/components/sbb-option/sbb-option.e2e.ts
@@ -3,7 +3,7 @@ import { html } from 'lit/static-html.js';
 import { sendKeys } from '@web/test-runner-commands';
 import { EventSpy } from '../../global/testing/event-spy';
 import { waitForLitRender } from '../../global/testing';
-import { SbbOption, events } from './sbb-option';
+import { SbbOption } from './sbb-option';
 import { SbbFormField } from '../sbb-form-field';
 import '../sbb-autocomplete';
 import '../sbb-form-field';
@@ -31,7 +31,7 @@ describe('sbb-option', () => {
     });
 
     it('set selected and emits on click', async () => {
-      const selectionChangeSpy = new EventSpy(events.selectionChange);
+      const selectionChangeSpy = new EventSpy(SbbOption.events.selectionChange);
       const optionOne = element.querySelector('sbb-option');
 
       optionOne.dispatchEvent(new CustomEvent('click'));

--- a/src/components/sbb-option/sbb-option.stories.tsx
+++ b/src/components/sbb-option/sbb-option.stories.tsx
@@ -4,11 +4,10 @@ import readme from './readme.md?raw';
 import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/web-components';
 import type { InputType } from '@storybook/types';
 import { StoryContext } from '@storybook/web-components';
-import { events } from './sbb-option';
+import { SbbOption } from './sbb-option';
 import '../sbb-form-field';
 import '../sbb-select';
 import '../sbb-autocomplete';
-import './sbb-option';
 
 const wrapperStyle = (context: StoryContext): Record<string, string> => ({
   'background-color': context.args.negative
@@ -186,7 +185,7 @@ const meta: Meta = {
   ],
   parameters: {
     actions: {
-      handles: [events.selectionChange, events.optionSelected],
+      handles: [SbbOption.events.selectionChange, SbbOption.events.optionSelected],
     },
     backgrounds: {
       disable: true,

--- a/src/components/sbb-option/sbb-option.tsx
+++ b/src/components/sbb-option/sbb-option.tsx
@@ -22,11 +22,6 @@ const optionObserverConfig: MutationObserverInit = {
   attributeFilter: ['data-group-disabled', 'data-negative'],
 };
 
-export const events = {
-  selectionChange: 'option-selection-change',
-  optionSelected: 'option-selected',
-};
-
 /**
  * @slot unnamed - Use this to provide the option label.
  * @slot icon - Use this slot to provide an icon. If `icon-name` is set, a sbb-icon will be used.
@@ -36,6 +31,10 @@ export type SbbOptionVariant = 'autocomplete' | 'select';
 @customElement('sbb-option')
 export class SbbOption extends LitElement {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    selectionChange: 'option-selection-change',
+    optionSelected: 'option-selected',
+  } as const;
 
   /** Value of the option. */
   @property() public value?: string;
@@ -57,10 +56,10 @@ export class SbbOption extends LitElement {
   @property({ type: Boolean }) public disabled?: boolean;
 
   /** Emits when the option selection status changes. */
-  private _selectionChange: EventEmitter = new EventEmitter(this, events.selectionChange);
+  private _selectionChange: EventEmitter = new EventEmitter(this, SbbOption.events.selectionChange);
 
   /** Emits when an option was selected by user. */
-  private _optionSelected: EventEmitter = new EventEmitter(this, events.optionSelected);
+  private _optionSelected: EventEmitter = new EventEmitter(this, SbbOption.events.optionSelected);
 
   /** Wheter to apply the negative styling */
   @state() private _negative = false;

--- a/src/components/sbb-pearl-chain-vertical-item/sbb-pearl-chain-vertical-item.tsx
+++ b/src/components/sbb-pearl-chain-vertical-item/sbb-pearl-chain-vertical-item.tsx
@@ -24,7 +24,6 @@ export interface PearlChainVerticalItemAttributes {
  * @slot left - content of the left side of the item
  * @slot right - content of the right side of the item
  */
-
 @customElement('sbb-pearl-chain-vertical-item')
 export class SbbPearlChainVerticalItem extends LitElement {
   public static override styles: CSSResult = Style;

--- a/src/components/sbb-radio-button-group/sbb-radio-button-group.tsx
+++ b/src/components/sbb-radio-button-group/sbb-radio-button-group.tsx
@@ -19,16 +19,14 @@ import Style from './sbb-radio-button-group.scss?lit&inline';
  * @slot unnamed - Use this to provide radio buttons within the group.
  * @slot error - Use this to provide a `sbb-form-error` to show an error message.
  */
-
-export const events = {
-  didChange: 'did-change',
-  change: 'change',
-  input: 'input',
-};
-
 @customElement('sbb-radio-button-group')
 export class SbbRadioButtonGroup extends LitElement {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    didChange: 'did-change',
+    change: 'change',
+    input: 'input',
+  } as const;
 
   /**
    * Whether the radios can be deselected.
@@ -163,17 +161,17 @@ export class SbbRadioButtonGroup extends LitElement {
    * Emits whenever the radio group value changes.
    * @deprecated only used for React. Will probably be removed once React 19 is available.
    */
-  private _didChange: EventEmitter = new EventEmitter(this, events.didChange);
+  private _didChange: EventEmitter = new EventEmitter(this, SbbRadioButtonGroup.events.didChange);
 
   /**
    * Emits whenever the radio group value changes.
    */
-  private _change: EventEmitter = new EventEmitter(this, events.change);
+  private _change: EventEmitter = new EventEmitter(this, SbbRadioButtonGroup.events.change);
 
   /**
    * Emits whenever the radio group value changes.
    */
-  private _input: EventEmitter = new EventEmitter(this, events.input);
+  private _input: EventEmitter = new EventEmitter(this, SbbRadioButtonGroup.events.input);
 
   private _handlerRepository = new HandlerRepository(
     this,

--- a/src/components/sbb-radio-button/sbb-radio-button.e2e.ts
+++ b/src/components/sbb-radio-button/sbb-radio-button.e2e.ts
@@ -1,4 +1,3 @@
-import { events } from './sbb-radio-button';
 import { waitForCondition, waitForLitRender } from '../../global/testing';
 import { assert, expect, fixture } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
@@ -22,7 +21,7 @@ describe('sbb-radio-button', () => {
   });
 
   it('selects radio on click', async () => {
-    const stateChange = new EventSpy(events.stateChange);
+    const stateChange = new EventSpy(SbbRadioButton.events.stateChange);
 
     element.click();
     await waitForLitRender(element);
@@ -33,7 +32,7 @@ describe('sbb-radio-button', () => {
   });
 
   it('does not deselect radio if already checked', async () => {
-    const stateChange = new EventSpy(events.stateChange);
+    const stateChange = new EventSpy(SbbRadioButton.events.stateChange);
 
     element.click();
     await waitForLitRender(element);
@@ -49,7 +48,7 @@ describe('sbb-radio-button', () => {
   });
 
   it('allows empty selection', async () => {
-    const stateChange = new EventSpy(events.stateChange);
+    const stateChange = new EventSpy(SbbRadioButton.events.stateChange);
 
     element.allowEmptySelection = true;
     element.click();

--- a/src/components/sbb-radio-button/sbb-radio-button.tsx
+++ b/src/components/sbb-radio-button/sbb-radio-button.tsx
@@ -31,13 +31,12 @@ const radioButtonObserverConfig: MutationObserverInit = {
  * @slot subtext - Slot used to render a subtext under the label (only visible within a selection panel).
  * @slot suffix - Slot used to render additional content after the label (only visible within a selection panel).
  */
-export const events = {
-  stateChange: 'state-change',
-};
-
 @customElement('sbb-radio-button')
 export class SbbRadioButton extends LitElement {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    stateChange: 'state-change',
+  } as const;
 
   /**
    * Whether the radio can be deselected.
@@ -109,7 +108,7 @@ export class SbbRadioButton extends LitElement {
    */
   private _stateChange: EventEmitter<RadioButtonStateChange> = new EventEmitter(
     this,
-    events.stateChange,
+    SbbRadioButton.events.stateChange,
     { bubbles: true },
   );
 

--- a/src/components/sbb-select/sbb-select.e2e.ts
+++ b/src/components/sbb-select/sbb-select.e2e.ts
@@ -1,10 +1,10 @@
-import { SbbOption, events as optionEvents } from '../sbb-option';
+import { SbbOption } from '../sbb-option';
 import { waitForCondition, waitForLitRender } from '../../global/testing';
 import { aTimeout, assert, expect, fixture } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
 import { sendKeys } from '@web/test-runner-commands';
 import { EventSpy } from '../../global/testing/event-spy';
-import { events, SbbSelect } from './sbb-select';
+import { SbbSelect } from './sbb-select';
 
 describe('sbb-select', () => {
   let element: SbbSelect,
@@ -41,10 +41,10 @@ describe('sbb-select', () => {
   });
 
   it('opens and closes the dialog', async () => {
-    const willOpen = new EventSpy(events.willOpen);
-    const didOpen = new EventSpy(events.didOpen);
-    const willClose = new EventSpy(events.willClose);
-    const didClose = new EventSpy(events.didClose);
+    const willOpen = new EventSpy(SbbSelect.events.willOpen);
+    const didOpen = new EventSpy(SbbSelect.events.didOpen);
+    const willClose = new EventSpy(SbbSelect.events.willClose);
+    const didClose = new EventSpy(SbbSelect.events.didClose);
     element.dispatchEvent(new CustomEvent('click'));
     await waitForLitRender(element);
     await waitForCondition(() => willOpen.events.length === 1);
@@ -155,8 +155,8 @@ describe('sbb-select', () => {
     expect(displayValue).to.have.trimmed.text('First');
     expect(element.value).to.be.equal('1');
 
-    const willOpen = new EventSpy(events.willOpen);
-    const didOpen = new EventSpy(events.didOpen);
+    const willOpen = new EventSpy(SbbSelect.events.willOpen);
+    const didOpen = new EventSpy(SbbSelect.events.didOpen);
     element.click();
 
     await waitForCondition(() => willOpen.events.length === 1);
@@ -173,10 +173,10 @@ describe('sbb-select', () => {
     expect(secondOption).not.to.have.attribute('active');
     expect(secondOption).not.to.have.attribute('selected');
 
-    const selectionChange = new EventSpy(optionEvents.selectionChange);
-    const optionSelected = new EventSpy(optionEvents.optionSelected);
-    const willClose = new EventSpy(events.willClose);
-    const didClose = new EventSpy(events.didClose);
+    const selectionChange = new EventSpy(SbbOption.events.selectionChange);
+    const optionSelected = new EventSpy(SbbOption.events.optionSelected);
+    const willClose = new EventSpy(SbbSelect.events.willClose);
+    const didClose = new EventSpy(SbbSelect.events.didClose);
 
     secondOption.click();
     await waitForLitRender(element);
@@ -199,8 +199,8 @@ describe('sbb-select', () => {
     element.setAttribute('multiple', '');
     await waitForLitRender(element);
 
-    const willOpen = new EventSpy(events.willOpen);
-    const didOpen = new EventSpy(events.didOpen);
+    const willOpen = new EventSpy(SbbSelect.events.willOpen);
+    const didOpen = new EventSpy(SbbSelect.events.didOpen);
     element.dispatchEvent(new CustomEvent('click'));
 
     await waitForCondition(() => willOpen.events.length === 1);
@@ -213,7 +213,7 @@ describe('sbb-select', () => {
     expect(secondOption).not.to.have.attribute('active');
     expect(secondOption).not.to.have.attribute('selected');
 
-    const selectionChange = new EventSpy(optionEvents.selectionChange);
+    const selectionChange = new EventSpy(SbbOption.events.selectionChange);
     firstOption.dispatchEvent(new CustomEvent('click'));
     await waitForLitRender(element);
     expect(selectionChange.count).to.be.equal(1);
@@ -238,8 +238,8 @@ describe('sbb-select', () => {
   });
 
   it('handles keypress on host', async () => {
-    const didOpen = new EventSpy(events.didOpen);
-    const didClose = new EventSpy(events.didClose);
+    const didOpen = new EventSpy(SbbSelect.events.didOpen);
+    const didClose = new EventSpy(SbbSelect.events.didClose);
 
     focusableElement.focus();
     await sendKeys({ press: 'Enter' });
@@ -281,7 +281,7 @@ describe('sbb-select', () => {
   });
 
   it('handles keyboard selection', async () => {
-    const didOpen = new EventSpy(events.didOpen);
+    const didOpen = new EventSpy(SbbSelect.events.didOpen);
     focusableElement.focus();
     await sendKeys({ press: ' ' });
     await waitForCondition(() => didOpen.events.length === 1);
@@ -322,8 +322,8 @@ describe('sbb-select', () => {
     element.setAttribute('multiple', '');
     await waitForLitRender(element);
 
-    const didOpen = new EventSpy(events.didOpen);
-    const didClose = new EventSpy(events.didClose);
+    const didOpen = new EventSpy(SbbSelect.events.didOpen);
+    const didClose = new EventSpy(SbbSelect.events.didClose);
     focusableElement.focus();
     await sendKeys({ press: 'ArrowUp' });
     await waitForCondition(() => didOpen.events.length === 1);

--- a/src/components/sbb-select/sbb-select.stories.tsx
+++ b/src/components/sbb-select/sbb-select.stories.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { Fragment, h, JSX } from 'jsx-dom';
-import { events } from './sbb-select';
-import { events as optionEvents } from '../sbb-option';
+import { SbbSelect } from './sbb-select';
+import { SbbOption } from '../sbb-option';
 import readme from './readme.md?raw';
 import { userEvent, within } from '@storybook/testing-library';
 import { waitForComponentsReady } from '../../global/testing/wait-for-components-ready';
@@ -19,8 +19,6 @@ import type { InputType } from '@storybook/types';
 import { withActions } from '@storybook/addon-actions/decorator';
 import '../sbb-form-field';
 import '../sbb-optgroup';
-import '../sbb-option';
-import './sbb-select';
 
 const wrapperStyle = (context: StoryContext): Record<string, string> => ({
   'background-color': context.args.negative
@@ -647,12 +645,12 @@ const meta: Meta = {
     chromatic: { disableSnapshot: false },
     actions: {
       handles: [
-        events.change,
-        events.didClose,
-        events.didOpen,
-        events.willClose,
-        events.willOpen,
-        optionEvents.optionSelected,
+        SbbSelect.events.change,
+        SbbSelect.events.didClose,
+        SbbSelect.events.didOpen,
+        SbbSelect.events.willClose,
+        SbbSelect.events.willOpen,
+        SbbOption.events.optionSelected,
       ],
     },
     backgrounds: {

--- a/src/components/sbb-select/sbb-select.tsx
+++ b/src/components/sbb-select/sbb-select.tsx
@@ -27,23 +27,22 @@ export interface SelectChange {
   value: string | string[];
 }
 
-export const events = {
-  didChange: 'did-change',
-  change: 'change',
-  input: 'input',
-  stateChange: 'state-change',
-  willOpen: 'will-open',
-  didOpen: 'did-open',
-  willClose: 'will-close',
-  didClose: 'did-close',
-};
-
 /**
  * @slot unnamed - Use this slot to project options.
  */
 @customElement('sbb-select')
 export class SbbSelect extends LitElement {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    didChange: 'did-change',
+    change: 'change',
+    input: 'input',
+    stateChange: 'state-change',
+    willOpen: 'will-open',
+    didOpen: 'did-open',
+    willClose: 'will-close',
+    didClose: 'did-close',
+  } as const;
 
   /** The value of the select component. If `multiple` is true, it's an array. */
   @property() public value: string | string[];
@@ -79,28 +78,32 @@ export class SbbSelect extends LitElement {
   /**
    * @deprecated only used for React. Will probably be removed once React 19 is available.
    */
-  private _didChange: EventEmitter = new EventEmitter(this, events.didChange);
+  private _didChange: EventEmitter = new EventEmitter(this, SbbSelect.events.didChange);
 
-  private _change: EventEmitter = new EventEmitter(this, events.change);
+  private _change: EventEmitter = new EventEmitter(this, SbbSelect.events.change);
 
-  private _input: EventEmitter = new EventEmitter(this, events.input);
+  private _input: EventEmitter = new EventEmitter(this, SbbSelect.events.input);
 
   /** @internal */
-  private _stateChange: EventEmitter<SelectChange> = new EventEmitter(this, events.stateChange, {
-    composed: false,
-  });
+  private _stateChange: EventEmitter<SelectChange> = new EventEmitter(
+    this,
+    SbbSelect.events.stateChange,
+    {
+      composed: false,
+    },
+  );
 
   /** Emits whenever the select starts the opening transition. */
-  private _willOpen: EventEmitter<void> = new EventEmitter(this, events.willOpen);
+  private _willOpen: EventEmitter<void> = new EventEmitter(this, SbbSelect.events.willOpen);
 
   /** Emits whenever the select is opened. */
-  private _didOpen: EventEmitter<void> = new EventEmitter(this, events.didOpen);
+  private _didOpen: EventEmitter<void> = new EventEmitter(this, SbbSelect.events.didOpen);
 
   /** Emits whenever the select begins the closing transition. */
-  private _willClose: EventEmitter<void> = new EventEmitter(this, events.willClose);
+  private _willClose: EventEmitter<void> = new EventEmitter(this, SbbSelect.events.willClose);
 
   /** Emits whenever the select is closed. */
-  private _didClose: EventEmitter<void> = new EventEmitter(this, events.didClose);
+  private _didClose: EventEmitter<void> = new EventEmitter(this, SbbSelect.events.didClose);
 
   private _overlay: HTMLElement;
   private _optionContainer: HTMLElement;

--- a/src/components/sbb-tab-group/sbb-tab-group.stories.tsx
+++ b/src/components/sbb-tab-group/sbb-tab-group.stories.tsx
@@ -1,11 +1,10 @@
 /** @jsx h */
 import { h, JSX } from 'jsx-dom';
-import { events } from './sbb-tab-group';
+import { SbbTabGroup } from './sbb-tab-group';
 import readme from './readme.md?raw';
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/web-components';
 import type { InputType } from '@storybook/types';
-import './sbb-tab-group';
 
 const firstTabTitle = (label, args): JSX.Element => (
   <sbb-tab-title {...args}>{label}</sbb-tab-title>
@@ -226,7 +225,7 @@ export const tintedBackground: StoryObj = {
 const meta: Meta = {
   parameters: {
     actions: {
-      handles: [events.selectedTabChanged],
+      handles: [SbbTabGroup.events.selectedTabChanged],
     },
     backgrounds: {
       disable: true,

--- a/src/components/sbb-tab-group/sbb-tab-group.tsx
+++ b/src/components/sbb-tab-group/sbb-tab-group.tsx
@@ -26,14 +26,12 @@ let nextId = 0;
  * This is correct: `<div>Some text <p>Some other text</p></div>`
  * This is not correct: `<span>Some text</span><p>Some other text</p>`
  */
-
-export const events = {
-  selectedTabChanged: 'did-change',
-};
-
 @customElement('sbb-tab-group')
 export class SbbTabGroup extends LitElement {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    selectedTabChanged: 'did-change',
+  } as const;
 
   private _tabs: InterfaceSbbTabGroupTab[] = [];
   private _selectedTab: InterfaceSbbTabGroupTab;
@@ -83,7 +81,7 @@ export class SbbTabGroup extends LitElement {
    */
   private _selectedTabChanged: EventEmitter<void> = new EventEmitter(
     this,
-    events.selectedTabChanged,
+    SbbTabGroup.events.selectedTabChanged,
   );
 
   /**

--- a/src/components/sbb-tab-title/sbb-tab-title.tsx
+++ b/src/components/sbb-tab-title/sbb-tab-title.tsx
@@ -14,7 +14,6 @@ import Style from './sbb-tab-title.scss?lit&inline';
  * @slot icon - Use this slot to display an icon to the left of the title, by providing the `sbb-icon` component.
  * @slot amount - Provide a number to show an amount to the right of the title.
  */
-
 @customElement('sbb-tab-title')
 export class SbbTabTitle extends LitElement {
   public static override styles: CSSResult = Style;

--- a/src/components/sbb-tag/sbb-tag.tsx
+++ b/src/components/sbb-tag/sbb-tag.tsx
@@ -19,16 +19,15 @@ import Style from './sbb-tag.scss?lit&inline';
  * @slot icon - Use this slot to display an icon at the component start, by providing a `sbb-icon` component.
  * @slot amount - Provide an amount to show it at the component end.
  */
-export const events = {
-  stateChange: 'state-change',
-  input: 'input',
-  didChange: 'did-change',
-  change: 'change',
-};
-
 @customElement('sbb-tag')
 export class SbbTag extends LitElement implements ButtonProperties {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    stateChange: 'state-change',
+    input: 'input',
+    didChange: 'did-change',
+    change: 'change',
+  } as const;
 
   /** The name attribute to use for the button. */
   @property({ reflect: true }) public name: string | undefined;
@@ -73,21 +72,27 @@ export class SbbTag extends LitElement implements ButtonProperties {
    * Internal event that emits whenever the state of the tag
    * in relation to the parent toggle changes.
    */
-  private _stateChange: EventEmitter<TagStateChange> = new EventEmitter(this, events.stateChange, {
-    bubbles: true,
-  });
+  private _stateChange: EventEmitter<TagStateChange> = new EventEmitter(
+    this,
+    SbbTag.events.stateChange,
+    {
+      bubbles: true,
+    },
+  );
 
   /** Input event emitter */
-  private _input: EventEmitter = new EventEmitter(this, events.input, {
+  private _input: EventEmitter = new EventEmitter(this, SbbTag.events.input, {
     bubbles: true,
     composed: true,
   });
 
   /** @deprecated only used for React. Will probably be removed once React 19 is available. */
-  private _didChange: EventEmitter = new EventEmitter(this, events.didChange, { bubbles: true });
+  private _didChange: EventEmitter = new EventEmitter(this, SbbTag.events.didChange, {
+    bubbles: true,
+  });
 
   /** Change event emitter */
-  private _change: EventEmitter = new EventEmitter(this, events.change, { bubbles: true });
+  private _change: EventEmitter = new EventEmitter(this, SbbTag.events.change, { bubbles: true });
 
   private _abort = new ConnectedAbortController(this);
   private _handlerRepository = new HandlerRepository(

--- a/src/components/sbb-teaser-hero/sbb-teaser-hero.tsx
+++ b/src/components/sbb-teaser-hero/sbb-teaser-hero.tsx
@@ -25,7 +25,6 @@ import '../sbb-image';
  * @slot link-content - link content of the panel
  * @slot image - the background image, can be a `sbb-image`
  */
-
 @customElement('sbb-teaser-hero')
 export class SbbTeaserHero extends LitElement implements LinkProperties {
   public static override styles: CSSResult = Style;

--- a/src/components/sbb-time-input/sbb-time-input.stories.tsx
+++ b/src/components/sbb-time-input/sbb-time-input.stories.tsx
@@ -5,8 +5,8 @@ import { withActions } from '@storybook/addon-actions/decorator';
 import type { Args, ArgTypes, Decorator, Meta, StoryObj } from '@storybook/web-components';
 import type { InputType } from '@storybook/types';
 import { StoryContext } from '@storybook/web-components';
-import { events } from './sbb-time-input';
-import './sbb-time-input';
+import { SbbTimeInput } from './sbb-time-input';
+
 import '../sbb-form-field';
 
 const wrapperStyle = (context: StoryContext): Record<string, string> => ({
@@ -236,7 +236,7 @@ const TemplateSbbTimeInput = ({
   </Fragment>
 );
 
-export const SbbTimeInput: StoryObj = {
+export const SbbTimeInputBase: StoryObj = {
   render: TemplateSbbTimeInput,
   argTypes: { ...formFieldBasicArgsTypes },
   args: { ...formFieldBasicArgs },
@@ -347,7 +347,7 @@ const meta: Meta = {
   ],
   parameters: {
     actions: {
-      handles: ['change', 'input', events.validationChange],
+      handles: ['change', 'input', SbbTimeInput.events.validationChange],
     },
     backgrounds: {
       disable: true,

--- a/src/components/sbb-time-input/sbb-time-input.tsx
+++ b/src/components/sbb-time-input/sbb-time-input.tsx
@@ -22,14 +22,13 @@ interface Time {
   minutes: number;
 }
 
-export const events = {
-  didChange: 'didChange',
-  validationChange: 'validationChange',
-};
-
 @customElement('sbb-time-input')
 export class SbbTimeInput extends LitElement {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    didChange: 'didChange',
+    validationChange: 'validationChange',
+  } as const;
 
   /** Reference of the native input connected to the datepicker. */
   @property()
@@ -49,7 +48,7 @@ export class SbbTimeInput extends LitElement {
   /**
    * @deprecated only used for React. Will probably be removed once React 19 is available.
    */
-  private _didChange: EventEmitter = new EventEmitter(this, events.didChange, {
+  private _didChange: EventEmitter = new EventEmitter(this, SbbTimeInput.events.didChange, {
     bubbles: true,
     cancelable: true,
   });
@@ -57,7 +56,7 @@ export class SbbTimeInput extends LitElement {
   /** Emits whenever the internal validation state changes. */
   private _validationChange: EventEmitter<ValidationChangeEvent> = new EventEmitter(
     this,
-    events.validationChange,
+    SbbTimeInput.events.validationChange,
     {
       bubbles: true,
       composed: false,

--- a/src/components/sbb-toast/sbb-toast.e2e.ts
+++ b/src/components/sbb-toast/sbb-toast.e2e.ts
@@ -1,7 +1,7 @@
 import { assert, expect, fixture } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
 import { EventSpy, waitForCondition, waitForLitRender } from '../../global/testing';
-import { SbbToast, events } from './sbb-toast';
+import { SbbToast } from './sbb-toast';
 
 describe('sbb-toast', () => {
   let element: SbbToast;
@@ -18,10 +18,10 @@ describe('sbb-toast', () => {
   });
 
   it('opens and closes after timeout', async () => {
-    const willOpenEventSpy = new EventSpy(events.willOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const willCloseEventSpy = new EventSpy(events.willClose);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const willOpenEventSpy = new EventSpy(SbbToast.events.willOpen);
+    const didOpenEventSpy = new EventSpy(SbbToast.events.didOpen);
+    const willCloseEventSpy = new EventSpy(SbbToast.events.willClose);
+    const didCloseEventSpy = new EventSpy(SbbToast.events.didClose);
 
     element.setAttribute('timeout', '50');
     await waitForLitRender(element);
@@ -52,9 +52,9 @@ describe('sbb-toast', () => {
   });
 
   it('closes by dismiss button click', async () => {
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const willCloseEventSpy = new EventSpy(events.willClose);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const didOpenEventSpy = new EventSpy(SbbToast.events.didOpen);
+    const willCloseEventSpy = new EventSpy(SbbToast.events.willClose);
+    const didCloseEventSpy = new EventSpy(SbbToast.events.didClose);
 
     element.setAttribute('dismissible', '');
     await waitForLitRender(element);
@@ -86,9 +86,9 @@ describe('sbb-toast', () => {
     `);
     const actionBtn = element.querySelector('sbb-button') as HTMLElement;
 
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const willCloseEventSpy = new EventSpy(events.willClose);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const didOpenEventSpy = new EventSpy(SbbToast.events.didOpen);
+    const willCloseEventSpy = new EventSpy(SbbToast.events.willClose);
+    const didCloseEventSpy = new EventSpy(SbbToast.events.didClose);
 
     element.open();
     await waitForLitRender(element);

--- a/src/components/sbb-toast/sbb-toast.stories.tsx
+++ b/src/components/sbb-toast/sbb-toast.stories.tsx
@@ -1,5 +1,4 @@
 /** @jsx h */
-import './sbb-toast';
 import { Fragment, h, JSX } from 'jsx-dom';
 import readme from './readme.md?raw';
 import { withActions } from '@storybook/addon-actions/decorator';
@@ -8,7 +7,7 @@ import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/web-c
 import type { InputType } from '@storybook/types';
 import { within } from '@storybook/testing-library';
 import { waitForComponentsReady } from '../../global/testing/wait-for-components-ready';
-import { events, SbbToast } from './sbb-toast';
+import { SbbToast } from './sbb-toast';
 
 // Story interaction executed after the story renders
 const playStory = async ({ canvasElement }): Promise<void> => {
@@ -177,7 +176,12 @@ const meta: Meta = {
   parameters: {
     chromatic: { disableSnapshot: false },
     actions: {
-      handles: [events.willOpen, events.didOpen, events.willClose, events.didClose],
+      handles: [
+        SbbToast.events.willOpen,
+        SbbToast.events.didOpen,
+        SbbToast.events.willClose,
+        SbbToast.events.didClose,
+      ],
     },
     backgrounds: {
       disable: true,

--- a/src/components/sbb-toast/sbb-toast.tsx
+++ b/src/components/sbb-toast/sbb-toast.tsx
@@ -24,19 +24,18 @@ import '../sbb-button';
 // A global collection of existing toasts
 const toastRefs = new Set<SbbToast>();
 
-export const events = {
-  willOpen: 'will-open',
-  didOpen: 'did-open',
-  willClose: 'will-close',
-  didClose: 'did-close',
-};
-
 /**
  * @slot unnamed - Use this to document a slot.
  */
 @customElement('sbb-toast')
 export class SbbToast extends LitElement {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    willOpen: 'will-open',
+    didOpen: 'did-open',
+    willClose: 'will-close',
+    didClose: 'did-close',
+  } as const;
 
   /**
    * The length of time in milliseconds to wait before automatically dismissing the toast.
@@ -76,28 +75,28 @@ export class SbbToast extends LitElement {
 
   /** Emits whenever the autocomplete starts the opening transition. */
 
-  private _willOpen: EventEmitter<void> = new EventEmitter(this, events.willOpen, {
+  private _willOpen: EventEmitter<void> = new EventEmitter(this, SbbToast.events.willOpen, {
     bubbles: true,
     composed: true,
   });
 
   /** Emits whenever the autocomplete is opened. */
 
-  private _didOpen: EventEmitter<void> = new EventEmitter(this, events.didOpen, {
+  private _didOpen: EventEmitter<void> = new EventEmitter(this, SbbToast.events.didOpen, {
     bubbles: true,
     composed: true,
   });
 
   /** Emits whenever the autocomplete begins the closing transition. */
 
-  private _willClose: EventEmitter<void> = new EventEmitter(this, events.willClose, {
+  private _willClose: EventEmitter<void> = new EventEmitter(this, SbbToast.events.willClose, {
     bubbles: true,
     composed: true,
   });
 
   /** Emits whenever the autocomplete is closed. */
 
-  private _didClose: EventEmitter<void> = new EventEmitter(this, events.didClose, {
+  private _didClose: EventEmitter<void> = new EventEmitter(this, SbbToast.events.didClose, {
     bubbles: true,
     composed: true,
   });

--- a/src/components/sbb-toggle-check/sbb-toggle-check.tsx
+++ b/src/components/sbb-toggle-check/sbb-toggle-check.tsx
@@ -13,10 +13,6 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { setAttributes } from '../../global/dom';
 import Style from './sbb-toggle-check.scss?lit&inline';
 
-export const events = {
-  didChange: 'did-change',
-};
-
 /**
  * @slot unnamed - Use this slot to provide the toggle label.
  * @slot icon - Use this slot to provide an icon. If `icon-name` is set, a sbb-icon will be used.
@@ -24,6 +20,9 @@ export const events = {
 @customElement('sbb-toggle-check')
 export class SbbToggleCheck extends LitElement {
   public static override styles = Style;
+  public static readonly events = {
+    didChange: 'did-change',
+  } as const;
 
   /** Whether the toggle-check is checked. */
   @property({ reflect: true, type: Boolean }) public checked = false;
@@ -53,7 +52,7 @@ export class SbbToggleCheck extends LitElement {
   /**
    * @deprecated only used for React. Will probably be removed once React 19 is available.
    */
-  private _didChange: EventEmitter = new EventEmitter(this, events.didChange, {
+  private _didChange: EventEmitter = new EventEmitter(this, SbbToggleCheck.events.didChange, {
     bubbles: true,
     cancelable: true,
   });

--- a/src/components/sbb-toggle-option/sbb-toggle-option.tsx
+++ b/src/components/sbb-toggle-option/sbb-toggle-option.tsx
@@ -17,14 +17,12 @@ import Style from './sbb-toggle-option.scss?lit&inline';
  * @slot unnamed - Slot used to render the label of the toggle option.
  * @slot icon - Slot used to render the `<sbb-icon>`.
  */
-
-export const events = {
-  stateChange: 'state-change',
-};
-
 @customElement('sbb-toggle-option')
 export class SbbToggleOption extends LitElement {
   public static override styles = Style;
+  public static readonly events = {
+    stateChange: 'state-change',
+  } as const;
 
   /**
    * Whether the toggle-option is checked.
@@ -104,7 +102,7 @@ export class SbbToggleOption extends LitElement {
 
   private _stateChange: EventEmitter<ToggleOptionStateChange> = new EventEmitter(
     this,
-    events.stateChange,
+    SbbToggleOption.events.stateChange,
     { bubbles: true },
   );
 

--- a/src/components/sbb-toggle/sbb-toggle.tsx
+++ b/src/components/sbb-toggle/sbb-toggle.tsx
@@ -14,15 +14,13 @@ import Style from './sbb-toggle.scss?lit&inline';
 /**
  * @slot unnamed - Slot used to render the `<sbb-toggle-option>`.
  */
-
-export const events = {
-  didChange: 'did-change',
-  change: 'change',
-};
-
 @customElement('sbb-toggle')
 export class SbbToggle extends LitElement {
   public static override styles = Style;
+  public static readonly events = {
+    didChange: 'did-change',
+    change: 'change',
+  } as const;
 
   /**
    * Whether the toggle is disabled.
@@ -96,7 +94,7 @@ export class SbbToggle extends LitElement {
    * @deprecated only used for React. Will probably be removed once React 19 is available.
    */
 
-  private _didChange: EventEmitter = new EventEmitter(this, events.didChange, {
+  private _didChange: EventEmitter = new EventEmitter(this, SbbToggle.events.didChange, {
     bubbles: true,
     composed: true,
   });
@@ -105,7 +103,7 @@ export class SbbToggle extends LitElement {
    * Emits whenever the radio group value changes.
    */
 
-  private _change: EventEmitter = new EventEmitter(this, events.change, {
+  private _change: EventEmitter = new EventEmitter(this, SbbToggle.events.change, {
     bubbles: true,
     composed: true,
   });

--- a/src/components/sbb-tooltip-trigger/sbb-tooltip-trigger.e2e.ts
+++ b/src/components/sbb-tooltip-trigger/sbb-tooltip-trigger.e2e.ts
@@ -3,8 +3,7 @@ import { sendKeys } from '@web/test-runner-commands';
 import { html } from 'lit/static-html.js';
 import { waitForCondition } from '../../global/testing';
 import { EventSpy } from '../../global/testing/event-spy';
-import '../sbb-tooltip/sbb-tooltip';
-import { SbbTooltip, events } from '../sbb-tooltip/sbb-tooltip';
+import { SbbTooltip } from '../sbb-tooltip';
 import { SbbTooltipTrigger } from './sbb-tooltip-trigger';
 
 describe('sbb-tooltip-trigger', () => {
@@ -28,8 +27,8 @@ describe('sbb-tooltip-trigger', () => {
 
   it('shows tooltip on tooltip-trigger click', async () => {
     const dialog = tooltip.shadowRoot.querySelector('dialog');
-    const willOpenEventSpy = new EventSpy(events.willOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
+    const willOpenEventSpy = new EventSpy(SbbTooltip.events.willOpen);
+    const didOpenEventSpy = new EventSpy(SbbTooltip.events.didOpen);
 
     element.click();
 
@@ -43,7 +42,7 @@ describe('sbb-tooltip-trigger', () => {
 
   it("doesn't show tooltip on disabled tooltip-trigger click", async () => {
     const dialog = tooltip.shadowRoot.querySelector('dialog');
-    const willOpenEventSpy = new EventSpy(events.willOpen);
+    const willOpenEventSpy = new EventSpy(SbbTooltip.events.willOpen);
     element.disabled = true;
     element.click();
 

--- a/src/components/sbb-tooltip/sbb-tooltip.e2e.ts
+++ b/src/components/sbb-tooltip/sbb-tooltip.e2e.ts
@@ -7,7 +7,7 @@ import '../sbb-button';
 import { SbbButton } from '../sbb-button';
 import '../sbb-link';
 import './sbb-tooltip';
-import { SbbTooltip, events } from './sbb-tooltip';
+import { SbbTooltip } from './sbb-tooltip';
 
 describe('sbb-tooltip', () => {
   let element: SbbTooltip, trigger: SbbButton;
@@ -30,8 +30,8 @@ describe('sbb-tooltip', () => {
   });
 
   it('shows the tooltip', async () => {
-    const willOpenEventSpy = new EventSpy(events.willOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
+    const willOpenEventSpy = new EventSpy(SbbTooltip.events.willOpen);
+    const didOpenEventSpy = new EventSpy(SbbTooltip.events.didOpen);
     const dialog = element.shadowRoot.querySelector('dialog');
 
     element.open();
@@ -46,8 +46,8 @@ describe('sbb-tooltip', () => {
   });
 
   it('shows on trigger click', async () => {
-    const willOpenEventSpy = new EventSpy(events.willOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
+    const willOpenEventSpy = new EventSpy(SbbTooltip.events.willOpen);
+    const didOpenEventSpy = new EventSpy(SbbTooltip.events.didOpen);
     const dialog = element.shadowRoot.querySelector('dialog');
 
     trigger.click();
@@ -62,10 +62,10 @@ describe('sbb-tooltip', () => {
   });
 
   it('closes the tooltip', async () => {
-    const willOpenEventSpy = new EventSpy(events.willOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const willCloseEventSpy = new EventSpy(events.willClose);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const willOpenEventSpy = new EventSpy(SbbTooltip.events.willOpen);
+    const didOpenEventSpy = new EventSpy(SbbTooltip.events.didOpen);
+    const willCloseEventSpy = new EventSpy(SbbTooltip.events.willClose);
+    const didCloseEventSpy = new EventSpy(SbbTooltip.events.didClose);
     const dialog = element.shadowRoot.querySelector('dialog');
 
     element.open();
@@ -88,10 +88,10 @@ describe('sbb-tooltip', () => {
   });
 
   it('closes the tooltip on close button click', async () => {
-    const willOpenEventSpy = new EventSpy(events.willOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const willCloseEventSpy = new EventSpy(events.willClose);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const willOpenEventSpy = new EventSpy(SbbTooltip.events.willOpen);
+    const didOpenEventSpy = new EventSpy(SbbTooltip.events.didOpen);
+    const willCloseEventSpy = new EventSpy(SbbTooltip.events.willClose);
+    const didCloseEventSpy = new EventSpy(SbbTooltip.events.didClose);
     const dialog = element.shadowRoot.querySelector('dialog');
     const closeButton = element.shadowRoot.querySelector('[sbb-tooltip-close]') as HTMLElement;
 
@@ -118,10 +118,10 @@ describe('sbb-tooltip', () => {
   });
 
   it('closes on interactive element click', async () => {
-    const willOpenEventSpy = new EventSpy(events.willOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const willCloseEventSpy = new EventSpy(events.willClose);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const willOpenEventSpy = new EventSpy(SbbTooltip.events.willOpen);
+    const didOpenEventSpy = new EventSpy(SbbTooltip.events.didOpen);
+    const willCloseEventSpy = new EventSpy(SbbTooltip.events.willClose);
+    const didCloseEventSpy = new EventSpy(SbbTooltip.events.didClose);
     const dialog = element.shadowRoot.querySelector('dialog');
     const tooltipLink = document.querySelector('sbb-tooltip > sbb-link') as HTMLElement;
 
@@ -150,8 +150,8 @@ describe('sbb-tooltip', () => {
   });
 
   it('is correctly positioned on screen', async () => {
-    const willOpenEventSpy = new EventSpy(events.willOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
+    const willOpenEventSpy = new EventSpy(SbbTooltip.events.willOpen);
+    const didOpenEventSpy = new EventSpy(SbbTooltip.events.didOpen);
 
     await setViewport({ width: 1200, height: 800 });
     const dialog = element.shadowRoot.querySelector('dialog');
@@ -182,8 +182,8 @@ describe('sbb-tooltip', () => {
   });
 
   it('should set correct focus attribute on trigger after backdrop click', async () => {
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const didOpenEventSpy = new EventSpy(SbbTooltip.events.didOpen);
+    const didCloseEventSpy = new EventSpy(SbbTooltip.events.didClose);
 
     element.open();
 
@@ -203,8 +203,8 @@ describe('sbb-tooltip', () => {
     const interactiveBackgroundElement = document.querySelector(
       '#interactive-background-element',
     ) as HTMLElement;
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const didOpenEventSpy = new EventSpy(SbbTooltip.events.didOpen);
+    const didCloseEventSpy = new EventSpy(SbbTooltip.events.didClose);
 
     element.open();
 
@@ -221,8 +221,8 @@ describe('sbb-tooltip', () => {
   });
 
   it('closes on interactive element click by keyboard', async () => {
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const didOpenEventSpy = new EventSpy(SbbTooltip.events.didOpen);
+    const didCloseEventSpy = new EventSpy(SbbTooltip.events.didClose);
     const tooltipLink = document.querySelector('sbb-tooltip > sbb-link') as HTMLElement;
 
     trigger.click();
@@ -243,8 +243,8 @@ describe('sbb-tooltip', () => {
   });
 
   it('sets the focus to the first focusable element when the tooltip is opened by keyboard', async () => {
-    const willOpenEventSpy = new EventSpy(events.willOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
+    const willOpenEventSpy = new EventSpy(SbbTooltip.events.willOpen);
+    const didOpenEventSpy = new EventSpy(SbbTooltip.events.didOpen);
     const dialog = element.shadowRoot.querySelector('dialog');
 
     await sendKeys({ down: 'Tab' });
@@ -265,8 +265,8 @@ describe('sbb-tooltip', () => {
   });
 
   it('closes the tooltip on close button click by keyboard', async () => {
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const didOpenEventSpy = new EventSpy(SbbTooltip.events.didOpen);
+    const didCloseEventSpy = new EventSpy(SbbTooltip.events.didClose);
     const closeButton = document
       .querySelector('sbb-tooltip')
       .shadowRoot.querySelector('[sbb-tooltip-close]') as HTMLElement;
@@ -287,10 +287,10 @@ describe('sbb-tooltip', () => {
   });
 
   it('closes on Esc keypress', async () => {
-    const willOpenEventSpy = new EventSpy(events.willOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const willCloseEventSpy = new EventSpy(events.willClose);
-    const didCloseEventSpy = new EventSpy(events.didClose);
+    const willOpenEventSpy = new EventSpy(SbbTooltip.events.willOpen);
+    const didOpenEventSpy = new EventSpy(SbbTooltip.events.didOpen);
+    const willCloseEventSpy = new EventSpy(SbbTooltip.events.willClose);
+    const didCloseEventSpy = new EventSpy(SbbTooltip.events.didClose);
     const dialog = element.shadowRoot.querySelector('dialog');
 
     trigger.click();
@@ -318,8 +318,8 @@ describe('sbb-tooltip', () => {
   });
 
   it('sets the focus on the dialog content when the tooltip is opened by click', async () => {
-    const willOpenEventSpy = new EventSpy(events.willOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
+    const willOpenEventSpy = new EventSpy(SbbTooltip.events.willOpen);
+    const didOpenEventSpy = new EventSpy(SbbTooltip.events.didOpen);
     const dialog = element.shadowRoot.querySelector('dialog');
 
     trigger.click();
@@ -365,10 +365,10 @@ describe('sbb-tooltip', () => {
       .querySelector('#another-tooltip')
       .shadowRoot.querySelector('dialog');
 
-    const willOpenEventSpy = new EventSpy(events.didOpen);
-    const didOpenEventSpy = new EventSpy(events.didOpen);
-    const willCloseEventSpy = new EventSpy(events.didClose);
-    const didCloseEventSpy = new EventSpy(events.didClose, element);
+    const willOpenEventSpy = new EventSpy(SbbTooltip.events.didOpen);
+    const didOpenEventSpy = new EventSpy(SbbTooltip.events.didOpen);
+    const willCloseEventSpy = new EventSpy(SbbTooltip.events.didClose);
+    const didCloseEventSpy = new EventSpy(SbbTooltip.events.didClose, element);
 
     expect(secondTrigger).not.to.be.null;
     expect(secondElement).not.to.be.null;

--- a/src/components/sbb-tooltip/sbb-tooltip.stories.tsx
+++ b/src/components/sbb-tooltip/sbb-tooltip.stories.tsx
@@ -10,8 +10,8 @@ import { waitForStablePosition } from '../../global/testing/wait-for-stable-posi
 import '../sbb-link';
 import '../sbb-tooltip-trigger';
 import readme from './readme.md?raw';
-import './sbb-tooltip';
-import { events } from './sbb-tooltip';
+
+import { SbbTooltip } from './sbb-tooltip';
 
 async function commonPlayStory(canvasElement): Promise<Element> {
   const canvas = within(canvasElement);
@@ -235,7 +235,12 @@ const meta: Meta = {
   parameters: {
     chromatic: { disableSnapshot: false },
     actions: {
-      handles: [events.willOpen, events.didOpen, events.didClose, events.willClose],
+      handles: [
+        SbbTooltip.events.willOpen,
+        SbbTooltip.events.didOpen,
+        SbbTooltip.events.didClose,
+        SbbTooltip.events.willClose,
+      ],
     },
     backgrounds: {
       disable: true,

--- a/src/components/sbb-tooltip/sbb-tooltip.tsx
+++ b/src/components/sbb-tooltip/sbb-tooltip.tsx
@@ -39,16 +39,15 @@ const tooltipsRef = new Set<SbbTooltip>();
 /**
  * @slot unnamed - Use this slot to project any content inside the tooltip.
  */
-export const events = {
-  willOpen: 'will-open',
-  didOpen: 'did-open',
-  willClose: 'will-close',
-  didClose: 'did-close',
-};
-
 @customElement('sbb-tooltip')
 export class SbbTooltip extends LitElement {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    willOpen: 'will-open',
+    didOpen: 'did-open',
+    willClose: 'will-close',
+    didClose: 'did-close',
+  } as const;
 
   /**
    * The element that will trigger the tooltip dialog.
@@ -110,19 +109,19 @@ export class SbbTooltip extends LitElement {
   /**
    * Emits whenever the tooltip starts the opening transition.
    */
-  private _willOpen: EventEmitter<void> = new EventEmitter(this, events.willOpen);
+  private _willOpen: EventEmitter<void> = new EventEmitter(this, SbbTooltip.events.willOpen);
 
   /**
    * Emits whenever the tooltip is opened.
    */
-  private _didOpen: EventEmitter<void> = new EventEmitter(this, events.didOpen);
+  private _didOpen: EventEmitter<void> = new EventEmitter(this, SbbTooltip.events.didOpen);
 
   /**
    * Emits whenever the tooltip begins the closing transition.
    */
   private _willClose: EventEmitter<{ closeTarget: HTMLElement }> = new EventEmitter(
     this,
-    events.willClose,
+    SbbTooltip.events.willClose,
   );
 
   /**
@@ -130,7 +129,7 @@ export class SbbTooltip extends LitElement {
    */
   private _didClose: EventEmitter<{ closeTarget: HTMLElement }> = new EventEmitter(
     this,
-    events.didClose,
+    SbbTooltip.events.didClose,
   );
 
   private _dialog: HTMLDialogElement;

--- a/src/components/sbb-train-formation/sbb-train-formation.tsx
+++ b/src/components/sbb-train-formation/sbb-train-formation.tsx
@@ -23,7 +23,6 @@ interface AggregatedSector {
 /**
  * @slot unnamed - Used for slotting sbb-trains.
  */
-
 @customElement('sbb-train-formation')
 export class SbbTrainFormation extends LitElement {
   public static override styles: CSSResult = Style;

--- a/src/components/sbb-train-wagon/sbb-train-wagon.tsx
+++ b/src/components/sbb-train-wagon/sbb-train-wagon.tsx
@@ -24,17 +24,15 @@ import { setAttribute } from '../../global/dom';
 import Style from './sbb-train-wagon.scss?lit&inline';
 import '../sbb-icon';
 
-export const events = {
-  sectorChange: 'sector-change',
-};
-
 /**
  * @slot unnamed - Used to slot one to x icons for meta information of the sbb-train-wagon.
  */
-
 @customElement('sbb-train-wagon')
 export class SbbTrainWagon extends LitElement {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    sectorChange: 'sector-change',
+  } as const;
 
   /** Wagon type. */
   @property({ reflect: true }) public type: InterfaceSbbTrainWagonAttributes['type'] = 'wagon';
@@ -94,7 +92,7 @@ export class SbbTrainWagon extends LitElement {
    * @internal
    * Emits whenever the sector value changes.
    */
-  private _sectorChange: EventEmitter = new EventEmitter(this, events.sectorChange, {
+  private _sectorChange: EventEmitter = new EventEmitter(this, SbbTrainWagon.events.sectorChange, {
     bubbles: true,
     cancelable: true,
   });

--- a/src/components/sbb-train/sbb-train.tsx
+++ b/src/components/sbb-train/sbb-train.tsx
@@ -15,17 +15,15 @@ import { SbbTrainWagon } from '../sbb-train-wagon';
 import Style from './sbb-train.scss?lit&inline';
 import '../sbb-icon';
 
-export const events = {
-  trainSlotChange: 'train-slot-change',
-};
-
 /**
  * @slot unnamed - Used for slotting sbb-train-wagons.
  */
-
 @customElement('sbb-train')
 export class SbbTrain extends LitElement {
   public static override styles: CSSResult = Style;
+  public static readonly events = {
+    trainSlotChange: 'train-slot-change',
+  } as const;
 
   /** General label for "driving direction". */
   @property({ attribute: 'direction-label' }) public directionLabel!: string;
@@ -50,7 +48,7 @@ export class SbbTrain extends LitElement {
    * @internal
    * Emits whenever the train slot changes.
    */
-  private _trainSlotChange: EventEmitter = new EventEmitter(this, events.trainSlotChange, {
+  private _trainSlotChange: EventEmitter = new EventEmitter(this, SbbTrain.events.trainSlotChange, {
     bubbles: true,
     cancelable: true,
   });

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -8,7 +8,384 @@ declare module '*?lit&inline' {
 
 declare namespace JSX {
   type Element = jsxDom.JSX.Element;
+  type SbbAccordion = import('./components/sbb-accordion/sbb-accordion').SbbAccordion;
+  type SbbActionGroup = import('./components/sbb-action-group/sbb-action-group').SbbActionGroup;
+  type SbbAlert = import('./components/sbb-alert/sbb-alert').SbbAlert;
+  type SbbAlertGroup = import('./components/sbb-alert-group/sbb-alert-group').SbbAlertGroup;
+  type SbbAutocomplete = import('./components/sbb-autocomplete/sbb-autocomplete').SbbAutocomplete;
+  type SbbBreadcrumb = import('./components/sbb-breadcrumb/sbb-breadcrumb').SbbBreadcrumb;
+  type SbbBreadcrumbGroup =
+    import('./components/sbb-breadcrumb-group/sbb-breadcrumb-group').SbbBreadcrumbGroup;
+  type SbbButton = import('./components/sbb-button/sbb-button').SbbButton;
+  type SbbCalendar = import('./components/sbb-calendar/sbb-calendar').SbbCalendar;
+  type SbbCard = import('./components/sbb-card/sbb-card').SbbCard;
+  type SbbCardAction = import('./components/sbb-card-action/sbb-card-action').SbbCardAction;
+  type SbbCardBadge = import('./components/sbb-card-badge/sbb-card-badge').SbbCardBadge;
+  type SbbCheckbox = import('./components/sbb-checkbox/sbb-checkbox').SbbCheckbox;
+  type SbbCheckboxGroup =
+    import('./components/sbb-checkbox-group/sbb-checkbox-group').SbbCheckboxGroup;
+  type SbbChip = import('./components/sbb-chip/sbb-chip').SbbChip;
+  type SbbClock = import('./components/sbb-clock/sbb-clock').SbbClock;
+  type SbbDatepicker = import('./components/sbb-datepicker/sbb-datepicker').SbbDatepicker;
+  type SbbDatepickerNextDay =
+    import('./components/sbb-datepicker-next-day/sbb-datepicker-next-day').SbbDatepickerNextDay;
+  type SbbDatepickerPreviousDay =
+    import('./components/sbb-datepicker-previous-day/sbb-datepicker-previous-day').SbbDatepickerPreviousDay;
+  type SbbDatepickerToggle =
+    import('./components/sbb-datepicker-toggle/sbb-datepicker-toggle').SbbDatepickerToggle;
+  type SbbDialog = import('./components/sbb-dialog/sbb-dialog').SbbDialog;
+  type SbbDivider = import('./components/sbb-divider/sbb-divider').SbbDivider;
+  type SbbExpansionPanel =
+    import('./components/sbb-expansion-panel/sbb-expansion-panel').SbbExpansionPanel;
+  type SbbExpansionPanelContent =
+    import('./components/sbb-expansion-panel-content/sbb-expansion-panel-content').SbbExpansionPanelContent;
+  type SbbExpansionPanelHeader =
+    import('./components/sbb-expansion-panel-header/sbb-expansion-panel-header').SbbExpansionPanelHeader;
+  type SbbFileSelector = import('./components/sbb-file-selector/sbb-file-selector').SbbFileSelector;
+  type SbbFooter = import('./components/sbb-footer/sbb-footer').SbbFooter;
+  type SbbFormError = import('./components/sbb-form-error/sbb-form-error').SbbFormError;
+  type SbbFormField = import('./components/sbb-form-field/sbb-form-field').SbbFormField;
+  type SbbFormFieldClear =
+    import('./components/sbb-form-field-clear/sbb-form-field-clear').SbbFormFieldClear;
+  type SbbHeader = import('./components/sbb-header/sbb-header').SbbHeader;
+  type SbbHeaderAction = import('./components/sbb-header-action/sbb-header-action').SbbHeaderAction;
+  type SbbIcon = import('./components/sbb-icon/sbb-icon').SbbIcon;
+  type SbbImage = import('./components/sbb-image/sbb-image').SbbImage;
+  type SbbJourneyHeader =
+    import('./components/sbb-journey-header/sbb-journey-header').SbbJourneyHeader;
+  type SbbJourneySummary =
+    import('./components/sbb-journey-summary/sbb-journey-summary').SbbJourneySummary;
+  type SbbLink = import('./components/sbb-link/sbb-link').SbbLink;
+  type SbbLinkList = import('./components/sbb-link-list/sbb-link-list').SbbLinkList;
+  type SbbLoadingIndicator =
+    import('./components/sbb-loading-indicator/sbb-loading-indicator').SbbLoadingIndicator;
+  type SbbLogo = import('./components/sbb-logo/sbb-logo').SbbLogo;
+  type SbbMapContainer = import('./components/sbb-map-container/sbb-map-container').SbbMapContainer;
+  type SbbMenu = import('./components/sbb-menu/sbb-menu').SbbMenu;
+  type SbbMenuAction = import('./components/sbb-menu-action/sbb-menu-action').SbbMenuAction;
+  type SbbMessage = import('./components/sbb-message/sbb-message').SbbMessage;
+  type SbbNavigation = import('./components/sbb-navigation/sbb-navigation').SbbNavigation;
+  type SbbNavigationAction =
+    import('./components/sbb-navigation-action/sbb-navigation-action').SbbNavigationAction;
+  type SbbNavigationList =
+    import('./components/sbb-navigation-list/sbb-navigation-list').SbbNavigationList;
+  type SbbNavigationMarker =
+    import('./components/sbb-navigation-marker/sbb-navigation-marker').SbbNavigationMarker;
+  type SbbNavigationSection =
+    import('./components/sbb-navigation-section/sbb-navigation-section').SbbNavigationSection;
+  type SbbNotification = import('./components/sbb-notification/sbb-notification').SbbNotification;
+  type SbbOptgroup = import('./components/sbb-optgroup/sbb-optgroup').SbbOptgroup;
+  type SbbOption = import('./components/sbb-option/sbb-option').SbbOption;
+  type SbbPearlChain = import('./components/sbb-pearl-chain/sbb-pearl-chain').SbbPearlChain;
+  type SbbPearlChainTime =
+    import('./components/sbb-pearl-chain-time/sbb-pearl-chain-time').SbbPearlChainTime;
+  type SbbPearlChainVertical =
+    import('./components/sbb-pearl-chain-vertical/sbb-pearl-chain-vertical').SbbPearlChainVertical;
+  type SbbPearlChainVerticalItem =
+    import('./components/sbb-pearl-chain-vertical-item/sbb-pearl-chain-vertical-item').SbbPearlChainVerticalItem;
+  type SbbRadioButton = import('./components/sbb-radio-button/sbb-radio-button').SbbRadioButton;
+  type SbbRadioButtonGroup =
+    import('./components/sbb-radio-button-group/sbb-radio-button-group').SbbRadioButtonGroup;
+  type SbbSelect = import('./components/sbb-select/sbb-select').SbbSelect;
+  type SbbSelectionPanel =
+    import('./components/sbb-selection-panel/sbb-selection-panel').SbbSelectionPanel;
+  type SbbSignet = import('./components/sbb-signet/sbb-signet').SbbSignet;
+  type SbbSkiplinkList = import('./components/sbb-skiplink-list/sbb-skiplink-list').SbbSkiplinkList;
+  type SbbSlider = import('./components/sbb-slider/sbb-slider').SbbSlider;
+  type SbbTabGroup = import('./components/sbb-tab-group/sbb-tab-group').SbbTabGroup;
+  type SbbTabTitle = import('./components/sbb-tab-title/sbb-tab-title').SbbTabTitle;
+  type SbbTag = import('./components/sbb-tag/sbb-tag').SbbTag;
+  type SbbTagGroup = import('./components/sbb-tag-group/sbb-tag-group').SbbTagGroup;
+  type SbbTeaser = import('./components/sbb-teaser/sbb-teaser').SbbTeaser;
+  type SbbTeaserHero = import('./components/sbb-teaser-hero/sbb-teaser-hero').SbbTeaserHero;
+  type SbbTimeInput = import('./components/sbb-time-input/sbb-time-input').SbbTimeInput;
+  type SbbTimetableBarrierFree =
+    import('./components/sbb-timetable-barrier-free/sbb-timetable-barrier-free').SbbTimetableBarrierFree;
+  type SbbTimetableDuration =
+    import('./components/sbb-timetable-duration/sbb-timetable-duration').SbbTimetableDuration;
+  type SbbTimetableOccupancy =
+    import('./components/sbb-timetable-occupancy/sbb-timetable-occupancy').SbbTimetableOccupancy;
+  type SbbTimetableParkAndRail =
+    import('./components/sbb-timetable-park-and-rail/sbb-timetable-park-and-rail').SbbTimetableParkAndRail;
+  type SbbTimetableRow = import('./components/sbb-timetable-row/sbb-timetable-row').SbbTimetableRow;
+  type SbbTimetableRowColumnHeaders =
+    import('./components/sbb-timetable-row-column-headers/sbb-timetable-row-column-headers').SbbTimetableRowColumnHeaders;
+  type SbbTimetableRowDayChange =
+    import('./components/sbb-timetable-row-day-change/sbb-timetable-row-day-change').SbbTimetableRowDayChange;
+  type SbbTimetableRowHeader =
+    import('./components/sbb-timetable-row-header/sbb-timetable-row-header').SbbTimetableRowHeader;
+  type SbbTimetableTransportationNumber =
+    import('./components/sbb-timetable-transportation-number/sbb-timetable-transportation-number').SbbTimetableTransportationNumber;
+  type SbbTimetableTransportationTime =
+    import('./components/sbb-timetable-transportation-time/sbb-timetable-transportation-time').SbbTimetableTransportationTime;
+  type SbbTimetableTravelHints =
+    import('./components/sbb-timetable-travel-hints/sbb-timetable-travel-hints').SbbTimetableTravelHints;
+  type SbbTitle = import('./components/sbb-title/sbb-title').SbbTitle;
+  type SbbToast = import('./components/sbb-toast/sbb-toast').SbbToast;
+  type SbbToggle = import('./components/sbb-toggle/sbb-toggle').SbbToggle;
+  type SbbToggleCheck = import('./components/sbb-toggle-check/sbb-toggle-check').SbbToggleCheck;
+  type SbbToggleOption = import('./components/sbb-toggle-option/sbb-toggle-option').SbbToggleOption;
+  type SbbTooltip = import('./components/sbb-tooltip/sbb-tooltip').SbbTooltip;
+  type SbbTooltipTrigger =
+    import('./components/sbb-tooltip-trigger/sbb-tooltip-trigger').SbbTooltipTrigger;
+  type SbbTrain = import('./components/sbb-train/sbb-train').SbbTrain;
+  type SbbTrainBlockedPassage =
+    import('./components/sbb-train-blocked-passage/sbb-train-blocked-passage').SbbTrainBlockedPassage;
+  type SbbTrainFormation =
+    import('./components/sbb-train-formation/sbb-train-formation').SbbTrainFormation;
+  type SbbTrainWagon = import('./components/sbb-train-wagon/sbb-train-wagon').SbbTrainWagon;
+  type SbbVisualCheckbox =
+    import('./components/sbb-visual-checkbox/sbb-visual-checkbox').SbbVisualCheckbox;
+
   interface IntrinsicElements {
-    'sbb-icon': import('./components/sbb-icon/sbb-icon').SbbIcon & jsxDom.JSX.Element;
+    'sbb-accordion': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbAccordion>, SbbAccordion>;
+    'sbb-action-group': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbActionGroup>,
+      SbbActionGroup
+    >;
+    'sbb-alert': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbAlert>, SbbAlert>;
+    'sbb-alert-group': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbAlertGroup>,
+      SbbAlertGroup
+    >;
+    'sbb-autocomplete': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbAutocomplete>,
+      SbbAutocomplete
+    >;
+    'sbb-breadcrumb': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbBreadcrumb>, SbbBreadcrumb>;
+    'sbb-breadcrumb-group': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbBreadcrumbGroup>,
+      SbbBreadcrumbGroup
+    >;
+    'sbb-button': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbButton>, SbbButton>;
+    'sbb-calendar': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbCalendar>, SbbCalendar>;
+    'sbb-card': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbCard>, SbbCard>;
+    'sbb-card-action': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbCardAction>,
+      SbbCardAction
+    >;
+    'sbb-card-badge': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbCardBadge>, SbbCardBadge>;
+    'sbb-checkbox': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbCheckbox>, SbbCheckbox>;
+    'sbb-checkbox-group': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbCheckboxGroup>,
+      SbbCheckboxGroup
+    >;
+    'sbb-chip': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbChip>, SbbChip>;
+    'sbb-clock': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbClock>, SbbClock>;
+    'sbb-datepicker': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbDatepicker>, SbbDatepicker>;
+    'sbb-datepicker-next-day': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbDatepickerNextDay>,
+      SbbDatepickerNextDay
+    >;
+    'sbb-datepicker-previous-day': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbDatepickerPreviousDay>,
+      SbbDatepickerPreviousDay
+    >;
+    'sbb-datepicker-toggle': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbDatepickerToggle>,
+      SbbDatepickerToggle
+    >;
+    'sbb-dialog': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbDialog>, SbbDialog>;
+    'sbb-divider': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbDivider>, SbbDivider>;
+    'sbb-expansion-panel': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbExpansionPanel>,
+      SbbExpansionPanel
+    >;
+    'sbb-expansion-panel-content': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbExpansionPanelContent>,
+      SbbExpansionPanelContent
+    >;
+    'sbb-expansion-panel-header': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbExpansionPanelHeader>,
+      SbbExpansionPanelHeader
+    >;
+    'sbb-file-selector': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbFileSelector>,
+      SbbFileSelector
+    >;
+    'sbb-footer': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbFooter>, SbbFooter>;
+    'sbb-form-error': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbFormError>, SbbFormError>;
+    'sbb-form-field': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbFormField>, SbbFormField>;
+    'sbb-form-field-clear': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbFormFieldClear>,
+      SbbFormFieldClear
+    >;
+    'sbb-header': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbHeader>, SbbHeader>;
+    'sbb-header-action': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbHeaderAction>,
+      SbbHeaderAction
+    >;
+    'sbb-icon': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbIcon>, SbbIcon>;
+    'sbb-image': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbImage>, SbbImage>;
+    'sbb-journey-header': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbJourneyHeader>,
+      SbbJourneyHeader
+    >;
+    'sbb-journey-summary': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbJourneySummary>,
+      SbbJourneySummary
+    >;
+    'sbb-link': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbLink>, SbbLink>;
+    'sbb-link-list': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbLinkList>, SbbLinkList>;
+    'sbb-loading-indicator': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbLoadingIndicator>,
+      SbbLoadingIndicator
+    >;
+    'sbb-logo': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbLogo>, SbbLogo>;
+    'sbb-map-container': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbMapContainer>,
+      SbbMapContainer
+    >;
+    'sbb-menu': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbMenu>, SbbMenu>;
+    'sbb-menu-action': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbMenuAction>,
+      SbbMenuAction
+    >;
+    'sbb-message': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbMessage>, SbbMessage>;
+    'sbb-navigation': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbNavigation>, SbbNavigation>;
+    'sbb-navigation-action': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbNavigationAction>,
+      SbbNavigationAction
+    >;
+    'sbb-navigation-list': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbNavigationList>,
+      SbbNavigationList
+    >;
+    'sbb-navigation-marker': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbNavigationMarker>,
+      SbbNavigationMarker
+    >;
+    'sbb-navigation-section': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbNavigationSection>,
+      SbbNavigationSection
+    >;
+    'sbb-notification': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbNotification>,
+      SbbNotification
+    >;
+    'sbb-optgroup': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbOptgroup>, SbbOptgroup>;
+    'sbb-option': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbOption>, SbbOption>;
+    'sbb-pearl-chain': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbPearlChain>,
+      SbbPearlChain
+    >;
+    'sbb-pearl-chain-time': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbPearlChainTime>,
+      SbbPearlChainTime
+    >;
+    'sbb-pearl-chain-vertical': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbPearlChainVertical>,
+      SbbPearlChainVertical
+    >;
+    'sbb-pearl-chain-vertical-item': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbPearlChainVerticalItem>,
+      SbbPearlChainVerticalItem
+    >;
+    'sbb-radio-button': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbRadioButton>,
+      SbbRadioButton
+    >;
+    'sbb-radio-button-group': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbRadioButtonGroup>,
+      SbbRadioButtonGroup
+    >;
+    'sbb-select': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbSelect>, SbbSelect>;
+    'sbb-selection-panel': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbSelectionPanel>,
+      SbbSelectionPanel
+    >;
+    'sbb-signet': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbSignet>, SbbSignet>;
+    'sbb-skiplink-list': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbSkiplinkList>,
+      SbbSkiplinkList
+    >;
+    'sbb-slider': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbSlider>, SbbSlider>;
+    'sbb-tab-group': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbTabGroup>, SbbTabGroup>;
+    'sbb-tab-title': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbTabTitle>, SbbTabTitle>;
+    'sbb-tag': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbTag>, SbbTag>;
+    'sbb-tag-group': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbTagGroup>, SbbTagGroup>;
+    'sbb-teaser': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbTeaser>, SbbTeaser>;
+    'sbb-teaser-hero': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbTeaserHero>,
+      SbbTeaserHero
+    >;
+    'sbb-time-input': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbTimeInput>, SbbTimeInput>;
+    'sbb-timetable-barrier-free': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbTimetableBarrierFree>,
+      SbbTimetableBarrierFree
+    >;
+    'sbb-timetable-duration': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbTimetableDuration>,
+      SbbTimetableDuration
+    >;
+    'sbb-timetable-occupancy': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbTimetableOccupancy>,
+      SbbTimetableOccupancy
+    >;
+    'sbb-timetable-park-and-rail': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbTimetableParkAndRail>,
+      SbbTimetableParkAndRail
+    >;
+    'sbb-timetable-row': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbTimetableRow>,
+      SbbTimetableRow
+    >;
+    'sbb-timetable-row-column-headers': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbTimetableRowColumnHeaders>,
+      SbbTimetableRowColumnHeaders
+    >;
+    'sbb-timetable-row-day-change': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbTimetableRowDayChange>,
+      SbbTimetableRowDayChange
+    >;
+    'sbb-timetable-row-header': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbTimetableRowHeader>,
+      SbbTimetableRowHeader
+    >;
+    'sbb-timetable-transportation-number': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbTimetableTransportationNumber>,
+      SbbTimetableTransportationNumber
+    >;
+    'sbb-timetable-transportation-time': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbTimetableTransportationTime>,
+      SbbTimetableTransportationTime
+    >;
+    'sbb-timetable-travel-hints': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbTimetableTravelHints>,
+      SbbTimetableTravelHints
+    >;
+    'sbb-title': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbTitle>, SbbTitle>;
+    'sbb-toast': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbToast>, SbbToast>;
+    'sbb-toggle': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbToggle>, SbbToggle>;
+    'sbb-toggle-check': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbToggleCheck>,
+      SbbToggleCheck
+    >;
+    'sbb-toggle-option': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbToggleOption>,
+      SbbToggleOption
+    >;
+    'sbb-tooltip': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbTooltip>, SbbTooltip>;
+    'sbb-tooltip-trigger': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbTooltipTrigger>,
+      SbbTooltipTrigger
+    >;
+    'sbb-train': jsxDom.DetailedHTMLProps<jsxDom.HTMLAttributes<SbbTrain>, SbbTrain>;
+    'sbb-train-blocked-passage': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbTrainBlockedPassage>,
+      SbbTrainBlockedPassage
+    >;
+    'sbb-train-formation': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbTrainFormation>,
+      SbbTrainFormation
+    >;
+    'sbb-train-wagon': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbTrainWagon>,
+      SbbTrainWagon
+    >;
+    'sbb-visual-checkbox': jsxDom.DetailedHTMLProps<
+      jsxDom.HTMLAttributes<SbbVisualCheckbox>,
+      SbbVisualCheckbox
+    >;
   }
 }


### PR DESCRIPTION
This PR inlines the events object in components into the component itself. This avoids potential naming conflicts, when importing multiple components.