### PR TITLE
fix(time-input): fix event names for consistency

### DIFF
--- a/src/components/time-input/readme.md
+++ b/src/components/time-input/readme.md
@@ -72,7 +72,7 @@ Whenever the validation state changes (e.g., a valid value becomes invalid or vi
 
 ## Events
 
-| Name               | Type                                 | Description                                                                      | Inherited From |
-| ------------------ | ------------------------------------ | -------------------------------------------------------------------------------- | -------------- |
-| `didChange`        | `CustomEvent<void>`                  | Deprecated. used for React. Will probably be removed once React 19 is available. |                |
-| `validationChange` | `CustomEvent<ValidationChangeEvent>` | Emits whenever the internal validation state changes.                            |                |
+| Name                | Type                                 | Description                                                                      | Inherited From |
+| ------------------- | ------------------------------------ | -------------------------------------------------------------------------------- | -------------- |
+| `did-change`        | `CustomEvent<void>`                  | Deprecated. used for React. Will probably be removed once React 19 is available. |                |
+| `validation-change` | `CustomEvent<ValidationChangeEvent>` | Emits whenever the internal validation state changes.                            |                |

--- a/src/components/time-input/time-input.ts
+++ b/src/components/time-input/time-input.ts
@@ -27,15 +27,15 @@ interface Time {
 /**
  * * Combined with a native input, it displays the input's value as a formatted time.
  *
- * @event {CustomEvent<void>} didChange - Deprecated. used for React. Will probably be removed once React 19 is available.
- * @event {CustomEvent<ValidationChangeEvent>} validationChange - Emits whenever the internal validation state changes.
+ * @event {CustomEvent<void>} did-change - Deprecated. used for React. Will probably be removed once React 19 is available.
+ * @event {CustomEvent<ValidationChangeEvent>} validation-change - Emits whenever the internal validation state changes.
  */
 @customElement('sbb-time-input')
 export class SbbTimeInput extends LitElement {
   public static override styles: CSSResultGroup = style;
   public static readonly events = {
-    didChange: 'didChange',
-    validationChange: 'validationChange',
+    didChange: 'did-change',
+    validationChange: 'validation-change',
   } as const;
 
   /** Reference of the native input connected to the datepicker. */


### PR DESCRIPTION
BREAKING CHANGE:
 - `didChange` renamed to `did-change`
 - `validationChange` renamed to `validation-change`