### PR TITLE
test: a11y tree snapshot showcase

### DIFF
--- a/src/components/autocomplete/autocomplete.e2e.ts
+++ b/src/components/autocomplete/autocomplete.e2e.ts
@@ -1,5 +1,10 @@
 import { assert, expect, fixture } from '@open-wc/testing';
-import { sendKeys, sendMouse } from '@web/test-runner-commands';
+import {
+  a11ySnapshot,
+  findAccessibilityNode,
+  sendKeys,
+  sendMouse,
+} from '@web/test-runner-commands';
 import { html } from 'lit/static-html.js';
 
 import { waitForCondition, waitForLitRender, EventSpy } from '../core/testing';
@@ -27,16 +32,18 @@ describe('sbb-autocomplete', () => {
     element = formField.querySelector('sbb-autocomplete');
   });
 
-  it('renders and sets the correct attributes', () => {
+  it('renders and sets the correct attributes', async () => {
     assert.instanceOf(formField, SbbFormField);
     assert.instanceOf(element, SbbAutocomplete);
 
-    expect(element).not.to.have.attribute('autocomplete-origin-borderless');
+    const snapshot = await a11ySnapshot({});
+    const combobox = findAccessibilityNode<any>(snapshot, (node) => node.role === 'combobox');
+    expect(combobox).not.to.be.null;
+    expect(combobox.autocomplete).to.be.equal('list');
+    expect(combobox.haspopup).to.be.equal('listbox');
 
+    expect(element).not.to.have.attribute('autocomplete-origin-borderless');
     expect(input).to.have.attribute('autocomplete', 'off');
-    expect(input).to.have.attribute('role', 'combobox');
-    expect(input).to.have.attribute('aria-autocomplete', 'list');
-    expect(input).to.have.attribute('aria-haspopup', 'listbox');
     expect(input).to.have.attribute('aria-controls', 'myAutocomplete');
     expect(input).to.have.attribute('aria-owns', 'myAutocomplete');
     expect(input).to.have.attribute('aria-expanded', 'false');

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -1,6 +1,7 @@
 import { defaultReporter, dotReporter, summaryReporter } from '@web/test-runner';
 import { playwrightLauncher } from '@web/test-runner-playwright';
 import { puppeteerLauncher } from '@web/test-runner-puppeteer';
+import { a11ySnapshotPlugin } from '@web/test-runner-commands/plugins';
 import { existsSync } from 'fs';
 import * as sass from 'sass';
 import { createServer } from 'vite';
@@ -31,7 +32,7 @@ export default {
   nodeResolve: true,
   reporters: isDebugMode ? [defaultReporter(), summaryReporter()] : [minimalReporter()],
   browsers: browsers,
-  plugins: [vitePlugin()],
+  plugins: [vitePlugin(), a11ySnapshotPlugin()],
   testFramework: {
     config: {
       timeout: '3000',


### PR DESCRIPTION

[Docs](https://modern-web.dev/docs/test-runner/commands/#accessibility-snapshot)

Unfortunately, I feel that the snapshot doesn't add much value to tests 😞 
Furthermore, Playwright marks the snapshot functionality as [deprecated](https://playwright.dev/docs/api/class-accessibility#deprecated) and advises using other tools like [Axe](https://www.deque.com/axe/) (which I checked, but is mainly helpful when testing full pages). 

On a positive note, I found something that might be useful during development on a11y matter.
Chrome dev tool offers an a11y tree inspector that's what screen readers use. 
It might be a good starting point to compare the trees when we have some screen reader misbehavior

![image](https://github.com/lyne-design-system/lyne-components/assets/12052575/4d86cc07-177e-4a27-9039-b56f672e1af7)
