### PR TITLE
fix(sbb-notification): delay removal of notification after closing

### DIFF
--- a/src/components/notification/notification.e2e.ts
+++ b/src/components/notification/notification.e2e.ts
@@ -1,4 +1,4 @@
-import { assert, expect, fixture } from '@open-wc/testing';
+import { aTimeout, assert, expect, fixture } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
 
 import { SbbButtonElement } from '../button';
@@ -44,6 +44,7 @@ describe('sbb-notification', () => {
 
     expect(element).to.have.attribute('data-state', 'closed');
 
+    await aTimeout(0);
     element = document.querySelector('sbb-notification');
     expect(element).to.be.null;
   });
@@ -71,6 +72,7 @@ describe('sbb-notification', () => {
 
     expect(element).to.have.attribute('data-state', 'closed');
 
+    await aTimeout(0);
     element = document.querySelector('sbb-notification');
     expect(element).to.be.null;
   });

--- a/src/components/notification/notification.ts
+++ b/src/components/notification/notification.ts
@@ -196,7 +196,7 @@ export class SbbNotificationElement extends LitElement {
     this._state = 'closed';
     this._didClose.emit();
     this._notificationResizeObserver.unobserve(this._notificationElement);
-    this.remove();
+    setTimeout(() => this.remove());
   }
 
   protected override render(): TemplateResult {


### PR DESCRIPTION
Currently if the notification node is removed directly after the `did-close` event is emitted, it causes an error in the React wrapper.