### PR TITLE
fix(sbb-journey-header): add non breaking space for screen readers

### DIFF
--- a/src/components/journey-header/journey-header.ts
+++ b/src/components/journey-header/journey-header.ts
@@ -51,14 +51,14 @@ export class SbbJourneyHeaderElement extends LitElement {
         <span class="sbb-journey-header" dir=${getDocumentWritingMode()}>
           <span class="sbb-journey-header__origin">
             <span class="sbb-journey-header__connection--visually-hidden">
-              ${i18nConnectionFrom[this._language.current]}
+              ${i18nConnectionFrom[this._language.current]}&nbsp;
             </span>
             ${this.origin}
           </span>
           <sbb-icon name=${iconName}></sbb-icon>
           <span class="sbb-journey-header__destination">
             <span class="sbb-journey-header__connection--visually-hidden">
-              ${i18nConnectionTo[this._language.current]}
+              &nbsp;${i18nConnectionTo[this._language.current]}&nbsp;
             </span>
             ${this.destination}
             ${this.roundTrip


### PR DESCRIPTION
This PR adds non breaking white space to the `sbb-journey-header`, to avoid text concatination (e.g. `from Zürich to Bern`, instead of `fromZürichtoBern`).