### PR TITLE
build: minify CSS in build bundle

### DIFF
--- a/src/components/vite.config.ts
+++ b/src/components/vite.config.ts
@@ -49,6 +49,7 @@ export default defineConfig((config) =>
         : []),
     ],
     build: {
+      cssMinify: isProdBuild(config),
       lib: {
         // Include all directories containing an index.ts
         entry: globIndexMap(packageRoot),


### PR DESCRIPTION
This PR configures Vite to minify CSS in our build bundle. This should reduce the payload both for our package and our consumers.