### PR TITLE
fix: connect sbb-datepicker with related components when initialized

### DIFF
--- a/src/components/datepicker/datepicker-next-day/datepicker-next-day.ts
+++ b/src/components/datepicker/datepicker-next-day/datepicker-next-day.ts
@@ -90,6 +90,11 @@ export class SbbDatepickerNextDay extends LitElement {
     this._syncUpstreamProperties();
     if (!this.datePicker) {
       this._init();
+      // If the component is attached to the DOM before the datepicker, it has to listen for the datepicker init,
+      // assuming that the two components share the same parent element.
+      if (!this._datePickerElement) {
+        this.parentElement.addEventListener('input-updated', () => this._init(), { once: true });
+      }
     }
   }
 

--- a/src/components/datepicker/datepicker-next-day/datepicker-next-day.ts
+++ b/src/components/datepicker/datepicker-next-day/datepicker-next-day.ts
@@ -207,7 +207,7 @@ export class SbbDatepickerNextDay extends LitElement {
   private _setAriaLabel(): void {
     const currentDate = this._datePickerElement.getValueAsDate();
 
-    if (!currentDate) {
+    if (!currentDate || !this._dateAdapter.isValid(currentDate)) {
       this.setAttribute('aria-label', i18nNextDay[this._currentLanguage]);
       return;
     }

--- a/src/components/datepicker/datepicker-next-day/datepicker-next-day.ts
+++ b/src/components/datepicker/datepicker-next-day/datepicker-next-day.ts
@@ -90,11 +90,6 @@ export class SbbDatepickerNextDay extends LitElement {
     this._syncUpstreamProperties();
     if (!this.datePicker) {
       this._init();
-      // If the component is attached to the DOM before the datepicker, it has to listen for the datepicker init,
-      // assuming that the two components share the same parent element.
-      if (!this._datePickerElement) {
-        this.parentElement.addEventListener('input-updated', () => this._init(), { once: true });
-      }
     }
   }
 
@@ -131,6 +126,13 @@ export class SbbDatepickerNextDay extends LitElement {
     this._datePickerController = new AbortController();
     this._datePickerElement = getDatePicker(this, picker);
     if (!this._datePickerElement) {
+      // If the component is attached to the DOM before the datepicker, it has to listen for the datepicker init,
+      // assuming that the two components share the same parent element.
+      this.parentElement.addEventListener(
+        'input-updated',
+        (e: Event) => this._init(e.target as SbbDatepicker),
+        { once: true, signal: this._abort.signal },
+      );
       return;
     }
     this._setDisabledState(this._datePickerElement);

--- a/src/components/datepicker/datepicker-next-day/readme.md
+++ b/src/components/datepicker/datepicker-next-day/readme.md
@@ -28,7 +28,7 @@ if it is disabled, or if the selected date is equal to the input's `max` attribu
 </sbb-form-field>
 ```
 
-Since the component needs the `sbb-datepicker` to work properly, if they are dynamically added,
+NOTE: Since the component needs the `sbb-datepicker` to work properly,
 both standalone or within the `sbb-form-field`, they must have the same parent element to be correctly connected.
 
 <!-- Auto Generated Below -->

--- a/src/components/datepicker/datepicker-next-day/readme.md
+++ b/src/components/datepicker/datepicker-next-day/readme.md
@@ -28,6 +28,9 @@ if it is disabled, or if the selected date is equal to the input's `max` attribu
 </sbb-form-field>
 ```
 
+Since the component needs the `sbb-datepicker` to work properly, if they are dynamically added,
+both standalone or within the `sbb-form-field`, they must have the same parent element to be correctly connected.
+
 <!-- Auto Generated Below -->
 
 ## Properties

--- a/src/components/datepicker/datepicker-previous-day/datepicker-previous-day.ts
+++ b/src/components/datepicker/datepicker-previous-day/datepicker-previous-day.ts
@@ -90,6 +90,11 @@ export class SbbDatepickerPreviousDay extends LitElement {
     this._syncUpstreamProperties();
     if (!this.datePicker) {
       this._init();
+      // If the component is attached to the DOM before the datepicker, it has to listen for the datepicker init,
+      // assuming that the two components share the same parent element.
+      if (!this._datePickerElement) {
+        this.parentElement.addEventListener('input-updated', () => this._init(), { once: true });
+      }
     }
   }
 

--- a/src/components/datepicker/datepicker-previous-day/datepicker-previous-day.ts
+++ b/src/components/datepicker/datepicker-previous-day/datepicker-previous-day.ts
@@ -207,7 +207,7 @@ export class SbbDatepickerPreviousDay extends LitElement {
   private _setAriaLabel(): void {
     const currentDate = this._datePickerElement.getValueAsDate();
 
-    if (!currentDate) {
+    if (!currentDate || !this._dateAdapter.isValid(currentDate)) {
       this.setAttribute('aria-label', i18nPreviousDay[this._currentLanguage]);
       return;
     }

--- a/src/components/datepicker/datepicker-previous-day/datepicker-previous-day.ts
+++ b/src/components/datepicker/datepicker-previous-day/datepicker-previous-day.ts
@@ -90,11 +90,6 @@ export class SbbDatepickerPreviousDay extends LitElement {
     this._syncUpstreamProperties();
     if (!this.datePicker) {
       this._init();
-      // If the component is attached to the DOM before the datepicker, it has to listen for the datepicker init,
-      // assuming that the two components share the same parent element.
-      if (!this._datePickerElement) {
-        this.parentElement.addEventListener('input-updated', () => this._init(), { once: true });
-      }
     }
   }
 
@@ -131,6 +126,13 @@ export class SbbDatepickerPreviousDay extends LitElement {
     this._datePickerController = new AbortController();
     this._datePickerElement = getDatePicker(this, picker);
     if (!this._datePickerElement) {
+      // If the component is attached to the DOM before the datepicker, it has to listen for the datepicker init,
+      // assuming that the two components share the same parent element.
+      this.parentElement.addEventListener(
+        'input-updated',
+        (e: Event) => this._init(e.target as SbbDatepicker),
+        { once: true, signal: this._abort.signal },
+      );
       return;
     }
     this._setDisabledState(this._datePickerElement);

--- a/src/components/datepicker/datepicker-previous-day/readme.md
+++ b/src/components/datepicker/datepicker-previous-day/readme.md
@@ -28,6 +28,9 @@ if it is disabled, or if the selected date is equal to the input's `min` attribu
 </sbb-form-field>
 ```
 
+Since the component needs the `sbb-datepicker` to work properly, if they are dynamically added,
+both standalone or within the `sbb-form-field`, they must have the same parent element to be correctly connected.
+
 <!-- Auto Generated Below -->
 
 ## Properties

--- a/src/components/datepicker/datepicker-previous-day/readme.md
+++ b/src/components/datepicker/datepicker-previous-day/readme.md
@@ -28,7 +28,7 @@ if it is disabled, or if the selected date is equal to the input's `min` attribu
 </sbb-form-field>
 ```
 
-Since the component needs the `sbb-datepicker` to work properly, if they are dynamically added,
+NOTE: Since the component needs the `sbb-datepicker` to work properly,
 both standalone or within the `sbb-form-field`, they must have the same parent element to be correctly connected.
 
 <!-- Auto Generated Below -->

--- a/src/components/datepicker/datepicker-toggle/datepicker-toggle.ts
+++ b/src/components/datepicker/datepicker-toggle/datepicker-toggle.ts
@@ -87,11 +87,6 @@ export class SbbDatepickerToggle extends LitElement {
     this._handlerRepository.connect();
     if (!this.datePicker) {
       this._init();
-      // If the component is attached to the DOM before the datepicker, it has to listen for the datepicker init,
-      // assuming that the two components share the same parent element.
-      if (!this._datePickerElement) {
-        this.parentElement.addEventListener('input-updated', () => this._init(), { once: true });
-      }
     }
 
     const formField = this.closest('sbb-form-field') ?? this.closest('[data-form-field]');
@@ -102,7 +97,7 @@ export class SbbDatepickerToggle extends LitElement {
 
   public override willUpdate(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has('datePicker')) {
-      this._findDatePicker(this.datePicker, changedProperties.get('datePicker'));
+      this._init(this.datePicker);
     }
   }
 
@@ -117,6 +112,13 @@ export class SbbDatepickerToggle extends LitElement {
     this._datePickerController = new AbortController();
     this._datePickerElement = getDatePicker(this, datePicker);
     if (!this._datePickerElement) {
+      // If the component is attached to the DOM before the datepicker, it has to listen for the datepicker init,
+      // assuming that the two components share the same parent element.
+      this.parentElement.addEventListener(
+        'input-updated',
+        (e: Event) => this._init(e.target as SbbDatepicker),
+        { once: true, signal: this._datePickerController.signal },
+      );
       return;
     }
 

--- a/src/components/datepicker/datepicker-toggle/datepicker-toggle.ts
+++ b/src/components/datepicker/datepicker-toggle/datepicker-toggle.ts
@@ -107,7 +107,7 @@ export class SbbDatepickerToggle extends LitElement {
     this._handlerRepository.disconnect();
   }
 
-  private async _init(datePicker?: string | SbbDatepicker): Promise<void> {
+  private _init(datePicker?: string | SbbDatepicker): void {
     this._datePickerController?.abort();
     this._datePickerController = new AbortController();
     this._datePickerElement = getDatePicker(this, datePicker);
@@ -149,6 +149,9 @@ export class SbbDatepickerToggle extends LitElement {
   }
 
   private _configureCalendar(calendar: SbbCalendar, datepicker: SbbDatepicker): void {
+    if (!calendar || !datepicker) {
+      return;
+    }
     calendar.wide = datepicker?.wide;
     calendar.dateFilter = datepicker?.dateFilter;
   }
@@ -225,7 +228,7 @@ export class SbbDatepickerToggle extends LitElement {
           .max=${this._max}
           ?wide=${this._datePickerElement?.wide}
           .dateFilter=${this._datePickerElement?.dateFilter}
-          @date-selected=${async (d: CustomEvent<Date>) => {
+          @date-selected=${(d: CustomEvent<Date>) => {
             const newDate = new Date(d.detail);
             this._calendarElement.selectedDate = newDate;
             this._datePickerElement.setValueAsDate(newDate);

--- a/src/components/datepicker/datepicker-toggle/datepicker-toggle.ts
+++ b/src/components/datepicker/datepicker-toggle/datepicker-toggle.ts
@@ -87,6 +87,11 @@ export class SbbDatepickerToggle extends LitElement {
     this._handlerRepository.connect();
     if (!this.datePicker) {
       this._init();
+      // If the component is attached to the DOM before the datepicker, it has to listen for the datepicker init,
+      // assuming that the two components share the same parent element.
+      if (!this._datePickerElement) {
+        this.parentElement.addEventListener('input-updated', () => this._init(), { once: true });
+      }
     }
 
     const formField = this.closest('sbb-form-field') ?? this.closest('[data-form-field]');

--- a/src/components/datepicker/datepicker-toggle/readme.md
+++ b/src/components/datepicker/datepicker-toggle/readme.md
@@ -29,7 +29,7 @@ otherwise, they can be connected using the `datePicker` property as described ab
 </sbb-form-field>
 ```
 
-Since the component needs the `sbb-datepicker` to work properly, if they are dynamically added,
+NOTE: Since the component needs the `sbb-datepicker` to work properly,
 both standalone or within the `sbb-form-field`, they must have the same parent element to be correctly connected.
 
 <!-- Auto Generated Below -->

--- a/src/components/datepicker/datepicker-toggle/readme.md
+++ b/src/components/datepicker/datepicker-toggle/readme.md
@@ -29,6 +29,9 @@ otherwise, they can be connected using the `datePicker` property as described ab
 </sbb-form-field>
 ```
 
+Since the component needs the `sbb-datepicker` to work properly, if they are dynamically added,
+both standalone or within the `sbb-form-field`, they must have the same parent element to be correctly connected.
+
 <!-- Auto Generated Below -->
 
 ## Properties


### PR DESCRIPTION
Closes #2047 

Code for testing (in toggle stories):

```
const fn = () : void => {
  const picker = document.createElement('sbb-datepicker');
  const container = document.querySelector('#container');
  container.append(picker);
};

const TestTemplate = ({negative, ...args}): JSX.Element => (
  <div>
    <sbb-form-field negative={negative} id='container'>
    <input />
    {StandaloneTemplate(null, args)}
    </sbb-form-field>
    <button onClick={() => fn()}>Click</button>
  </div>
);

export const Test: StoryObj = {
  render: TestTemplate,
  argTypes: defaultArgTypes,
  args: { ...defaultArgs },
};
```

Code for testing standalone case:

```
const fn = () : void => {
  const picker = document.createElement('sbb-datepicker');
  picker.setAttribute('id', 'datepicker');
  picker.setAttribute('input', 'datepicker-input');
  const container = document.querySelector('#container');
  container.append(picker);
};

const TestTemplate = ({negative, ...args}): JSX.Element => (
  <div id='container'>
    <input  id="datepicker-input" />
    {StandaloneTemplate('datepicker', args)}
    <button onClick={() => fn()}>Click</button>
  </div>
);

export const Test: StoryObj = {
  render: TestTemplate,
  argTypes: defaultArgTypes,
  args: { ...defaultArgs },
};
```
