### PR TITLE
refactor: change EventEmitter.emit to return the result of dispatchEvent

### DIFF
--- a/src/components/core/eventing/event-emitter.ts
+++ b/src/components/core/eventing/event-emitter.ts
@@ -1,20 +1,36 @@
-const defaultOptions = {
+const defaultOptions: EventInit = {
   bubbles: true,
   cancelable: true,
   composed: true,
-};
+} as const;
 
+/**
+ * Creates an event emitter, that can dispatch CustomEvent instances for the given
+ * element with the specified event name.
+ * Event options default to bubbles, cancelable and composed set to true.
+ */
 export class EventEmitter<T = any> {
   public constructor(
     private _element: HTMLElement,
     private _eventName: string,
-    private _options?: { bubbles?: boolean; cancelable?: boolean; composed?: boolean },
+    private _options: {
+      bubbles?: boolean;
+      cancelable?: boolean;
+      composed?: boolean;
+    } = defaultOptions,
   ) {}
 
-  public emit(data?: T): CustomEvent<T> {
-    const options = this._options ?? defaultOptions;
-    const event = new CustomEvent(this._eventName, Object.assign({}, options, { detail: data }));
-    this._element.dispatchEvent?.(event);
-    return event;
+  /**
+   * Dispatches an event.
+   * @param detail The detail to dispatch with the event.
+   * @returns true when the event was successfully emitted or false,
+   *  if preventDefault() was called. Always returns true in SSR.
+   */
+  public emit(detail?: T): boolean {
+    return (
+      this._element.dispatchEvent?.(
+        new CustomEvent(this._eventName, { ...this._options, detail }),
+      ) ?? true
+    );
   }
 }


### PR DESCRIPTION
This change allows us to check if an event was prevented. Additionally this PR enables SSR usage.