### PR TITLE
chore: removed stencil references from docs

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -21,10 +21,10 @@ Run `yarn lint --fix` to fix any automatically fixable lint issues and report th
 
 ## Outputs
 
-| Folder             | Explanation                               |
-| ------------------ | ----------------------------------------- |
-| ./dist             | main output target for stencil components |
-| ./storybook-static | rendered static storybook site            |
+| Folder             | Explanation                           |
+| ------------------ | ------------------------------------- |
+| ./dist             | main output target for web-components |
+| ./storybook-static | rendered static storybook site        |
 
 ## Running tests
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > _Lyne Components_ are the building blocks of the [Lyne Design System](https://github.com/lyne-design-system/lyne/blob/master/docs/TERMINOLOGY.md#lyne)
 > and are based on standard compliant [Web Components](https://github.com/lyne-design-system/lyne/blob/master/docs/TERMINOLOGY.md#web-components)
-> compiled by [StencilJS](https://github.com/lyne-design-system/lyne/blob/master/docs/TERMINOLOGY.md#stenciljs) and
+> created using [Lit](https://github.com/lyne-design-system/lyne/blob/master/docs/TERMINOLOGY.md#lit) and
 > browsable through [Storybook](https://github.com/lyne-design-system/lyne/blob/master/docs/TERMINOLOGY.md#storybook)
 
 <br>

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,7 +1,7 @@
 # Todos
 
 - [git(hub)](#github)
-- [Local dev setup / Stencil setup](#local-dev-setup--stencil-setup)
+- [Local dev setup](#local-dev-setup)
 - [Storybook](#storybook)
 - [CI / CD pipeline](#ci--cd-pipeline)
 - [Documentation](#documentation)
@@ -56,22 +56,16 @@
 
 ✅ Nothing to verify
 
-## Local dev setup / Stencil setup
+## Local dev setup
 
 - [ ] Rename npm package name to `lyne-components`
-- [x] npm script `start` runs Stencil and Storybook in parallel. We need sequential. The problem is that `start:stencil` has no exit code since it is serving and watching, so the second sequential command `start:storybook` is not run. Quick fix is to run them parallel. Possible workaround: `"build:stencil:dev": "stencil build --ci --dev --docs", "build:dev": "npm-run-all --sequential build:stencil:dev build:storybook", "develop": "npm-run-all --sequential build:dev start"`
-- [ ] We have 2 servers running, 1 for stencil and 1 for storybook. If you run `npm start`, and then press `ctrl&c` only 1 server is stopped, the other is still running (you can verify by pressing to up arrow key)
 - [ ] For storybook v6, `addon-docs` had to be removed since it is deprecated. Switch to mdx docs.
 
 - [ ] Decide if we should fix dependencies/devDependencies in `package.json` to patch versions only (~1.0.0) or minor versions (^1.0.0) or to exact version (1.0.0). If so, which ones? Why? Probably fix to minor version? Or Major?
 - [x] ESLint: currently, we ignore `*.spec.ts` and `*.e2e.ts` files. Include them in linting and add corresponding rules
-- [ ] Stencil has a set of typescript-rules. It would make sense that we adhere to these:
-  - [ ] https://stenciljs.com/docs/style-guide
-  - [ ] https://www.npmjs.com/package/tslint-stencil (TSLint is deprecated. We might/must write our own portation to ESLint: https://github.com/natemoo-re/tslint-stencil/issues/9)
-- [ ] Add React output target https://github.com/ionic-team/stencil-ds-plugins. We need to discuss if we really want that. It means, we would have to publish a separate package on npm.
-- [ ] Add Angular output target https://github.com/ionic-team/stencil-ds-plugins. Note: angular output target is hard to implement since `ValueAccessorConfig` needs to be manually generated and kept up to date during development. This is the config that duet uses: [https://gist.github.com/viljamis/4ef368862b1ac1a914ac77ddf8b0a3aa](https://gist.github.com/viljamis/4ef368862b1ac1a914ac77ddf8b0a3aa)
+- [ ] Add React output target https://lit.dev/docs/frameworks/react/. We need to discuss if we really want that. It means, we would have to publish a separate package on npm.
+- [ ] Verify Angular integration
 - [ ] alongside unit and e2e tests, we might start using muation tests. We could possibly use https://stryker-mutator.io/ for that
-- [ ] optimize start script. Preferred solution: wait for the stencil node-event `build-finished`. After the event is received, run `start:storybook`. Stencil node-event `build-finished` doesn't exist yet, a pull-request at stencil is needed.
 - [x] Typescript: string literal types -> documentation. Example: in lyne-heading, we limit the values for the level property with string literal types. Find away to automatically include those type definitions in documenation.
 - [ ] Local npm dependencies vs. dependencies installed by travis: a developer installs a dependency, version 1.0.0. A month later, that dependency got several updates and is now on version 1.2.5. In a build, travis will install 1.2.5, while the developers are still on older version, as long as they don't run `npm up` or similar. We need to find a way to force developers to update dependencies, or make it easy for them.
 - [ ] To be consequent, we should write our stories in typescript as well
@@ -82,7 +76,7 @@
 
 #### Check
 
-- [ ] Stencil ESLint / TSLint in https://github.com/ionic-team/stencil-eslint
+✅ Nothing to check
 
 #### Verify
 
@@ -100,8 +94,7 @@
 
 #### Check
 
-- [ ] Storybook [Web Components](https://github.com/storybookjs/storybook/tree/next/app/web-components) integration in next major release. Replace current with upcoming if promising
-- [ ] Also have a look here https://github.com/ionic-team/stencil-sass/issues/15#issuecomment-603496922
+- [x] Storybook [Web Components](https://github.com/storybookjs/storybook/tree/next/app/web-components) integration in next major release. Replace current with upcoming if promising
 
 #### Verify
 

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -22,5 +22,5 @@ To make sure developers properly style their commit messages, we use `husky` tog
 
 The following build artefacts are relevant for deployments:
 
-- `./dist` & `./loader`: stencil components that are published to npm
+- `./dist`: web-components that are published to npm
 - `./storybook-static`: the storybook build that is deployed to netlify

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -112,11 +112,10 @@ You can find a list of all branches along with their Netlify deployment URL here
 
 ## Outputs
 
-| Folder             | Explanation                               |
-| ------------------ | ----------------------------------------- |
-| ./dist             | main output target for stencil components |
-| ./www              | build target for stencil dev server       |
-| ./storybook-static | rendered static storybook site            |
+| Folder             | Explanation                           |
+| ------------------ | ------------------------------------- |
+| ./dist             | main output target for web-components |
+| ./storybook-static | rendered static storybook site        |
 
 ## Checks & monitoring
 

--- a/src/components/core/interfaces/link-button-properties.ts
+++ b/src/components/core/interfaces/link-button-properties.ts
@@ -65,7 +65,7 @@ export interface LinkButtonRenderVariables {
  * The interface contains the possible attributes of both the <a> and the <button> tags.
  * It is intended to be used in all cases where a component needs to render a tag that can be an <a> or a <button>,
  * for instance depending on whether the value of the href attribute is present or not.
- * NOTE: a class could not be created because StencilJS does not support inheritance/component extension.
+ * TODO: a class could not be created with StencilJS. Check if a refactor is needed.
  */
 export interface LinkButtonProperties extends LinkProperties, ButtonProperties {}
 

--- a/src/components/core/styles/global.scss
+++ b/src/components/core/styles/global.scss
@@ -1,17 +1,3 @@
-// *****************************************************************************
-// Important
-//
-// Changes in global.scss and from global.scss referenced .scss files only
-// get compiled through a Stencil build. Restarting (stopping/starting) the build
-// is necessary so the changes get reflected in the global CSS (sbb-components.css)
-//
-// This is a known and unsolved stencil-sass bug: see
-// https://github.com/ionic-team/stencil/issues/2635
-// https://github.com/ionic-team/stencil-sass/issues/8
-// https://github.com/ionic-team/stencil-sass/issues/15
-//
-// *****************************************************************************
-
 @use './_index' as sbb;
 @use './normalize';
 @use './typography';

--- a/src/components/core/testing/event-spy.ts
+++ b/src/components/core/testing/event-spy.ts
@@ -1,8 +1,8 @@
 /**
- * This class exists to facilitate the E2E tests from stencil to lit.
+ * This class exists to facilitate the E2E test migration from stencil to lit.
  * It mimics the API that stencil provided to test events.
  *
- * TODO: Properly implement and document this class
+ * TODO: Document me
  */
 export class EventSpy<T extends Event> {
   private _count: number = 0;


### PR DESCRIPTION
## TODO
- [x] Add Lit to [TERMINOLOGY doc](https://github.com/lyne-design-system/lyne/blob/master/docs/TERMINOLOGY.md) ([PR link](https://github.com/lyne-design-system/lyne/pull/7))