### PR TITLE
chore: remove unused import and code

### DIFF
--- a/src/components/datepicker/datepicker-toggle/datepicker-toggle.ts
+++ b/src/components/datepicker/datepicker-toggle/datepicker-toggle.ts
@@ -62,15 +62,6 @@ export class SbbDatepickerToggle extends LitElement {
     languageChangeHandlerAspect((l) => (this._currentLanguage = l)),
   );
 
-  private _findDatePicker(
-    newValue: string | SbbDatepicker,
-    oldValue: string | SbbDatepicker,
-  ): void {
-    if (newValue !== oldValue) {
-      this._init(this.datePicker);
-    }
-  }
-
   /**
    * Opens the calendar.
    */

--- a/src/components/logo/logo.ts
+++ b/src/components/logo/logo.ts
@@ -1,4 +1,4 @@
-import { CSSResultGroup, html, LitElement, nothing, TemplateResult } from 'lit';
+import { CSSResultGroup, html, LitElement, TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { SbbProtectiveRoom } from '../core/interfaces';

--- a/src/components/signet/signet.ts
+++ b/src/components/signet/signet.ts
@@ -1,4 +1,4 @@
-import { CSSResultGroup, html, LitElement, nothing, TemplateResult } from 'lit';
+import { CSSResultGroup, html, LitElement, TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { SbbProtectiveRoom } from '../core/interfaces';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "experimentalDecorators": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "noUnusedLocals": true,
     "paths": {
       "@sbb-esta/lyne-components": ["src/components"],
       "@sbb-esta/lyne-components/*": ["src/components/*"],


### PR DESCRIPTION
Removed unused method on `sbb-datepicker-toggle` and imports in `sbb-logo` and `sbb-signet`.