### PR TITLE
fix: remove setTimeout from SlotChildObserver

### DIFF
--- a/src/components/core/common-behaviors/slot-child-observer.ts
+++ b/src/components/core/common-behaviors/slot-child-observer.ts
@@ -58,11 +58,9 @@ export const SlotChildObserver = <T extends Constructor<LitElement>>(
 
     protected override firstUpdated(changedProperties: PropertyValues): void {
       super.firstUpdated(changedProperties);
-      setTimeout(() => {
-        this._hydratedResolved = true;
-        this._hydratedResolve();
-        this.checkChildren();
-      }, 0);
+      this._hydratedResolved = true;
+      this._hydratedResolve();
+      this.checkChildren();
     }
 
     protected override async getUpdateComplete(): Promise<boolean> {


### PR DESCRIPTION
Our homepage is currently unstable and would crash on refresh, the problem only occurs on Mac and Chrome when there are a number of components on the page that depend on each other and are nested for more than two levels, it basically happens in the navigation with its various internal components (nav -> marker -> list -> action...). This is due to the new logic to do the children check with the `checkChildren` method implemented to optimise the SSR, by removing the `setTimeout` from the `firstUpdated` callback of the SlotChildObserver the problem is fixed.