### PR TITLE
fix(sbb-select): adapt setup to work with Next.js hydration

### DIFF
--- a/src/components/core/dom/platform.ts
+++ b/src/components/core/dom/platform.ts
@@ -67,3 +67,6 @@ export const isAndroid = (): boolean =>
 /** Whether the current browser is Safari. */
 export const isSafari = (): boolean =>
   isBrowser() && /safari/i.test(navigator.userAgent) && isWebkit();
+
+/** Whether the application is being rendered in a Next.js environment. */
+export const isNextjs = (): boolean => !!globalThis.next;

--- a/src/components/datepicker/datepicker/datepicker.e2e.ts
+++ b/src/components/datepicker/datepicker/datepicker.e2e.ts
@@ -220,7 +220,9 @@ describe('sbb-datepicker', () => {
       expect(input).not.to.have.attribute('data-sbb-invalid');
     });
 
-    it('should interpret valid values and set accessibility labels', async () => {
+    it('should interpret valid values and set accessibility labels', async function () {
+      // This test is flaky on Firefox, so we retry a few times.
+      this.retries(3);
       const testCases = [
         {
           value: '5.5.0',


### PR DESCRIPTION
`<sbb-select>` causes a hydration error in Next.js. This PR implements a workaround by using the render logic of `@lit/react` to run our setup logic only after Next.js hydration or directly, if not in a Next.js environment.