### PR TITLE
fix: chromatic instability

### DIFF
--- a/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.stories.ts
+++ b/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.stories.ts
@@ -158,7 +158,7 @@ export const CollapsedState: StoryObj = {
 const meta: Meta = {
   decorators: [
     (story) => html`
-      <div style="padding: 2rem;">
+      <div style="padding: 2rem; max-width: 1000px;">
         ${story()}
         <div>Page content</div>
       </div>

--- a/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.stories.ts
+++ b/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.stories.ts
@@ -168,7 +168,6 @@ const meta: Meta = {
     backgrounds: {
       disable: true,
     },
-    chromatic: { delay: 5000 },
     docs: {
       extractComponentDescription: () => readme,
     },

--- a/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.stories.ts
+++ b/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.stories.ts
@@ -16,7 +16,7 @@ const addBreadcrumb = (event: Event): void => {
     .querySelector('sbb-breadcrumb-group');
   const breadcrumb = document.createElement('sbb-breadcrumb');
   breadcrumb.setAttribute('href', '/');
-  breadcrumb.textContent = 'Breadcrumb ' + breadcrumbGroup.children.length;
+  breadcrumb.textContent = 'Link ' + breadcrumbGroup.children.length;
   breadcrumbGroup.append(breadcrumb);
 };
 
@@ -108,7 +108,7 @@ const defaultArgTypes: ArgTypes = {
 
 const defaultArgs: Args = {
   numberOfBreadcrumbs: 3,
-  text: 'Breadcrumb',
+  text: 'Link',
   href: 'https://github.com/lyne-design-system/lyne-components',
   target: '_blank',
   rel: undefined,
@@ -129,7 +129,7 @@ const createBreadcrumbs = ({ numberOfBreadcrumbs, text, ...args }): TemplateResu
 
 const Template = (args): TemplateResult => html`
   <div class="container">
-    <sbb-breadcrumb-group aria-label="You are here:" data-testid="breadcrumb-group">
+    <sbb-breadcrumb-group aria-label="You are here:">
       ${createBreadcrumbs(args)}
     </sbb-breadcrumb-group>
     <div style="margin-block: 2rem; gap: 1rem; display: flex;">

--- a/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.stories.ts
+++ b/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.stories.ts
@@ -1,8 +1,11 @@
+import { within } from '@storybook/testing-library';
 import type { InputType } from '@storybook/types';
 import type { Meta, StoryObj, ArgTypes, Args } from '@storybook/web-components';
+import isChromatic from 'chromatic';
 import { html, TemplateResult } from 'lit';
-import { styleMap } from 'lit/directives/style-map.js';
 
+import { waitForComponentsReady } from '../../../storybook/testing/wait-for-components-ready';
+import { waitForStablePosition } from '../../../storybook/testing/wait-for-stable-position';
 import { sbbSpread } from '../../core/dom';
 
 import readme from './readme.md?raw';
@@ -10,6 +13,15 @@ import readme from './readme.md?raw';
 import '../../button';
 import './breadcrumb-group';
 import '../breadcrumb';
+
+// Story interaction executed after the story renders
+const playStory = async ({ canvasElement }): Promise<void> => {
+  const canvas = within(canvasElement);
+  await waitForComponentsReady(() =>
+    canvas.getByTestId('breadcrumb-group').shadowRoot.querySelectorAll('sbb-breadcrumb'),
+  );
+  await waitForStablePosition(() => canvas.getByTestId('breadcrumb-group'));
+};
 
 const addBreadcrumb = (event: Event): void => {
   const breadcrumbGroup = (event.target as HTMLElement)
@@ -130,10 +142,10 @@ const createBreadcrumbs = ({ numberOfBreadcrumbs, text, ...args }): TemplateResu
 
 const Template = (args): TemplateResult => html`
   <div class="container">
-    <sbb-breadcrumb-group aria-label="You are here:">
+    <sbb-breadcrumb-group aria-label="You are here:" data-testid="breadcrumb-group">
       ${createBreadcrumbs(args)}
     </sbb-breadcrumb-group>
-    <div style=${styleMap({ 'margin-block': '2rem', gap: '1rem', display: 'flex' })}>
+    <div style="margin-block: 2rem; gap: 1rem; display: flex;">
       <sbb-button variant="secondary" @click=${(event: Event) => addBreadcrumb(event)}
         >Add</sbb-button
       >
@@ -148,18 +160,20 @@ export const Default: StoryObj = {
   render: Template,
   argTypes: defaultArgTypes,
   args: { ...defaultArgs },
+  play: isChromatic() ? playStory : undefined,
 };
 
 export const CollapsedState: StoryObj = {
   render: Template,
   argTypes: defaultArgTypes,
   args: { ...defaultArgs, numberOfBreadcrumbs: 25 },
+  play: isChromatic() ? playStory : undefined,
 };
 
 const meta: Meta = {
   decorators: [
     (story) => html`
-      <div style=${styleMap({ padding: '2rem' })}>
+      <div style="padding: 2rem;">
         ${story()}
         <div>Page content</div>
       </div>

--- a/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.stories.ts
+++ b/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.stories.ts
@@ -168,7 +168,7 @@ const meta: Meta = {
     backgrounds: {
       disable: true,
     },
-    chromatic: { diffThreshold: 0.25, delay: 5000 },
+    chromatic: { delay: 5000 },
     docs: {
       extractComponentDescription: () => readme,
     },

--- a/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.stories.ts
+++ b/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.stories.ts
@@ -18,7 +18,7 @@ import '../breadcrumb';
 const playStory = async ({ canvasElement }): Promise<void> => {
   const canvas = within(canvasElement);
   await waitForComponentsReady(() =>
-    canvas.getByTestId('breadcrumb-group').shadowRoot.querySelectorAll('sbb-breadcrumb'),
+    canvas.getByTestId('breadcrumb-group').shadowRoot.querySelectorAll('li'),
   );
   await waitForStablePosition(() => canvas.getByTestId('breadcrumb-group'));
 };

--- a/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.stories.ts
+++ b/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.stories.ts
@@ -1,11 +1,7 @@
-import { within } from '@storybook/testing-library';
 import type { InputType } from '@storybook/types';
 import type { Meta, StoryObj, ArgTypes, Args } from '@storybook/web-components';
-import isChromatic from 'chromatic';
 import { html, TemplateResult } from 'lit';
 
-import { waitForComponentsReady } from '../../../storybook/testing/wait-for-components-ready';
-import { waitForStablePosition } from '../../../storybook/testing/wait-for-stable-position';
 import { sbbSpread } from '../../core/dom';
 
 import readme from './readme.md?raw';
@@ -13,15 +9,6 @@ import readme from './readme.md?raw';
 import '../../button';
 import './breadcrumb-group';
 import '../breadcrumb';
-
-// Story interaction executed after the story renders
-const playStory = async ({ canvasElement }): Promise<void> => {
-  const canvas = within(canvasElement);
-  await waitForComponentsReady(() =>
-    canvas.getByTestId('breadcrumb-group').shadowRoot.querySelectorAll('li'),
-  );
-  await waitForStablePosition(() => canvas.getByTestId('breadcrumb-group'));
-};
 
 const addBreadcrumb = (event: Event): void => {
   const breadcrumbGroup = (event.target as HTMLElement)
@@ -160,14 +147,12 @@ export const Default: StoryObj = {
   render: Template,
   argTypes: defaultArgTypes,
   args: { ...defaultArgs },
-  play: isChromatic() ? playStory : undefined,
 };
 
 export const CollapsedState: StoryObj = {
   render: Template,
   argTypes: defaultArgTypes,
   args: { ...defaultArgs, numberOfBreadcrumbs: 25 },
-  play: isChromatic() ? playStory : undefined,
 };
 
 const meta: Meta = {
@@ -183,6 +168,7 @@ const meta: Meta = {
     backgrounds: {
       disable: true,
     },
+    chromatic: { diffThreshold: 0.25, delay: 5000 },
     docs: {
       extractComponentDescription: () => readme,
     },

--- a/src/components/breadcrumb/breadcrumb/breadcrumb.stories.ts
+++ b/src/components/breadcrumb/breadcrumb/breadcrumb.stories.ts
@@ -1,7 +1,6 @@
 import type { InputType } from '@storybook/types';
 import type { Meta, StoryObj, ArgTypes, Args } from '@storybook/web-components';
 import { html, TemplateResult } from 'lit';
-import { styleMap } from 'lit/directives/style-map.js';
 
 import { sbbSpread } from '../../core/dom';
 
@@ -131,9 +130,7 @@ export const LongContent: StoryObj = {
     'icon-name': 'house-small',
     text: 'This label name is so long that it needs ellipsis to fit.',
   },
-  decorators: [
-    (story) => html` <div style=${styleMap({ 'max-width': '200px' })}>${story()}</div> `,
-  ],
+  decorators: [(story) => html` <div style="max-width: 200px;">${story()}</div> `],
 };
 
 export const NoLink: StoryObj = {
@@ -143,7 +140,7 @@ export const NoLink: StoryObj = {
 };
 
 const meta: Meta = {
-  decorators: [(story) => html` <div style=${styleMap({ padding: '2rem' })}>${story()}</div> `],
+  decorators: [(story) => html` <div style="padding: 2rem;">${story()}</div> `],
   parameters: {
     backgrounds: {
       disable: true,

--- a/src/components/image/image.scss
+++ b/src/components/image/image.scss
@@ -18,7 +18,6 @@
   object-fit: cover;
 }
 
-.image__lqip,
 .image__img {
   position: absolute;
   inset: 0;

--- a/src/components/image/image.stories.ts
+++ b/src/components/image/image.stories.ts
@@ -204,7 +204,7 @@ export const NoCaptionNoRadius: StoryObj = {
 const meta: Meta = {
   decorators: [(story) => html` <div style="max-width: 1000px;">${story()}</div> `],
   parameters: {
-    // chromatic: { diffThreshold: 1, delay: 10000 },
+    chromatic: { disableSnapshot: false },
     docs: {
       extractComponentDescription: () => readme,
     },

--- a/src/components/image/image.stories.ts
+++ b/src/components/image/image.stories.ts
@@ -15,15 +15,11 @@ import './image';
 // Story interaction executed after the story renders
 const playStory = async ({ canvasElement }): Promise<void> => {
   const canvas = within(canvasElement);
-  await waitForComponentsReady(() =>
-    canvas.getByTestId('image').shadowRoot.querySelector('.image__img'),
-  );
-
-  await new Promise<void>((resolve: () => void) => {
-    canvas
-      .getByTestId('image')
-      .shadowRoot.querySelector('.image__img')
-      .addEventListener('load', resolve, { once: true });
+  await waitForComponentsReady(async () => {
+    const img = canvas.getByTestId('image').shadowRoot.querySelector('.image__img');
+    await new Promise<void>((resolve: () => void) => {
+      img.addEventListener('load', resolve, { once: true });
+    });
   });
 };
 
@@ -208,7 +204,7 @@ export const NoCaptionNoRadius: StoryObj = {
 const meta: Meta = {
   decorators: [(story) => html` <div style="max-width: 1000px;">${story()}</div> `],
   parameters: {
-    chromatic: { diffThreshold: 1, delay: 10000 },
+    // chromatic: { diffThreshold: 1, delay: 10000 },
     docs: {
       extractComponentDescription: () => readme,
     },

--- a/src/components/image/image.stories.ts
+++ b/src/components/image/image.stories.ts
@@ -1,27 +1,14 @@
-import { within } from '@storybook/testing-library';
 import type { InputType } from '@storybook/types';
 import type { Meta, StoryObj, ArgTypes, Args } from '@storybook/web-components';
 import isChromatic from 'chromatic';
 import { html, TemplateResult } from 'lit';
 
-import { waitForComponentsReady } from '../../storybook/testing/wait-for-components-ready';
 import { sbbSpread } from '../core/dom';
 import images from '../core/images';
 
 import readme from './readme.md?raw';
 
 import './image';
-
-// Story interaction executed after the story renders
-const playStory = async ({ canvasElement }): Promise<void> => {
-  const canvas = within(canvasElement);
-  await waitForComponentsReady(async () => {
-    const img = canvas.getByTestId('image').shadowRoot.querySelector('.image__img');
-    await new Promise<void>((resolve: () => void) => {
-      img.addEventListener('load', resolve, { once: true });
-    });
-  });
-};
 
 const Template = (args): TemplateResult =>
   html`<sbb-image data-testid="image" ${sbbSpread(args)}></sbb-image>`;
@@ -178,7 +165,6 @@ export const Default: StoryObj = {
     caption:
       'Mit Ihrem Halbtax profitieren Sie zudem von attraktiven Zusatzleistungen und Rabatten. Wenn Sie unter 25 Jahre jung sind, können Sie zu Ihrem Halbtax das beliebte <a href="https://www.sbb.ch/abos-billette/abonnemente/gleis-7-freie-fahrt-ab-19-uhr.html#jahrg_nger_halbtax">Gleis 7</a> dazu kaufen.',
   },
-  play: isChromatic() ? playStory : undefined,
 };
 
 export const TransparentImage: StoryObj = {
@@ -188,7 +174,6 @@ export const TransparentImage: StoryObj = {
     ...defaultArgs,
     'image-src': imageSrc.options[9],
   },
-  play: isChromatic() ? playStory : undefined,
 };
 
 export const NoCaptionNoRadius: StoryObj = {
@@ -198,13 +183,12 @@ export const NoCaptionNoRadius: StoryObj = {
     ...defaultArgs,
     'no-border-radius': true,
   },
-  play: isChromatic() ? playStory : undefined,
 };
 
 const meta: Meta = {
-  decorators: [(story) => html` <div style="max-width: 1000px;">${story()}</div> `],
+  decorators: [(story) => html` <div style="max-width: 480px;">${story()}</div> `],
   parameters: {
-    chromatic: { disableSnapshot: false },
+    chromatic: { diffThreshold: 0.11, delay: 8000 },
     docs: {
       extractComponentDescription: () => readme,
     },

--- a/src/components/image/image.stories.ts
+++ b/src/components/image/image.stories.ts
@@ -10,8 +10,7 @@ import readme from './readme.md?raw';
 
 import './image';
 
-const Template = (args): TemplateResult =>
-  html`<sbb-image data-testid="image" ${sbbSpread(args)}></sbb-image>`;
+const Template = (args): TemplateResult => html`<sbb-image ${sbbSpread(args)}></sbb-image>`;
 
 const imageSrc: InputType = {
   control: {

--- a/src/components/image/image.stories.ts
+++ b/src/components/image/image.stories.ts
@@ -208,7 +208,7 @@ export const NoCaptionNoRadius: StoryObj = {
 const meta: Meta = {
   decorators: [(story) => html` <div style="max-width: 1000px;">${story()}</div> `],
   parameters: {
-    // chromatic: { diffThreshold: 0.11, delay: 8000 }, // test playStory for chromatic
+    chromatic: { diffThreshold: 0.25, delay: 10000 },
     docs: {
       extractComponentDescription: () => readme,
     },

--- a/src/components/image/image.stories.ts
+++ b/src/components/image/image.stories.ts
@@ -208,7 +208,7 @@ export const NoCaptionNoRadius: StoryObj = {
 const meta: Meta = {
   decorators: [(story) => html` <div style="max-width: 1000px;">${story()}</div> `],
   parameters: {
-    chromatic: { diffThreshold: 0.25, delay: 10000 },
+    chromatic: { diffThreshold: 1, delay: 10000 },
     docs: {
       extractComponentDescription: () => readme,
     },

--- a/src/components/image/image.stories.ts
+++ b/src/components/image/image.stories.ts
@@ -4,6 +4,7 @@ import type { Meta, StoryObj, ArgTypes, Args } from '@storybook/web-components';
 import isChromatic from 'chromatic';
 import { html, TemplateResult } from 'lit';
 
+import { waitForComponentsReady } from '../../storybook/testing/wait-for-components-ready';
 import { sbbSpread } from '../core/dom';
 import images from '../core/images';
 
@@ -14,9 +15,15 @@ import './image';
 // Story interaction executed after the story renders
 const playStory = async ({ canvasElement }): Promise<void> => {
   const canvas = within(canvasElement);
-  const innerImg = canvas.getByTestId('image').shadowRoot.querySelector('.image__img');
+  await waitForComponentsReady(() =>
+    canvas.getByTestId('image').shadowRoot.querySelector('.image__img'),
+  );
+
   await new Promise<void>((resolve: () => void) => {
-    innerImg.addEventListener('load', resolve, { once: true });
+    canvas
+      .getByTestId('image')
+      .shadowRoot.querySelector('.image__img')
+      .addEventListener('load', resolve, { once: true });
   });
 };
 

--- a/src/components/image/image.stories.ts
+++ b/src/components/image/image.stories.ts
@@ -4,8 +4,6 @@ import type { Meta, StoryObj, ArgTypes, Args } from '@storybook/web-components';
 import isChromatic from 'chromatic';
 import { html, TemplateResult } from 'lit';
 
-import { waitForComponentsReady } from '../../storybook/testing/wait-for-components-ready';
-import { waitForStablePosition } from '../../storybook/testing/wait-for-stable-position';
 import { sbbSpread } from '../core/dom';
 import images from '../core/images';
 
@@ -16,10 +14,10 @@ import './image';
 // Story interaction executed after the story renders
 const playStory = async ({ canvasElement }): Promise<void> => {
   const canvas = within(canvasElement);
-  await waitForComponentsReady(() =>
-    canvas.getByTestId('image').shadowRoot.querySelectorAll('.image__img'),
-  );
-  await waitForStablePosition(() => canvas.getByTestId('image'));
+  const innerImg = canvas.getByTestId('image').shadowRoot.querySelector('.image__img');
+  await new Promise<void>((resolve: () => void) => {
+    innerImg.addEventListener('load', resolve, { once: true });
+  });
 };
 
 const Template = (args): TemplateResult =>
@@ -177,6 +175,7 @@ export const Default: StoryObj = {
     caption:
       'Mit Ihrem Halbtax profitieren Sie zudem von attraktiven Zusatzleistungen und Rabatten. Wenn Sie unter 25 Jahre jung sind, können Sie zu Ihrem Halbtax das beliebte <a href="https://www.sbb.ch/abos-billette/abonnemente/gleis-7-freie-fahrt-ab-19-uhr.html#jahrg_nger_halbtax">Gleis 7</a> dazu kaufen.',
   },
+  play: isChromatic() ? playStory : undefined,
 };
 
 export const TransparentImage: StoryObj = {

--- a/src/components/image/image.ts
+++ b/src/components/image/image.ts
@@ -489,11 +489,13 @@ export class SbbImageElement extends LitElement {
                 html` <source
                   media=${`${mediaQuery}`}
                   sizes=${`${imageWidth}px`}
-                  srcset=${`${imageUrlWithParams}&w=${imageWidth}&h=${imageHeight}&q=${this._config.nonRetinaQuality} ${imageWidth}w, ` +
-                  `${imageUrlWithParams}&w=${imageWidth * 2}&h=${imageHeight * 2}&q=${
-                    this._config.retinaQuality
-                  } ${imageWidth * 2}w`}
-                />`,
+                  srcset=${
+                    `${imageUrlWithParams}&w=${imageWidth}&h=${imageHeight}&q=${this._config.nonRetinaQuality} ${imageWidth}w, ` +
+                    `${imageUrlWithParams}&w=${imageWidth * 2}&h=${imageHeight * 2}&q=${
+                      this._config.retinaQuality
+                    } ${imageWidth * 2}w`
+                  }
+                ></source>`,
               ];
             })}
             <img

--- a/src/components/selection-panel/selection-panel.stories.ts
+++ b/src/components/selection-panel/selection-panel.stories.ts
@@ -716,7 +716,7 @@ export const NestedCheckboxes: StoryObj = {
 
 const meta: Meta = {
   decorators: [
-    (story) => html` <div style="padding: 2rem;">${story()}</div> `,
+    (story) => html` <div style="padding: 2rem; max-width: 1440px;">${story()}</div> `,
     withActions as Decorator,
   ],
   parameters: {

--- a/src/components/selection-panel/selection-panel.stories.ts
+++ b/src/components/selection-panel/selection-panel.stories.ts
@@ -720,7 +720,7 @@ const meta: Meta = {
     withActions as Decorator,
   ],
   parameters: {
-    chromatic: { delay: 6000 },
+    chromatic: { delay: 8000 },
     actions: {
       handles: [
         SbbSelectionPanelElement.events.didOpen,

--- a/src/components/selection-panel/selection-panel.stories.ts
+++ b/src/components/selection-panel/selection-panel.stories.ts
@@ -720,7 +720,7 @@ const meta: Meta = {
     withActions as Decorator,
   ],
   parameters: {
-    chromatic: { delay: 8000 },
+    chromatic: { delay: 3000 },
     actions: {
       handles: [
         SbbSelectionPanelElement.events.didOpen,

--- a/src/components/selection-panel/selection-panel.stories.ts
+++ b/src/components/selection-panel/selection-panel.stories.ts
@@ -720,7 +720,7 @@ const meta: Meta = {
     withActions as Decorator,
   ],
   parameters: {
-    chromatic: { delay: 3000 },
+    chromatic: { delay: 6000 },
     actions: {
       handles: [
         SbbSelectionPanelElement.events.didOpen,

--- a/src/components/selection-panel/selection-panel.stories.ts
+++ b/src/components/selection-panel/selection-panel.stories.ts
@@ -716,11 +716,11 @@ export const NestedCheckboxes: StoryObj = {
 
 const meta: Meta = {
   decorators: [
-    (story) => html` <div style="padding: 2rem; max-width: 1440px;">${story()}</div> `,
+    (story) => html` <div style="padding: 2rem;">${story()}</div> `,
     withActions as Decorator,
   ],
   parameters: {
-    chromatic: { delay: 3000 },
+    chromatic: { delay: 9000 },
     actions: {
       handles: [
         SbbSelectionPanelElement.events.didOpen,

--- a/src/components/selection-panel/selection-panel.ts
+++ b/src/components/selection-panel/selection-panel.ts
@@ -134,11 +134,9 @@ export class SbbSelectionPanelElement extends LitElement {
     if (this._checked) {
       this._state = 'opening';
       this._willOpen.emit();
-      this.disableAnimation && this._handleOpening();
     } else {
       this._state = 'closing';
       this._willClose.emit();
-      this.disableAnimation && this._handleClosing();
     }
   }
 


### PR DESCRIPTION
Closes #2184

Fix for Chromatic issues:
  - sbb-breadcrumb-group: 
      - changed label from 'Breadcrumb' to 'Link' to avoid issue on smaller breakpoints;
      - added `max-width` to handle expanded case in bigger breakpoints
  - sbb-selection-panel:
      - removed a duplicate emitter of did-* events when `disableAnimation` is true
      - with a delay of 9 sec, it seems to correctly load (tested with 4 consecutive builds - can this be trusted?)
  - sbb-image
      - removed useless class in css
      - adding a `max-width` seems to be solve the issue on Firefox