### PR TITLE
refactor: remove CSS selectors for boolean attributes

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -472,7 +472,7 @@ Also define CSS variables in :host.
   }
 }
 
-:host([disabled]:not([disabled='false'])) {
+:host([disabled]) {
   --sbb-component-color: var(--sbb-color-disabled);
 }
 
@@ -618,27 +618,6 @@ When it is not super obvious, include a brief description of what a class repres
 
 // Portion of the floating panel that sits, invisibly, on top of the input.
 .sbb-datepicker-input-mask { }
-```
-
-#### Boolean properties
-
-When using a CSS attribute selector of a boolean property, it is necessary to exclude the case of value `false`.
-
-In TypeScript, when checking if an attribute value is truthy,
-you can use the `isValidAttribute()` function which checks both possible cases.
-
-```scss
-// AVOID
-:host([negative]) {
-  ...;
-}
-```
-
-```scss
-// PREFER
-:host([negative]:not([negative='false'])) {
-  ...;
-}
 ```
 
 ### Storybook

--- a/src/components/core/a11y/focus.ts
+++ b/src/components/core/a11y/focus.ts
@@ -1,6 +1,6 @@
 import { interactivityChecker } from './interactivity-checker';
 
-export const IS_FOCUSABLE_QUERY = `:is(button, [href], input, select, textarea, details, summary:not(:disabled), [tabindex]):not([disabled]:not([disabled='false'])):not([tabindex="-1"])`;
+export const IS_FOCUSABLE_QUERY = `:is(button, [href], input, select, textarea, details, summary:not(:disabled), [tabindex]):not([disabled]):not([tabindex="-1"])`;
 
 // Note: the use of this function for more complex scenarios (with many nested elements) may be expensive.
 export function getFocusableElements(

--- a/src/components/core/styles/mixins/buttons.scss
+++ b/src/components/core/styles/mixins/buttons.scss
@@ -25,11 +25,11 @@
 @mixin icon-button($button-selector, $icon-selector) {
   @include icon-button-base(':host', #{$button-selector}, #{$icon-selector});
 
-  :host([negative]:not([negative='false'])) {
+  :host([negative]) {
     @include icon-button-variables-negative;
   }
 
-  :host([data-disabled]:not([data-disabled='false'])) {
+  :host([data-disabled]) {
     @include icon-button-disabled(#{$button-selector});
   }
 

--- a/src/components/core/styles/typography.scss
+++ b/src/components/core/styles/typography.scss
@@ -32,7 +32,7 @@ sbb-form-field {
     -webkit-text-fill-color: var(--sbb-color-granite-default);
   }
 
-  &[floating-label]:not([floating-label='false']) input::placeholder {
+  &[floating-label] input::placeholder {
     color: transparent;
     -webkit-text-fill-color: transparent;
 

--- a/src/components/sbb-autocomplete/sbb-autocomplete.scss
+++ b/src/components/sbb-autocomplete/sbb-autocomplete.scss
@@ -14,7 +14,7 @@
   --sbb-options-panel-internal-z-index: var(--sbb-autocomplete-z-index, var(--sbb-overlay-z-index));
 }
 
-:host([negative]:not([negative='false'])) {
+:host([negative]) {
   @include sbb.options-panel-overlay-negative-variables;
 }
 
@@ -51,11 +51,11 @@
   );
 }
 
-:host([disable-animation]:not([disable-animation='false'])) {
+:host([disable-animation]) {
   --sbb-options-panel-animation-duration: 0.1ms;
 }
 
-:host([preserve-icon-space]:not([preserve-icon-space='false'])) {
+:host([preserve-icon-space]) {
   --sbb-option-icon-container-display: block;
 }
 
@@ -84,7 +84,7 @@
     @include sbb.shadow-level-5-hard;
   }
 
-  :host(:is([data-state='opened'], [data-state='opening'])[negative]:not([negative='false'])) & {
+  :host(:is([data-state='opened'], [data-state='opening'])[negative]) & {
     @include sbb.shadow-level-5-hard-negative;
   }
 
@@ -112,7 +112,7 @@
         :is(
             [data-state='opened'],
             [data-state='opening']
-          )[data-option-panel-origin-borderless][negative]:not([negative='false'])
+          )[data-option-panel-origin-borderless][negative]
       )
       & {
       @include sbb.shadow-level-5-hard-negative;

--- a/src/components/sbb-button/sbb-button.scss
+++ b/src/components/sbb-button/sbb-button.scss
@@ -52,13 +52,13 @@
   }
 }
 
-:host([negative]:not([negative='false'])) {
+:host([negative]) {
   --sbb-button-color-disabled-background: var(--sbb-color-anthracite-default);
   --sbb-button-color-disabled-border: var(--sbb-color-granite-default);
   --sbb-button-color-disabled-text: var(--sbb-color-aluminium-default);
 }
 
-:host([variant='primary'][negative]:not([negative='false'])) {
+:host([variant='primary'][negative]) {
   --sbb-button-color-active-background: var(--sbb-color-cloud-default);
   --sbb-button-color-active-border: var(--sbb-color-cloud-default);
   --sbb-button-color-active-text: var(--sbb-color-red150-default);
@@ -86,7 +86,7 @@
   --sbb-button-shadow-2-color: var(--sbb-color-cement-alpha-20);
 }
 
-:host([variant='secondary'][negative]:not([negative='false'])) {
+:host([variant='secondary'][negative]) {
   --sbb-button-color-active-background: transparent;
   --sbb-button-color-active-border: var(--sbb-color-cloud-default);
   --sbb-button-color-active-text: var(--sbb-color-cloud-default);
@@ -124,7 +124,7 @@
   --sbb-button-color-hover-text: var(--sbb-color-black-default);
 }
 
-:host([variant='transparent'][negative]:not([negative='false'])) {
+:host([variant='transparent'][negative]) {
   --sbb-button-color-active-background: var(--sbb-color-iron-default);
   --sbb-button-color-active-border: var(--sbb-color-iron-default);
   --sbb-button-color-active-text: var(--sbb-color-white-default);
@@ -150,13 +150,13 @@
   --icon-margin-inline-end: 0;
 }
 
-:host([disabled]:not([disabled='false'])) {
+:host([disabled]) {
   @include sbb.if-forced-colors {
     --sbb-button-color-disabled-text: GrayText !important;
   }
 }
 
-:host(:not([disabled]:not([disabled='false']), :active, [data-active]):hover) {
+:host(:not([disabled], :active, [data-active]):hover) {
   @include sbb.hover-mq($hover: true) {
     --sbb-button-translate-y-content-hover: #{sbb.px-to-rem-build(-1)};
     --sbb-button-shadow-1-offset-y: calc(
@@ -194,7 +194,7 @@
   --sbb-button-shadow-2-color: var(--sbb-color-black-alpha-0);
 }
 
-:host([data-icon-small][negative]:not([negative='false'])) {
+:host([data-icon-small][negative]) {
   @include sbb.icon-button-variables-negative;
 
   --sbb-button-shadow-1-color: var(--sbb-color-black-alpha-0);
@@ -241,7 +241,7 @@
     transition-timing-function: var(--sbb-button-transition-easing-function);
     transition-property: inset, background-color, border-color, box-shadow;
 
-    :host([disabled]:not([disabled='false'])) & {
+    :host([disabled]) & {
       background-color: var(--sbb-button-color-disabled-background);
       border-color: var(--sbb-button-color-disabled-border);
     }
@@ -257,7 +257,7 @@
       @include sbb.focus-outline;
     }
 
-    :host(:not([disabled]:not([disabled='false']), :active, [data-active]):hover) & {
+    :host(:not([disabled], :active, [data-active]):hover) & {
       @include sbb.hover-mq($hover: true) {
         inset: calc(var(--sbb-button-border-width) * -1);
         background-color: var(--sbb-button-color-hover-background);
@@ -265,7 +265,7 @@
       }
     }
 
-    :host(:not([disabled]:not([disabled='false'])):is(:active, [data-active])) & {
+    :host(:not([disabled]):is(:active, [data-active])) & {
       color: var(--sbb-button-color-active-text);
       background-color: var(--sbb-button-color-active-background);
       border-color: var(--sbb-button-color-active-border);
@@ -274,7 +274,7 @@
     // Only apply shadow definitions where it is really used.
     :host(
         :is([variant='primary'], [variant='secondary']:not([negative]), [variant='tertiary']):not(
-            [disabled]:not([disabled='false']),
+            [disabled],
             :active,
             [data-active]
           )
@@ -295,14 +295,14 @@
     justify-content: center;
   }
 
-  :host([disabled]:not([disabled='false'])) & {
+  :host([disabled]) & {
     color: var(--sbb-button-color-disabled-text);
     cursor: default;
     pointer-events: none;
     text-decoration: line-through;
   }
 
-  :host(:not([disabled]:not([disabled='false']), :active, [data-active]):hover) & {
+  :host(:not([disabled], :active, [data-active]):hover) & {
     @include sbb.hover-mq($hover: true) {
       color: var(--sbb-button-color-hover-text);
     }

--- a/src/components/sbb-checkbox/sbb-checkbox.scss
+++ b/src/components/sbb-checkbox/sbb-checkbox.scss
@@ -18,7 +18,7 @@
   outline: none !important;
 }
 
-:host(:is([data-group-disabled], [disabled]:not([disabled='false']))) {
+:host(:is([data-group-disabled], [disabled])) {
   --sbb-checkbox-label-color: var(--sbb-color-charcoal-default);
   --sbb-checkbox-cursor: default;
   --sbb-checkbox-subtext-color: var(--sbb-color-smoke-default);

--- a/src/components/sbb-dialog/sbb-dialog.scss
+++ b/src/components/sbb-dialog/sbb-dialog.scss
@@ -65,7 +65,7 @@
   --sbb-dialog-max-height: 100%;
 }
 
-:host([negative]:not([negative='false'])) {
+:host([negative]) {
   @include sbb.scrollbar-variables--color-negative;
 
   --sbb-focus-outline-color: var(--sbb-focus-outline-color-dark);
@@ -74,11 +74,11 @@
   --sbb-dialog-footer-border: none;
 }
 
-:host([disable-animation]:not([disable-animation='false'])) {
+:host([disable-animation]) {
   --sbb-dialog-animation-duration: 0.1ms;
 }
 
-:host([data-fullscreen]:not([negative]:not([negative='false']))) {
+:host([data-fullscreen]:not([negative])) {
   --sbb-dialog-background-color: var(--sbb-color-milk-default);
 }
 
@@ -86,7 +86,7 @@
   --sbb-dialog-header-padding-block: var(--sbb-spacing-responsive-s);
 }
 
-:host([data-overflows]:not([data-fullscreen], [negative]:not([negative='false']))) {
+:host([data-overflows]:not([data-fullscreen], [negative])) {
   --sbb-dialog-footer-border: none;
 }
 
@@ -248,7 +248,7 @@
 
 // stylelint-disable selector-not-notation
 :is(.sbb-dialog__header, .sbb-dialog__footer) {
-  :host([data-overflows]:not([data-fullscreen], [negative]:not([negative='false']))) & {
+  :host([data-overflows]:not([data-fullscreen], [negative])) & {
     @include sbb.shadow-level-9-soft;
   }
 }

--- a/src/components/sbb-divider/sbb-divider.scss
+++ b/src/components/sbb-divider/sbb-divider.scss
@@ -13,7 +13,7 @@
   height: 100%;
 }
 
-:host([negative]:not([negative='false'])) {
+:host([negative]) {
   --sbb-divider-color: var(--sbb-color-iron-default);
 }
 

--- a/src/components/sbb-expansion-panel-header/sbb-expansion-panel-header.scss
+++ b/src/components/sbb-expansion-panel-header/sbb-expansion-panel-header.scss
@@ -16,7 +16,7 @@
   }
 }
 
-:host([disabled]:not([disabled='false'])) {
+:host([disabled]) {
   --sbb-expansion-panel-header-cursor: default;
   --sbb-expansion-panel-header-text-color: var(--sbb-color-granite-default);
 

--- a/src/components/sbb-expansion-panel/sbb-expansion-panel.scss
+++ b/src/components/sbb-expansion-panel/sbb-expansion-panel.scss
@@ -29,7 +29,7 @@
   --sbb-expansion-panel-icon-size: var(--sbb-size-icon-ui-medium);
 }
 
-:host([disabled]:not([disabled='false'])) {
+:host([disabled]) {
   @include sbb.if-forced-colors {
     --sbb-expansion-panel-border-color: GrayText;
     --sbb-expansion-panel-border-block-start-color: GrayText;
@@ -47,7 +47,7 @@
       var(--sbb-expansion-panel-animation-duration) var(--sbb-animation-easing);
 }
 
-:host([disable-animation]:not([disable-animation='false'])) {
+:host([disable-animation]) {
   --sbb-expansion-panel-animation-duration: 0.1ms;
 }
 
@@ -77,7 +77,7 @@
   --sbb-expansion-panel-background-color: var(--sbb-color-milk-default);
 }
 
-:host([borderless]:not([borderless='false'])) {
+:host([borderless]) {
   --sbb-expansion-panel-border-width: 0;
   --sbb-expansion-panel-border-color: transparent;
   --sbb-expansion-panel-border-block-start-width: 0;
@@ -88,14 +88,14 @@
   }
 }
 
-:host([borderless]:not([borderless='false'])[data-accordion]:not([data-accordion-first])) {
+:host([borderless][data-accordion]:not([data-accordion-first])) {
   --sbb-expansion-panel-border-block-start-width: var(--sbb-spacing-fixed-1x);
   @include sbb.if-forced-colors {
     --sbb-expansion-panel-border-block-start-width: 0;
   }
 }
 
-:host(:not([disabled]:not([disabled='false']))[data-toggle-hover]) {
+:host(:not([disabled])[data-toggle-hover]) {
   --sbb-expansion-panel-background-color: var(--sbb-color-milk-default);
   @include sbb.if-forced-colors {
     --sbb-expansion-panel-border-color: Highlight;
@@ -103,7 +103,7 @@
   }
 }
 
-:host(:not([disabled]:not([disabled='false']))[color='milk'][data-toggle-hover]) {
+:host(:not([disabled])[color='milk'][data-toggle-hover]) {
   --sbb-expansion-panel-background-color: var(--sbb-color-white-default);
 }
 

--- a/src/components/sbb-file-selector/sbb-file-selector.scss
+++ b/src/components/sbb-file-selector/sbb-file-selector.scss
@@ -15,7 +15,7 @@
   width: #{sbb.px-to-rem-build(320)};
 }
 
-:host([disabled]:not([disabled='false'])) {
+:host([disabled]) {
   @include sbb.if-forced-colors {
     --sbb-file-selector-color: GrayText;
     --sbb-file-selector-subtitle-color: GrayText;

--- a/src/components/sbb-footer/sbb-footer.scss
+++ b/src/components/sbb-footer/sbb-footer.scss
@@ -16,7 +16,7 @@
   }
 }
 
-:host([negative]:not([negative='false'])) {
+:host([negative]) {
   --sbb-footer-background-color: var(--sbb-color-charcoal-default);
   --sbb-footer-color: var(--sbb-color-white-default);
   --sbb-focus-outline-color: var(--sbb-focus-outline-color-dark);
@@ -37,11 +37,11 @@
 
 .sbb-footer-wrapper {
   /* stylelint-disable-next-line plugin/stylelint-bem-namics */
-  :host(:not([expanded]:not([expanded='false']))) & {
+  :host(:not([expanded])) & {
     @include sbb.page-spacing;
   }
 
-  :host([expanded]:not([expanded='false'])) & {
+  :host([expanded]) & {
     @include sbb.page-spacing-expanded;
   }
 }

--- a/src/components/sbb-form-error/sbb-form-error.scss
+++ b/src/components/sbb-form-error/sbb-form-error.scss
@@ -24,7 +24,7 @@
   min-height: var(--sbb-form-error-height);
 }
 
-:host([negative]:not([negative='false'])) {
+:host([negative]) {
   --sbb-form-error-color: var(--sbb-color-red-mode-dark);
 }
 

--- a/src/components/sbb-form-field/sbb-form-field.scss
+++ b/src/components/sbb-form-field/sbb-form-field.scss
@@ -45,7 +45,7 @@
   width: min(#{sbb.px-to-rem-build(300)}, 100%);
 }
 
-:host([negative]:not([negative='false'])) {
+:host([negative]) {
   --sbb-form-field-background-color: var(--sbb-color-midnight-default);
   --sbb-form-field-border-color: var(--sbb-color-smoke-default);
   --sbb-form-field-label-color: var(--sbb-color-smoke-default);
@@ -81,7 +81,7 @@
   }
 }
 
-:host(:is([data-readonly], [data-disabled])[negative]:not([negative='false'])) {
+:host(:is([data-readonly], [data-disabled])[negative]) {
   --sbb-form-field-background-color: var(--sbb-color-charcoal-default);
   --sbb-form-field-arrow-color: var(--sbb-color-smoke-default);
 }
@@ -99,11 +99,11 @@
   }
 }
 
-:host([data-disabled][negative]:not([negative='false'])) {
+:host([data-disabled][negative]) {
   --sbb-form-field-text-color: var(--sbb-color-smoke-default);
 }
 
-:host([data-readonly]:not([negative]:not([negative='false']))) {
+:host([data-readonly]:not([negative])) {
   --sbb-form-field-label-color: var(--sbb-color-granite-default);
   --sbb-form-field-prefix-color: var(--sbb-color-granite-default);
 }
@@ -119,7 +119,7 @@
   }
 }
 
-:host(:is([data-input-focused], [data-has-popup-open])[negative]:not([negative='false'])) {
+:host(:is([data-input-focused], [data-has-popup-open])[negative]) {
   --sbb-form-field-border-color: var(--sbb-color-milk-default);
   --sbb-form-field-prefix-color: var(--sbb-color-milk-default);
 }
@@ -134,7 +134,7 @@
   }
 }
 
-:host([data-invalid][negative]:not([negative='false'])) {
+:host([data-invalid][negative]) {
   --sbb-form-field-border-color: var(--sbb-color-red-mode-dark);
   --sbb-form-field-text-color: var(--sbb-color-red-mode-dark);
 }
@@ -143,7 +143,7 @@
   --sbb-form-field-error-padding-block-start: 0;
 }
 
-:host([floating-label]:not([floating-label='false'])) {
+:host([floating-label]) {
   --sbb-select-placeholder-color: transparent;
 }
 
@@ -177,12 +177,11 @@
 
   // In high contrast, there is no borderless variant
   @media (forced-colors: none) {
-    :host(:is([borderless]:not([borderless='false']), [data-input-type='sbb-slider'])) & {
+    :host(:is([borderless], [data-input-type='sbb-slider'])) & {
       border-color: transparent;
     }
 
-    :host(:is([data-input-focused], [data-has-popup-open])[borderless]:not([borderless='false']))
-      & {
+    :host(:is([data-input-focused], [data-has-popup-open])[borderless]) & {
       position: relative;
 
       &::after {
@@ -261,7 +260,7 @@
     padding-inline-end: var(--sbb-form-field-select-inline-padding-end);
   }
 
-  :host([floating-label]:not([floating-label='false'])) & {
+  :host([floating-label]) & {
     transform-origin: 0 0;
     pointer-events: none; // We shouldn't catch mouse events (let them through).
     backface-visibility: hidden;
@@ -279,7 +278,7 @@
   // then apply the label transition.
   // If it is empty and readonly, always apply transition
   :host(
-      [floating-label]:not([floating-label='false']):is(
+      [floating-label]:is(
           :not([data-input-focused]:not([data-input-type='sbb-select']), [data-has-popup-open]),
           [data-readonly]
         )[data-input-empty]
@@ -324,7 +323,7 @@
   &::placeholder {
     @include sbb.placeholder;
 
-    :host([floating-label]:not([floating-label='false'])) & {
+    :host([floating-label]) & {
       color: transparent !important;
       -webkit-text-fill-color: transparent !important;
 
@@ -334,7 +333,7 @@
       }
     }
 
-    :host([data-disabled]:not([floating-label]:not([floating-label='false']))) & {
+    :host([data-disabled]:not([floating-label])) & {
       color: var(--sbb-color-granite-default);
       -webkit-text-fill-color: var(--sbb-color-granite-default);
     }

--- a/src/components/sbb-header/sbb-header.scss
+++ b/src/components/sbb-header/sbb-header.scss
@@ -75,11 +75,11 @@
   justify-content: flex-start;
   height: var(--sbb-header-height);
 
-  :host(:not([expanded]:not([expanded='false']))) & {
+  :host(:not([expanded])) & {
     @include sbb.page-spacing;
   }
 
-  :host([expanded]:not([expanded='false'])) & {
+  :host([expanded]) & {
     @include sbb.page-spacing-expanded;
   }
 }

--- a/src/components/sbb-image/sbb-image.scss
+++ b/src/components/sbb-image/sbb-image.scss
@@ -28,7 +28,7 @@
 // To support transparent images, we need also to fade out the blurred lqip image.
 // This is not perfect in the case of a non transparent image, but does not look that bad.
 .image__figure :is(.image__img, .image__blur-hash) {
-  :host(:not([disable-animation]:not([disable-animation='false']))) & {
+  :host(:not([disable-animation])) & {
     transition: opacity var(--sbb-animation-duration-4x) var(--sbb-animation-easing);
   }
 }

--- a/src/components/sbb-link/sbb-link.scss
+++ b/src/components/sbb-link/sbb-link.scss
@@ -25,7 +25,7 @@
 }
 
 // Using :where to be not more specific than inline variant
-:host([negative]:where(:not([negative='false']))) {
+:host([negative]) {
   @include sbb.link-variables--negative;
 }
 
@@ -33,7 +33,7 @@
   @include sbb.link-variables--inline;
 }
 
-:host([variant='inline'][negative]:not([negative='false'])) {
+:host([variant='inline'][negative]) {
   @include sbb.link-variables--inline-negative;
 }
 
@@ -56,6 +56,15 @@
     @include sbb.link-inline-base;
   }
 
+  :host([disabled]) & {
+    pointer-events: none;
+    cursor: default;
+
+    @include sbb.if-forced-colors {
+      color: GrayText;
+    }
+  }
+
   :host([size='xs']:not([variant='inline'])) & {
     @include sbb.text-xs--regular;
   }
@@ -68,15 +77,6 @@
     @include sbb.text-m--regular;
   }
 
-  :host([disabled]:not([disabled='false'])) & {
-    pointer-events: none;
-    cursor: default;
-
-    @include sbb.if-forced-colors {
-      color: GrayText;
-    }
-  }
-
   // Hide focus outline when focus origin is mouse or touch. This is being used in tooltip as a workaround.
   :host(:focus-visible:not([data-focus-origin='mouse'], [data-focus-origin='touch'])) & {
     @include sbb.focus-outline;
@@ -84,11 +84,11 @@
     border-radius: calc(var(--sbb-border-radius-4x) - var(--sbb-focus-outline-offset));
   }
 
-  :host(:hover:not([disabled]:not([disabled='false']))) & {
+  :host(:hover:not([disabled])) & {
     @include sbb.link-hover-rules;
   }
 
-  :host(:is(:active, [data-active]):not([disabled]:not([disabled='false']))) & {
+  :host(:is(:active, [data-active]):not([disabled])) & {
     // Active definitions have to be after :hover definitions
     @include sbb.link-active-rules;
   }

--- a/src/components/sbb-loading-indicator/sbb-loading-indicator.scss
+++ b/src/components/sbb-loading-indicator/sbb-loading-indicator.scss
@@ -11,7 +11,7 @@
   line-height: 0;
 }
 
-:host([disable-animation]:not([disable-animation='false'])) {
+:host([disable-animation]) {
   --sbb-loading-indicator-duration: 0;
 }
 

--- a/src/components/sbb-logo/sbb-logo.scss
+++ b/src/components/sbb-logo/sbb-logo.scss
@@ -24,7 +24,7 @@
   height: var(--sbb-logo-height);
 }
 
-:host([negative]:not([negative='false'])) {
+:host([negative]) {
   --sbb-logo-word-mark-color: var(--sbb-color-white-default);
 }
 

--- a/src/components/sbb-menu-action/sbb-menu-action.scss
+++ b/src/components/sbb-menu-action/sbb-menu-action.scss
@@ -17,14 +17,14 @@
   --sbb-menu-action-forced-color-border-color: CanvasText;
 }
 
-:host(:hover:not([disabled]:not([disabled='false']))) {
+:host(:hover:not([disabled])) {
   @include sbb.hover-mq($hover: true) {
     --sbb-menu-background-color: var(--sbb-color-iron-default);
     --sbb-menu-action-forced-color-border-color: Highlight;
   }
 }
 
-:host([disabled]:not([disabled='false'])) {
+:host([disabled]) {
   --sbb-menu-action-cursor: default;
   --sbb-menu-action-color: var(--sbb-color-graphite-default);
   --sbb-menu-action-forced-color-border-color: GrayText;
@@ -85,7 +85,7 @@
 .sbb-menu-action__label {
   @include sbb.ellipsis;
 
-  :host([disabled]:not([disabled='false'])) & {
+  :host([disabled]) & {
     text-decoration: line-through;
   }
 }

--- a/src/components/sbb-menu/sbb-menu.scss
+++ b/src/components/sbb-menu/sbb-menu.scss
@@ -53,7 +53,7 @@
   --sbb-menu-inset: 0;
 }
 
-:host([disable-animation]:not([disable-animation='false'])) {
+:host([disable-animation]) {
   --sbb-menu-animation-duration: 0.1ms;
 }
 

--- a/src/components/sbb-navigation-action/sbb-navigation-action.scss
+++ b/src/components/sbb-navigation-action/sbb-navigation-action.scss
@@ -12,7 +12,7 @@
   --sbb-navigation-action-color: var(--sbb-color-cloud-default);
 }
 
-:host([active]:not([active='false'])) {
+:host([active]) {
   --sbb-navigation-action-color: var(--sbb-color-storm-default);
 
   @include sbb.if-forced-colors {

--- a/src/components/sbb-navigation-section/sbb-navigation-section.scss
+++ b/src/components/sbb-navigation-section/sbb-navigation-section.scss
@@ -84,7 +84,7 @@
   --sbb-navigation-section-display: block;
 }
 
-:host([disable-animation]:not([disable-animation='false'])) {
+:host([disable-animation]) {
   --sbb-navigation-section-animation-duration: 0.1ms;
 }
 

--- a/src/components/sbb-navigation/sbb-navigation.scss
+++ b/src/components/sbb-navigation/sbb-navigation.scss
@@ -94,7 +94,7 @@
   }
 }
 
-:host([disable-animation]:not([disable-animation='false'])) {
+:host([disable-animation]) {
   --sbb-navigation-animation-duration: 0.1ms;
 }
 

--- a/src/components/sbb-notification/sbb-notification.scss
+++ b/src/components/sbb-notification/sbb-notification.scss
@@ -58,7 +58,7 @@
   margin: var(--sbb-notification-margin);
 }
 
-:host(:is([data-resize-disable-animation], [disable-animation]:not([disable-animation='false']))) {
+:host(:is([data-resize-disable-animation], [disable-animation])) {
   --sbb-notification-animation-duration: 0.1ms;
 }
 

--- a/src/components/sbb-optgroup/sbb-optgroup.tsx
+++ b/src/components/sbb-optgroup/sbb-optgroup.tsx
@@ -44,9 +44,7 @@ export class SbbOptGroup extends LitElement {
   public override connectedCallback(): void {
     super.connectedCallback();
     this._negativeObserver?.disconnect();
-    this._negative = !!this.closest(
-      `:is(sbb-autocomplete, sbb-select, sbb-form-field)[negative]:not([negative='false']`,
-    );
+    this._negative = !!this.closest(`:is(sbb-autocomplete, sbb-select, sbb-form-field)[negative]`);
     toggleDatasetEntry(this, 'negative', this._negative);
 
     this._negativeObserver.observe(this, {

--- a/src/components/sbb-option/sbb-option.scss
+++ b/src/components/sbb-option/sbb-option.scss
@@ -31,17 +31,17 @@
   --sbb-focus-outline-color: var(--sbb-focus-outline-color-dark);
 }
 
-:host([active]:not([active='false'])) {
+:host([active]) {
   --sbb-focus-outline-offset: calc(-1 * var(--sbb-spacing-fixed-1x));
 }
 
-:host(:hover:not([disabled]:not([disabled='false']), [data-group-disabled])) {
+:host(:hover:not([disabled], [data-group-disabled])) {
   @include sbb.hover-mq($hover: true) {
     --sbb-option-background-color: var(--sbb-option-background-color-hover);
   }
 }
 
-:host(:active:not([disabled]:not([disabled='false']), [data-group-disabled])) {
+:host(:active:not([disabled], [data-group-disabled])) {
   --sbb-option-background-color: var(--sbb-option-background-color-active);
 }
 
@@ -52,7 +52,7 @@
   }
 }
 
-:host(:is([data-group-disabled], [disabled]:not([disabled='false']))) {
+:host(:is([data-group-disabled], [disabled])) {
   --sbb-option-cursor: default;
 
   @include sbb.if-forced-colors {
@@ -70,7 +70,7 @@
 }
 
 .sbb-option__label--highlight {
-  :host(:not(:is([disabled]:not([disabled='false']), [data-group-disabled]))) & {
+  :host(:not(:is([disabled], [data-group-disabled]))) & {
     @include sbb.text--bold;
     @include sbb.if-forced-colors {
       color: Highlight;
@@ -97,14 +97,14 @@
   -webkit-tap-highlight-color: transparent;
   -webkit-text-fill-color: var(--sbb-option-color);
 
-  :host([active]:not([active='false'])) & {
+  :host([active]) & {
     @include sbb.focus-outline;
 
     border-radius: var(--sbb-option-border-radius);
   }
 
   // Add inner border and background for disabled option when it's not multiple
-  :host(:is([data-group-disabled], [disabled]:not([disabled='false'])):not([data-multiple])) & {
+  :host(:is([data-group-disabled], [disabled]):not([data-multiple])) & {
     position: relative;
     z-index: 0;
 

--- a/src/components/sbb-option/sbb-option.tsx
+++ b/src/components/sbb-option/sbb-option.tsx
@@ -166,7 +166,7 @@ export class SbbOption extends LitElement {
 
     this._negative = !!this.closest(
       // :is() selector not possible due to test environment
-      `sbb-autocomplete[negative]:not([negative='false']),sbb-select[negative]:not([negative='false']),sbb-form-field[negative]:not([negative='false'])`,
+      `sbb-autocomplete[negative],sbb-select[negative],sbb-form-field[negative]`,
     );
     toggleDatasetEntry(this, 'negative', this._negative);
 

--- a/src/components/sbb-pearl-chain-vertical-item/sbb-pearl-chain-vertical-item.scss
+++ b/src/components/sbb-pearl-chain-vertical-item/sbb-pearl-chain-vertical-item.scss
@@ -182,7 +182,7 @@ slot[name='right']::slotted(*) {
 
   inset-block-start: var(--sbb-pearl-chain-vertical-item-position);
 
-  :host([disable-animation]:not([disable-animation='false'])) & {
+  :host([disable-animation]) & {
     animation: unset !important;
   }
 }

--- a/src/components/sbb-radio-button/sbb-radio-button.scss
+++ b/src/components/sbb-radio-button/sbb-radio-button.scss
@@ -60,7 +60,7 @@
   }
 }
 
-:host([checked]:not([checked='false'])) {
+:host([checked]) {
   --sbb-radio-button-inner-circle-color: var(--sbb-color-red-default);
   --sbb-radio-button-background-fake-border-width: calc(
     (var(--sbb-radio-button-dimension) - var(--sbb-radio-button-inner-circle-dimension)) / 2
@@ -73,7 +73,7 @@
 }
 
 // Disabled definitions have to be after checked definitions
-:host(:is([data-group-disabled], [disabled]):not([disabled='false'])) {
+:host(:is([data-group-disabled], [disabled])) {
   --sbb-radio-button-background-color: var(--sbb-color-milk-default);
   --sbb-radio-button-subtext-color: var(--sbb-color-smoke-default);
   --sbb-radio-button-border-style: dashed;

--- a/src/components/sbb-select/sbb-select.scss
+++ b/src/components/sbb-select/sbb-select.scss
@@ -14,7 +14,7 @@
   --sbb-options-panel-internal-z-index: var(--sbb-select-z-index, var(--sbb-overlay-z-index));
 }
 
-:host([negative]:not([negative='false'])) {
+:host([negative]) {
   @include sbb.options-panel-overlay-negative-variables;
 }
 
@@ -51,7 +51,7 @@
   );
 }
 
-:host([disable-animation]:not([disable-animation='false'])) {
+:host([disable-animation]) {
   --sbb-options-panel-animation-duration: 0.1ms;
 }
 
@@ -59,7 +59,7 @@
   margin-block: var(--sbb-spacing-fixed-3x);
 }
 
-:host([preserve-icon-space]:not([preserve-icon-space='false'])) {
+:host([preserve-icon-space]) {
   --sbb-option-icon-container-display: block;
 }
 
@@ -101,7 +101,7 @@
     @include sbb.shadow-level-5-hard;
   }
 
-  :host(:is([data-state='opened'], [data-state='opening'])[negative]:not([negative='false'])) & {
+  :host(:is([data-state='opened'], [data-state='opening'])[negative]) & {
     @include sbb.shadow-level-5-hard-negative;
   }
 
@@ -129,7 +129,7 @@
         :is(
             [data-state='opened'],
             [data-state='opening']
-          )[data-option-panel-origin-borderless][negative]:not([negative='false'])
+          )[data-option-panel-origin-borderless][negative]
       )
       & {
       @include sbb.shadow-level-5-hard-negative;

--- a/src/components/sbb-selection-panel/sbb-selection-panel.scss
+++ b/src/components/sbb-selection-panel/sbb-selection-panel.scss
@@ -49,11 +49,11 @@
   --sbb-selection-panel-border-color: transparent;
 }
 
-:host(:is([data-resize-disable-animation], [disable-animation]:not([disable-animation='false']))) {
+:host(:is([data-resize-disable-animation], [disable-animation])) {
   --sbb-selection-panel-animation-duration: 0.1ms;
 }
 
-:host([data-has-content][force-open]:not([force-open='false'])),
+:host([data-has-content][force-open]),
 :host([data-has-content][data-checked]) {
   --sbb-selection-panel-input-padding: var(--sbb-spacing-responsive-xs)
     var(--sbb-spacing-responsive-xxs) var(--sbb-spacing-responsive-xxs)

--- a/src/components/sbb-slider/sbb-slider.scss
+++ b/src/components/sbb-slider/sbb-slider.scss
@@ -32,20 +32,20 @@
   width: min(#{sbb.px-to-rem-build(400)}, 100%);
 }
 
-:host([disabled]:not([disabled='false'])) {
+:host([disabled]) {
   --sbb-slider-icon-color: var(--sbb-color-graphite-default);
   --sbb-slider-knob-border-color: var(--sbb-color-smoke-default);
   --sbb-slider-knob-border-size: var(--sbb-border-width-2x);
   --sbb-slider-knob-border-style: dashed;
 }
 
-:host([readonly]:not([readonly='false'])) {
+:host([readonly]) {
   --sbb-slider-icon-color: var(--sbb-color-smoke-default);
   --sbb-slider-knob-border-color: var(--sbb-slider-selected-line-disabled-color);
 }
 
-:host([disabled]:not([disabled='false'])),
-:host([readonly]:not([readonly='false'])) {
+:host([disabled]),
+:host([readonly]) {
   @include sbb.if-forced-colors {
     --sbb-slider-icon-color: GrayText;
     --sbb-slider-selected-line-disabled-color: GrayText;
@@ -129,9 +129,7 @@
   }
 
   // slider knob resize on click (active / focus)
-  :host(:not(:is([disabled]:not([disabled='false']), [readonly]:not([readonly='false']))))
-    .sbb-slider__range-input:active
-    ~ & {
+  :host(:not(:is([disabled], [readonly]))) .sbb-slider__range-input:active ~ & {
     --sbb-slider-knob-size: var(--sbb-slider-knob-size-active);
   }
 }

--- a/src/components/sbb-tab-group/sbb-tab-group.scss
+++ b/src/components/sbb-tab-group/sbb-tab-group.scss
@@ -20,7 +20,7 @@
     overflow: hidden;
   }
 
-  ::slotted(*[active]:not([active='false'])) {
+  ::slotted(*[active]) {
     visibility: visible;
     opacity: 1;
     height: fit-content;
@@ -39,8 +39,8 @@
 }
 
 // Make inactive nested tab groups non-focusable, to ensure accessibility
-:host(.tab-group--nested:not([active]:not([active='false']))) *,
-:host(.tab-group--nested:not([active]:not([active='false']))) ::slotted(*) {
+:host(.tab-group--nested:not([active])) *,
+:host(.tab-group--nested:not([active])) ::slotted(*) {
   visibility: hidden;
   opacity: 0;
   height: 0;

--- a/src/components/sbb-tab-title/sbb-tab-title.scss
+++ b/src/components/sbb-tab-title/sbb-tab-title.scss
@@ -38,7 +38,7 @@
   }
 }
 
-:host([disabled]:not([disabled='false'])) {
+:host([disabled]) {
   --sbb-tab-title-icon-color: var(--sbb-color-granite-default);
   --sbb-tab-title-background-color: var(--sbb-color-milk-default);
   --sbb-tab-title-cursor: unset;
@@ -53,7 +53,7 @@
 }
 
 // If active and not disabled
-:host([active]:not([active='false'], [disabled]:not([disabled='false']))) {
+:host([active]:not([disabled])) {
   --sbb-tab-title-color: var(--sbb-color-charcoal-default);
   --sbb-tab-title-icon-color: var(--sbb-tab-title-color);
   --sbb-tab-title-background-color: var(--sbb-color-black-default);
@@ -68,7 +68,7 @@
   }
 }
 
-:host(:hover:not([disabled]:not([disabled='false']))) {
+:host(:hover:not([disabled])) {
   @include sbb.hover-mq($hover: true) {
     --sbb-tab-title-marker-transform: scale(1);
   }

--- a/src/components/sbb-tag/sbb-tag.scss
+++ b/src/components/sbb-tag/sbb-tag.scss
@@ -41,7 +41,7 @@
 }
 
 // Active state
-:host([checked]:not([checked='false'])) {
+:host([checked]) {
   --sbb-tag-border-color: var(--sbb-color-charcoal-default);
   --sbb-tag-border-width: var(--sbb-border-width-2x);
 
@@ -50,7 +50,7 @@
   }
 }
 
-:host([disabled]:not([disabled='false'])) {
+:host([disabled]) {
   --sbb-tag-text-color: var(--sbb-color-granite-default);
   --sbb-tag-amount-color: var(--sbb-tag-text-color);
   --sbb-tag-background-color: var(--sbb-color-milk-default);
@@ -64,11 +64,11 @@
   }
 }
 
-:host([checked]:not([checked='false'])[disabled]:not([disabled='false'])) {
+:host([checked][disabled]) {
   --sbb-tag-border-color: var(--sbb-color-metal-default);
 }
 
-:host(:hover:not([disabled]:not([disabled='false']), :active, [data-active])) {
+:host(:hover:not([disabled], :active, [data-active])) {
   @include sbb.hover-mq($hover: true) {
     --sbb-tag-background-color: var(--sbb-color-milk-default);
     --sbb-tag-inset: calc(var(--sbb-border-width-2x) * -1);
@@ -81,7 +81,7 @@
 }
 
 // Pressed state
-:host(:is(:active, [data-active]):not([disabled]:not([disabled='false']))) {
+:host(:is(:active, [data-active]):not([disabled])) {
   --sbb-tag-background-color: var(--sbb-color-milk-default);
   --sbb-tag-border-color: var(--sbb-color-iron-default);
   --sbb-tag-border-width: var(--sbb-border-width-2x);
@@ -127,7 +127,7 @@
     }
   }
 
-  :host([disabled]:not([disabled='false'])) & {
+  :host([disabled]) & {
     cursor: unset;
     pointer-events: none;
   }

--- a/src/components/sbb-teaser/sbb-teaser.scss
+++ b/src/components/sbb-teaser/sbb-teaser.scss
@@ -21,7 +21,7 @@
   --sbb-teaser-brightness-hover: 1.075;
 }
 
-:host([is-stacked]:not([is-stacked='false'])) {
+:host([is-stacked]) {
   --sbb-teaser-flex-direction: column;
   --sbb-teaser-align-items: baseline;
   --sbb-teaser-gap: var(--sbb-spacing-fixed-3x);

--- a/src/components/sbb-timetable-row/sbb-timetable-row.scss
+++ b/src/components/sbb-timetable-row/sbb-timetable-row.scss
@@ -12,7 +12,7 @@
   --sbb-timetable-row-skeleton-pulse-duration: 1800ms;
 }
 
-:host([disable-animation]:not([disable-animation='false'])) {
+:host([disable-animation]) {
   --sbb-timetable-row-skeleton-pulse-duration: 0;
 }
 

--- a/src/components/sbb-title/sbb-title.scss
+++ b/src/components/sbb-title/sbb-title.scss
@@ -15,62 +15,38 @@
   margin-block: var(--sbb-title-margin-block-start) var(--sbb-title-margin-block-end);
 }
 
-:host(:where(:not([visually-hidden]:not([visually-hidden='false'])))) {
+:host(:where(:not([visually-hidden]))) {
   --sbb-title-margin-block-start: var(--sbb-spacing-responsive-m);
   --sbb-title-margin-block-end: var(--sbb-spacing-responsive-s);
 }
 
 // Due to using :where, order does matter
-:host(
-    :where([level='1']:not([visual-level]), [visual-level='1']):where(
-        :not([visually-hidden]:not([visually-hidden='false']))
-      )
-  ) {
+:host(:where([level='1']:not([visual-level]), [visual-level='1']):where(:not([visually-hidden]))) {
   --sbb-title-margin-block-start: var(--sbb-spacing-responsive-l);
 }
 
 // Due to using :where, order does matter
-:host(
-    :where([level='2']:not([visual-level]), [visual-level='2']):where(
-        :not([visually-hidden]:not([visually-hidden='false']))
-      )
-  ),
-:host(
-    :where([level='3']:not([visual-level]), [visual-level='3']):where(
-        :not([visually-hidden]:not([visually-hidden='false']))
-      )
-  ) {
+:host(:where([level='2']:not([visual-level]), [visual-level='2']):where(:not([visually-hidden]))),
+:host(:where([level='3']:not([visual-level]), [visual-level='3']):where(:not([visually-hidden]))) {
   --sbb-title-margin-block-end: var(--sbb-spacing-responsive-xxxs);
 }
 
 // Due to using :where, order does matter
-:host(
-    :where([level='4']:not([visual-level]), [visual-level='4']):where(
-        :not([visually-hidden]:not([visually-hidden='false']))
-      )
-  ) {
+:host(:where([level='4']:not([visual-level]), [visual-level='4']):where(:not([visually-hidden]))) {
   --sbb-title-margin-block-end: var(--sbb-spacing-fixed-3x);
 }
 
 // Due to using :where, order does matter
-:host(
-    :where([level='5']:not([visual-level]), [visual-level='5']):where(
-        :not([visually-hidden]:not([visually-hidden='false']))
-      )
-  ) {
+:host(:where([level='5']:not([visual-level]), [visual-level='5']):where(:not([visually-hidden]))) {
   --sbb-title-margin-block-end: var(--sbb-spacing-fixed-2x);
 }
 
 // Due to using :where, order does matter
-:host(
-    :where([level='6']:not([visual-level]), [visual-level='6']):where(
-        :not([visually-hidden]:not([visually-hidden='false']))
-      )
-  ) {
+:host(:where([level='6']:not([visual-level]), [visual-level='6']):where(:not([visually-hidden]))) {
   --sbb-title-margin-block-end: var(--sbb-spacing-fixed-1x);
 }
 
-:host([negative]:not([negative='false'])) {
+:host([negative]) {
   @include sbb.title--negative;
 }
 
@@ -83,7 +59,7 @@
 
   color: var(--sbb-title-text-color-normal);
 
-  :host([visually-hidden]:not([visually-hidden='false'])) & {
+  :host([visually-hidden]) & {
     @include sbb.screen-reader-only;
   }
 

--- a/src/components/sbb-toast/sbb-toast.scss
+++ b/src/components/sbb-toast/sbb-toast.scss
@@ -21,7 +21,7 @@
   --sbb-toast-vertical-position: initial;
 }
 
-:host([disable-animation]:not([disable-animation='false'])) {
+:host([disable-animation]) {
   --sbb-toast-animation-duration: 0.1ms;
 }
 

--- a/src/components/sbb-toggle-check/sbb-toggle-check.scss
+++ b/src/components/sbb-toggle-check/sbb-toggle-check.scss
@@ -37,7 +37,7 @@
   --sbb-toggle-check-overall-height: calc(1em * var(--sbb-typo-line-height-body-text));
 }
 
-:host([checked]:not([checked='false'])) {
+:host([checked]) {
   --sbb-toggle-check-background-color: var(--sbb-toggle-check-checked-color);
   --sbb-toggle-check-circle-border-color: var(--sbb-toggle-check-background-color);
   --sbb-toggle-check-icon-opacity: 1;
@@ -56,7 +56,7 @@
   }
 }
 
-:host([disabled]:not([disabled='false'])) {
+:host([disabled]) {
   --sbb-toggle-check-background-color: var(--sbb-color-cloud-default);
   --sbb-toggle-check-circle-border-color: var(--sbb-color-smoke-default);
   --sbb-toggle-check-circle-border-style: dashed;
@@ -71,7 +71,7 @@
   }
 }
 
-:host([checked]:not([checked='false'])[disabled]:not([disabled='false'])) {
+:host([checked][disabled]) {
   --sbb-toggle-check-circle-background-color: var(--sbb-color-white-default);
 }
 

--- a/src/components/sbb-toggle-option/sbb-toggle-option.scss
+++ b/src/components/sbb-toggle-option/sbb-toggle-option.scss
@@ -24,11 +24,11 @@
   outline: none !important;
 }
 
-:host([checked]:not([checked='false'])) {
+:host([checked]) {
   --sbb-toggle-option-color: var(--sbb-color-charcoal-default);
 }
 
-:host([disabled]:not([disabled='false'])) {
+:host([disabled]) {
   --sbb-toggle-option-cursor: unset;
   --sbb-toggle-option-color: var(--sbb-color-granite-default);
 }

--- a/src/components/sbb-toggle/sbb-toggle.scss
+++ b/src/components/sbb-toggle/sbb-toggle.scss
@@ -27,7 +27,7 @@
   }
 }
 
-:host([even]:not([even='false'])) {
+:host([even]) {
   --sbb-toggle-width: 100%;
 
   ::slotted(sbb-toggle-option) {
@@ -35,7 +35,7 @@
   }
 }
 
-:host([disabled]:not([disabled='false'])) {
+:host([disabled]) {
   --sbb-toggle-selected-option-border-color: var(--sbb-color-graphite-default);
   --sbb-toggle-border-style: dashed;
 
@@ -54,7 +54,7 @@
   }
 }
 
-:host([disable-animation]:not([disable-animation='false'])),
+:host([disable-animation]),
 :host([data-disable-animation-on-resizing]) {
   --sbb-toggle-animation-duration: 0.1ms;
 }

--- a/src/components/sbb-tooltip-trigger/sbb-tooltip-trigger.scss
+++ b/src/components/sbb-tooltip-trigger/sbb-tooltip-trigger.scss
@@ -22,7 +22,7 @@
     --sbb-tooltip-color: var(--sbb-color-iron-default);
   }
 
-  :host(:hover[negative]:not([negative='false'])) {
+  :host(:hover[negative]) {
     --sbb-tooltip-color: var(--sbb-color-cloud-default);
   }
 }
@@ -31,11 +31,11 @@
   --sbb-tooltip-color: var(--sbb-color-anthracite-default);
 }
 
-:host(:is(:active, [data-active])[negative]:not([negative='false'])) {
+:host(:is(:active, [data-active])[negative]) {
   --sbb-tooltip-color: var(--sbb-color-cement-default);
 }
 
-:host([disabled]:not([disabled='false'])) {
+:host([disabled]) {
   --sbb-tooltip-color: var(--sbb-color-graphite-default);
 
   @include sbb.if-forced-colors {
@@ -45,17 +45,17 @@
   pointer-events: none;
 }
 
-:host([disabled]:not([disabled='false'])[negative]:not([negative='false'])) {
+:host([disabled][negative]) {
   --sbb-tooltip-color: var(--sbb-color-smoke-default);
 }
 
 @include sbb.icon-button-base(':host([data-icon-small])', '.sbb-tooltip-trigger', 'sbb-icon');
 
-:host([data-icon-small][negative]:not([negative='false'])) {
+:host([data-icon-small][negative]) {
   @include sbb.icon-button-variables-negative;
 }
 
-:host([data-icon-small][disabled]:not([disabled='false'])) {
+:host([data-icon-small][disabled]) {
   @include sbb.icon-button-disabled('.sbb-tooltip-trigger');
 }
 
@@ -65,7 +65,7 @@
   @include sbb.icon-button-focus-visible('.sbb-tooltip-trigger');
 }
 
-:host([data-icon-small]:not([disabled]:not([disabled='false']), :active, [data-active]):hover) {
+:host([data-icon-small]:not([disabled], :active, [data-active]):hover) {
   @include sbb.icon-button-hover('.sbb-tooltip-trigger');
 }
 

--- a/src/components/sbb-tooltip/sbb-tooltip.scss
+++ b/src/components/sbb-tooltip/sbb-tooltip.scss
@@ -29,7 +29,7 @@
   display: contents;
 }
 
-:host([disable-animation]:not([disable-animation='false'])) {
+:host([disable-animation]) {
   --sbb-tooltip-animation-duration: 0.1ms;
 }
 

--- a/src/components/sbb-train-formation/sbb-train-formation.scss
+++ b/src/components/sbb-train-formation/sbb-train-formation.scss
@@ -16,7 +16,7 @@
   }
 }
 
-:host([hide-wagon-label]:not([hide-wagon-label='false'])) {
+:host([hide-wagon-label]) {
   --sbb-train-formation-wagon-label-display: none;
 }
 

--- a/src/components/sbb-visual-checkbox/sbb-visual-checkbox.scss
+++ b/src/components/sbb-visual-checkbox/sbb-visual-checkbox.scss
@@ -19,7 +19,7 @@
   }
 }
 
-:host([negative]:not([negative='false'])) {
+:host([negative]) {
   --sbb-visual-checkbox-background-color: var(--sbb-color-midnight-default);
   --sbb-visual-checkbox-border-color: var(--sbb-color-smoke-default);
   --sbb-visual-checkbox-selection-color: var(--sbb-color-red-default);
@@ -29,7 +29,7 @@
   }
 }
 
-:host([disabled]:not([disabled='false'])) {
+:host([disabled]) {
   --sbb-visual-checkbox-background-color: var(--sbb-color-milk-default);
   --sbb-visual-checkbox-border-color: var(--sbb-color-smoke-default);
   --sbb-visual-checkbox-border-style: dashed;
@@ -41,7 +41,7 @@
   }
 }
 
-:host([disabled]:not([disabled='false'])[negative]:not([negative='false'])) {
+:host([disabled][negative]) {
   --sbb-visual-checkbox-background-color: var(--sbb-color-charcoal-default);
   --sbb-visual-checkbox-border-color: var(--sbb-color-smoke-default);
   --sbb-visual-checkbox-selection-color: var(--sbb-color-white-default);
@@ -51,13 +51,13 @@
   }
 }
 
-:host([indeterminate]:not([indeterminate='false'])) {
+:host([indeterminate]) {
   @include sbb.if-forced-colors {
     --sbb-visual-checkbox-selection-color: ButtonBorder;
   }
 }
 
-:host([indeterminate]:not([indeterminate='false'])[disabled]:not([disabled='false'])) {
+:host([indeterminate][disabled]) {
   @include sbb.if-forced-colors {
     --sbb-visual-checkbox-selection-color: GrayText;
   }
@@ -80,16 +80,16 @@
     outline: var(--sbb-border-width-2x) solid ButtonBorder;
     outline-offset: calc(-1 * var(--sbb-border-width-2x));
 
-    :host([checked]:not([checked='false'])) & {
+    :host([checked]) & {
       background-color: HighLight;
       outline: none;
     }
 
-    :host([disabled]:not([disabled='false'])) & {
+    :host([disabled]) & {
       outline-color: GrayText;
     }
 
-    :host([checked]:not([checked='false'])[disabled]:not([disabled='false'])) & {
+    :host([checked][disabled]) & {
       background-color: GrayText;
     }
   }


### PR DESCRIPTION
Removes CSS selectors for boolean attribues. For example: 
```scss 
:not([disabled="false"]);
```