### PR TITLE
refactor: extract base functionality of list components into `NamedSlotListElement`

### DIFF
--- a/config/custom-elements-manifest.config.js
+++ b/config/custom-elements-manifest.config.js
@@ -1,5 +1,3 @@
-import { parse } from 'comment-parser';
-
 /**
  * Docs: https://custom-elements-manifest.open-wc.org/analyzer/getting-started/
  */
@@ -13,26 +11,7 @@ export default {
   plugins: [
     {
       analyzePhase({ ts, node, moduleDoc }) {
-        if (ts.isPropertyDeclaration(node)) {
-          const className = node.parent.name.getText();
-          const classDoc = moduleDoc.declarations.find(
-            (declaration) => declaration.name === className,
-          );
-
-          for (const jsDoc of node.jsDoc ?? []) {
-            for (const parsedJsDoc of parse(jsDoc.getFullText())) {
-              for (const tag of parsedJsDoc.tags) {
-                if (tag.tag === 'ssrchildcounter') {
-                  const member = classDoc.members.find((m) => m.name === node.name.getText());
-                  member['_ssrchildcounter'] = true;
-                }
-              }
-            }
-          }
-        } else if (
-          ts.isNewExpression(node) &&
-          node.expression.getText() === 'NamedSlotStateController'
-        ) {
+        if (ts.isNewExpression(node) && node.expression.getText() === 'NamedSlotStateController') {
           let classNode = node;
           while (classNode) {
             if (ts.isClassDeclaration(classNode)) {

--- a/src/components/autocomplete/autocomplete.ts
+++ b/src/components/autocomplete/autocomplete.ts
@@ -239,6 +239,7 @@ export class SbbAutocompleteElement extends SlotChildObserver(LitElement) {
   }
 
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
+    super.willUpdate(changedProperties);
     if (changedProperties.has('origin')) {
       this._resetOriginClickListener(this.origin, changedProperties.get('origin'));
     }

--- a/src/components/breadcrumb/breadcrumb-group/__snapshots__/breadcrumb-group.spec.snap.js
+++ b/src/components/breadcrumb/breadcrumb-group/__snapshots__/breadcrumb-group.spec.snap.js
@@ -4,7 +4,7 @@ export const snapshots = {};
 snapshots["sbb-breadcrumb-group renders"] = 
 `<ol class="sbb-breadcrumb-group">
   <li class="sbb-breadcrumb-group__item">
-    <slot name="breadcrumb-0">
+    <slot name="child-0">
     </slot>
     <sbb-icon
       aria-hidden="true"
@@ -16,7 +16,7 @@ snapshots["sbb-breadcrumb-group renders"] =
     </sbb-icon>
   </li>
   <li class="sbb-breadcrumb-group__item">
-    <slot name="breadcrumb-1">
+    <slot name="child-1">
     </slot>
     <sbb-icon
       aria-hidden="true"
@@ -28,7 +28,7 @@ snapshots["sbb-breadcrumb-group renders"] =
     </sbb-icon>
   </li>
   <li class="sbb-breadcrumb-group__item">
-    <slot name="breadcrumb-2">
+    <slot name="child-2">
     </slot>
   </li>
 </ol>

--- a/src/components/breadcrumb/breadcrumb-group/__snapshots__/breadcrumb-group.spec.snap.js
+++ b/src/components/breadcrumb/breadcrumb-group/__snapshots__/breadcrumb-group.spec.snap.js
@@ -4,7 +4,7 @@ export const snapshots = {};
 snapshots["sbb-breadcrumb-group renders"] = 
 `<ol class="sbb-breadcrumb-group">
   <li class="sbb-breadcrumb-group__item">
-    <slot name="child-0">
+    <slot name="li-0">
     </slot>
     <sbb-icon
       aria-hidden="true"
@@ -16,7 +16,7 @@ snapshots["sbb-breadcrumb-group renders"] =
     </sbb-icon>
   </li>
   <li class="sbb-breadcrumb-group__item">
-    <slot name="child-1">
+    <slot name="li-1">
     </slot>
     <sbb-icon
       aria-hidden="true"
@@ -28,7 +28,7 @@ snapshots["sbb-breadcrumb-group renders"] =
     </sbb-icon>
   </li>
   <li class="sbb-breadcrumb-group__item">
-    <slot name="child-2">
+    <slot name="li-2">
     </slot>
   </li>
 </ol>

--- a/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.e2e.ts
+++ b/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.e2e.ts
@@ -91,8 +91,8 @@ describe('sbb-breadcrumb-group', () => {
       // only two slots are displayed, and the second is the last one
       const slots = breadcrumbGroup.shadowRoot!.querySelectorAll('li > slot');
       expect(slots.length).to.be.equal(2);
-      expect(slots[0]).to.have.attribute('name', 'breadcrumb-0');
-      expect(slots[1]).to.have.attribute('name', 'breadcrumb-6');
+      expect(slots[0]).to.have.attribute('name', 'child-0');
+      expect(slots[1]).to.have.attribute('name', 'child-6');
     });
 
     it('keyboard navigation with ellipsis', async () => {

--- a/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.e2e.ts
+++ b/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.e2e.ts
@@ -91,8 +91,8 @@ describe('sbb-breadcrumb-group', () => {
       // only two slots are displayed, and the second is the last one
       const slots = breadcrumbGroup.shadowRoot!.querySelectorAll('li > slot');
       expect(slots.length).to.be.equal(2);
-      expect(slots[0]).to.have.attribute('name', 'child-0');
-      expect(slots[1]).to.have.attribute('name', 'child-6');
+      expect(slots[0]).to.have.attribute('name', 'li-0');
+      expect(slots[1]).to.have.attribute('name', 'li-6');
     });
 
     it('keyboard navigation with ellipsis', async () => {

--- a/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.spec.ts
+++ b/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.spec.ts
@@ -19,11 +19,11 @@ describe('sbb-breadcrumb-group', () => {
 
     expect(root).dom.to.be.equal(`
       <sbb-breadcrumb-group role='navigation' data-loaded>
-        <sbb-breadcrumb id="sbb-breadcrumb-1" href="/" icon-name="pie-small" slot="child-0" dir="ltr" role="link" tabindex="0"></sbb-breadcrumb>
-        <sbb-breadcrumb id="sbb-breadcrumb-2" href="/one" slot="child-1" dir="ltr" role="link" tabindex="0">
+        <sbb-breadcrumb id="sbb-breadcrumb-1" href="/" icon-name="pie-small" slot="li-0" dir="ltr" role="link" tabindex="0"></sbb-breadcrumb>
+        <sbb-breadcrumb id="sbb-breadcrumb-2" href="/one" slot="li-1" dir="ltr" role="link" tabindex="0">
           One
         </sbb-breadcrumb>
-        <sbb-breadcrumb id="sbb-breadcrumb-3" href="/one" slot="child-2" aria-current="page" dir="ltr" role="link" tabindex="0">
+        <sbb-breadcrumb id="sbb-breadcrumb-3" href="/one" slot="li-2" aria-current="page" dir="ltr" role="link" tabindex="0">
           Two
         </sbb-breadcrumb>
       </sbb-breadcrumb-group>

--- a/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.spec.ts
+++ b/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.spec.ts
@@ -19,11 +19,11 @@ describe('sbb-breadcrumb-group', () => {
 
     expect(root).dom.to.be.equal(`
       <sbb-breadcrumb-group role='navigation' data-loaded>
-        <sbb-breadcrumb id="sbb-breadcrumb-0" href="/" icon-name="pie-small" slot="breadcrumb-0" dir="ltr" role="link" tabindex="0"></sbb-breadcrumb>
-        <sbb-breadcrumb id="sbb-breadcrumb-1" href="/one" slot="breadcrumb-1" dir="ltr" role="link" tabindex="0">
+        <sbb-breadcrumb id="sbb-breadcrumb-1" href="/" icon-name="pie-small" slot="child-0" dir="ltr" role="link" tabindex="0"></sbb-breadcrumb>
+        <sbb-breadcrumb id="sbb-breadcrumb-2" href="/one" slot="child-1" dir="ltr" role="link" tabindex="0">
           One
         </sbb-breadcrumb>
-        <sbb-breadcrumb id="sbb-breadcrumb-2" href="/one" slot="breadcrumb-2" aria-current="page" dir="ltr" role="link" tabindex="0">
+        <sbb-breadcrumb id="sbb-breadcrumb-3" href="/one" slot="child-2" aria-current="page" dir="ltr" role="link" tabindex="0">
           Two
         </sbb-breadcrumb>
       </sbb-breadcrumb-group>

--- a/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.spec.ts
+++ b/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.spec.ts
@@ -19,11 +19,11 @@ describe('sbb-breadcrumb-group', () => {
 
     expect(root).dom.to.be.equal(`
       <sbb-breadcrumb-group role='navigation' data-loaded>
-        <sbb-breadcrumb id="sbb-breadcrumb-1" href="/" icon-name="pie-small" slot="li-0" dir="ltr" role="link" tabindex="0"></sbb-breadcrumb>
-        <sbb-breadcrumb id="sbb-breadcrumb-2" href="/one" slot="li-1" dir="ltr" role="link" tabindex="0">
+        <sbb-breadcrumb href="/" icon-name="pie-small" slot="li-0" dir="ltr" role="link" tabindex="0"></sbb-breadcrumb>
+        <sbb-breadcrumb href="/one" slot="li-1" dir="ltr" role="link" tabindex="0">
           One
         </sbb-breadcrumb>
-        <sbb-breadcrumb id="sbb-breadcrumb-3" href="/one" slot="li-2" aria-current="page" dir="ltr" role="link" tabindex="0">
+        <sbb-breadcrumb href="/one" slot="li-2" aria-current="page" dir="ltr" role="link" tabindex="0">
           Two
         </sbb-breadcrumb>
       </sbb-breadcrumb-group>

--- a/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.ts
+++ b/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.ts
@@ -67,6 +67,7 @@ export class SbbBreadcrumbGroupElement extends NamedSlotListElement<SbbBreadcrum
   }
 
   protected override willUpdate(changedProperties: PropertyValueMap<WithListChildren<this>>): void {
+    super.willUpdate(changedProperties);
     if (changedProperties.has('listChildren')) {
       this._syncBreadcrumbs();
     }
@@ -143,7 +144,7 @@ export class SbbBreadcrumbGroupElement extends NamedSlotListElement<SbbBreadcrum
   private _renderCollapsed(): TemplateResult {
     return html`
       <li class="sbb-breadcrumb-group__item">
-        <slot name="child-0"></slot>
+        <slot name="li-0"></slot>
       </li>
       <li class="sbb-breadcrumb-group__item" id="sbb-breadcrumb-group-ellipsis">
         <sbb-icon
@@ -165,7 +166,7 @@ export class SbbBreadcrumbGroupElement extends NamedSlotListElement<SbbBreadcrum
           name="chevron-small-right-small"
           class="sbb-breadcrumb-group__divider-icon"
         ></sbb-icon>
-        <slot name=${`child-${this.listChildren.length - 1}`}></slot>
+        <slot name=${`li-${this.listChildren.length - 1}`}></slot>
       </li>
     `;
   }

--- a/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.ts
+++ b/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.ts
@@ -1,9 +1,10 @@
-import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
-import { html, LitElement, nothing } from 'lit';
+import type { CSSResultGroup, PropertyValueMap, PropertyValues, TemplateResult } from 'lit';
+import { html, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
 import { getNextElementIndex, isArrowKeyPressed, sbbInputModalityDetector } from '../../core/a11y';
-import { LanguageController, SlotChildObserver } from '../../core/common-behaviors';
+import type { WithListChildren } from '../../core/common-behaviors';
+import { LanguageController, NamedSlotListElement } from '../../core/common-behaviors';
 import { setAttribute } from '../../core/dom';
 import { ConnectedAbortController } from '../../core/eventing';
 import { i18nBreadcrumbEllipsisButtonLabel } from '../../core/i18n';
@@ -20,11 +21,9 @@ import '../../icon';
  * @slot - Use the unnamed slot to add `sbb-breadcrumb` elements.
  */
 @customElement('sbb-breadcrumb-group')
-export class SbbBreadcrumbGroupElement extends SlotChildObserver(LitElement) {
+export class SbbBreadcrumbGroupElement extends NamedSlotListElement<SbbBreadcrumbElement> {
   public static override styles: CSSResultGroup = style;
-
-  /** Local instance of slotted sbb-breadcrumb elements */
-  @state() private _breadcrumbs: SbbBreadcrumbElement[] = [];
+  protected override readonly listChildTagNames = ['SBB-BREADCRUMB'];
 
   @state() private _state?: 'collapsed' | 'manually-expanded';
 
@@ -35,7 +34,7 @@ export class SbbBreadcrumbGroupElement extends SlotChildObserver(LitElement) {
 
   private _handleKeyDown(evt: KeyboardEvent): void {
     if (
-      !this._breadcrumbs ||
+      !this.listChildren.length ||
       // don't trap nested handling
       ((evt.target as HTMLElement) !== this && (evt.target as HTMLElement).parentElement !== this)
     ) {
@@ -62,52 +61,40 @@ export class SbbBreadcrumbGroupElement extends SlotChildObserver(LitElement) {
     this.toggleAttribute('data-loaded', true);
   }
 
-  protected override updated(): void {
+  public override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._resizeObserver.disconnect();
+  }
+
+  protected override willUpdate(changedProperties: PropertyValueMap<WithListChildren<this>>): void {
+    if (changedProperties.has('listChildren')) {
+      this._syncBreadcrumbs();
+    }
+  }
+
+  protected override updated(changedProperties: PropertyValueMap<WithListChildren<this>>): void {
+    super.updated(changedProperties);
+    if (changedProperties.has('listChildren')) {
+      Promise.resolve().then(() => this._evaluateCollapsedState());
+    }
     if (this._markForFocus && sbbInputModalityDetector.mostRecentModality === 'keyboard') {
-      this._breadcrumbs[1]?.focus();
+      this.listChildren[1]?.focus();
 
       // Reset mark for focus
       this._markForFocus = false;
     }
   }
 
-  public override disconnectedCallback(): void {
-    super.disconnectedCallback();
-    this._resizeObserver.disconnect();
-  }
-
-  /** Creates and sets an array with only the sbb-breadcrumb children. */
-  protected override checkChildren(): void {
-    this._evaluateCollapsedState();
-
-    const breadcrumbs = Array.from(this.children ?? []).filter(
-      (e): e is SbbBreadcrumbElement => e.tagName === 'SBB-BREADCRUMB',
-    );
-    // If the slotted sbb-breadcrumb instances have not changed,
-    // we can skip syncing and updating the breadcrumb reference list.
-    if (
-      this._breadcrumbs &&
-      breadcrumbs.length === this._breadcrumbs.length &&
-      this._breadcrumbs.every((e, i) => breadcrumbs[i] === e)
-    ) {
-      return;
-    }
-    this._breadcrumbs = breadcrumbs;
-    this._syncBreadcrumbs();
-  }
-
   /** Apply the aria-current attribute to the last sbb-breadcrumb element. */
   private _syncBreadcrumbs(): void {
-    this._breadcrumbs.forEach((breadcrumb, index) => {
-      breadcrumb.removeAttribute('aria-current');
-      if (!breadcrumb.id) {
-        breadcrumb.id = `sbb-breadcrumb-${index}`;
-      }
-    });
-    this._breadcrumbs[this._breadcrumbs.length - 1]?.setAttribute('aria-current', 'page');
+    this.listChildren
+      .slice(0, -1)
+      .filter((c) => c.hasAttribute('aria-current'))
+      .forEach((c) => c.removeAttribute('aria-current'));
+    this.listChildren[this.listChildren.length - 1]?.setAttribute('aria-current', 'page');
 
     // If it is not expandable, reset state
-    if (this._breadcrumbs.length < 3) {
+    if (this.listChildren.length < 3) {
       this._state = undefined;
     }
   }
@@ -117,16 +104,16 @@ export class SbbBreadcrumbGroupElement extends SlotChildObserver(LitElement) {
    */
   private _focusNextCollapsed(evt: KeyboardEvent): void {
     const arrayCollapsed: SbbBreadcrumbElement[] = [
-      this._breadcrumbs[0],
+      this.listChildren[0],
       this.shadowRoot!.querySelector('#sbb-breadcrumb-ellipsis') as SbbBreadcrumbElement,
-      this._breadcrumbs[this._breadcrumbs.length - 1],
+      this.listChildren[this.listChildren.length - 1],
     ];
     this._focusNext(evt, arrayCollapsed);
   }
 
   private _focusNext(
     evt: KeyboardEvent,
-    breadcrumbs: SbbBreadcrumbElement[] = this._breadcrumbs,
+    breadcrumbs: SbbBreadcrumbElement[] = this.listChildren,
   ): void {
     const current: number = breadcrumbs.findIndex(
       (e) => e === document.activeElement || e === this.shadowRoot!.activeElement,
@@ -154,17 +141,9 @@ export class SbbBreadcrumbGroupElement extends SlotChildObserver(LitElement) {
   }
 
   private _renderCollapsed(): TemplateResult {
-    for (let i = 0; i < this._breadcrumbs.length; i++) {
-      if (i === 0 || i === this._breadcrumbs.length - 1) {
-        this._breadcrumbs[i].setAttribute('slot', `breadcrumb-${i}`);
-      } else {
-        this._breadcrumbs[i].removeAttribute('slot');
-      }
-    }
-
     return html`
       <li class="sbb-breadcrumb-group__item">
-        <slot name="breadcrumb-0"></slot>
+        <slot name="child-0"></slot>
       </li>
       <li class="sbb-breadcrumb-group__item" id="sbb-breadcrumb-group-ellipsis">
         <sbb-icon
@@ -186,29 +165,25 @@ export class SbbBreadcrumbGroupElement extends SlotChildObserver(LitElement) {
           name="chevron-small-right-small"
           class="sbb-breadcrumb-group__divider-icon"
         ></sbb-icon>
-        <slot name=${`breadcrumb-${this._breadcrumbs.length - 1}`}></slot>
+        <slot name=${`child-${this.listChildren.length - 1}`}></slot>
       </li>
     `;
   }
 
   private _renderExpanded(): TemplateResult[] {
-    const slotName = (index: number): string => `breadcrumb-${index}`;
-
-    return this._breadcrumbs.map((element: SbbBreadcrumbElement, index: number) => {
-      element.setAttribute('slot', slotName(index));
-
-      return html`
+    return this.listSlotNames().map(
+      (name, index, array) => html`
         <li class="sbb-breadcrumb-group__item">
-          <slot name="${slotName(index)}"></slot>
-          ${index !== this._breadcrumbs.length - 1
+          <slot name=${name}></slot>
+          ${index !== array.length - 1
             ? html`<sbb-icon
                 name="chevron-small-right-small"
                 class="sbb-breadcrumb-group__divider-icon"
               ></sbb-icon>`
             : nothing}
         </li>
-      `;
-    });
+      `,
+    );
   }
 
   protected override render(): TemplateResult {
@@ -216,12 +191,10 @@ export class SbbBreadcrumbGroupElement extends SlotChildObserver(LitElement) {
     setAttribute(this, 'data-state', this._state);
 
     return html`
-      <ol class="sbb-breadcrumb-group">
+      <ol class="sbb-breadcrumb-group" role=${this.roleOverride()}>
         ${this._state === 'collapsed' ? this._renderCollapsed() : this._renderExpanded()}
       </ol>
-      <span hidden>
-        <slot></slot>
-      </span>
+      ${this.renderHiddenSlot()}
     `;
   }
 }

--- a/src/components/breadcrumb/breadcrumb/breadcrumb.spec.ts
+++ b/src/components/breadcrumb/breadcrumb/breadcrumb.spec.ts
@@ -1,17 +1,28 @@
 import { expect, fixture } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
+
+import { waitForLitRender } from '../../core/testing';
+
 import './breadcrumb';
 
 describe('sbb-breadcrumb', () => {
   it('renders with text', async () => {
     const root = await fixture(html`
-      <sbb-breadcrumb href="/test" target="_blank" download="true" rel="subsection"
+      <sbb-breadcrumb href="/test" target="_blank" download rel="subsection"
         >Breadcrumb</sbb-breadcrumb
       >
     `);
 
     expect(root).dom.to.be.equal(`
-      <sbb-breadcrumb dir="ltr" role="link" tabindex="0" href="/test" target="_blank" download="true" rel="subsection">
+      <sbb-breadcrumb
+        dir="ltr"
+        role="link"
+        tabindex="0"
+        href="/test"
+        target="_blank"
+        download
+        rel="subsection"
+        id="sbb-breadcrumb-1">
         Breadcrumb
       </sbb-breadcrumb>
     `);
@@ -24,8 +35,15 @@ describe('sbb-breadcrumb', () => {
       <sbb-breadcrumb href="/" icon-name="house-small"></sbb-breadcrumb>
     `);
 
+    await waitForLitRender(root);
     expect(root).dom.to.be.equal(`
-      <sbb-breadcrumb dir="ltr" role="link" tabindex="0" href="/" icon-name="house-small"></sbb-breadcrumb>
+      <sbb-breadcrumb
+        dir="ltr"
+        role="link"
+        tabindex="0"
+        href="/"
+        icon-name="house-small"
+        id="sbb-breadcrumb-2"></sbb-breadcrumb>
     `);
 
     await expect(root).shadowDom.to.equalSnapshot();
@@ -36,8 +54,15 @@ describe('sbb-breadcrumb', () => {
       <sbb-breadcrumb href="/" icon-name="house-small">Home</sbb-breadcrumb>
     `);
 
+    await waitForLitRender(root);
     expect(root).dom.to.be.equal(`
-      <sbb-breadcrumb dir="ltr" role="link" tabindex="0" href="/" icon-name="house-small">
+      <sbb-breadcrumb
+        dir="ltr"
+        role="link"
+        tabindex="0"
+        href="/"
+        icon-name="house-small"
+        id="sbb-breadcrumb-3">
         Home
       </sbb-breadcrumb>
     `);
@@ -49,7 +74,7 @@ describe('sbb-breadcrumb', () => {
     const root = await fixture(html`<sbb-breadcrumb>Breadcrumb</sbb-breadcrumb>`);
 
     expect(root).dom.to.be.equal(`
-      <sbb-breadcrumb dir="ltr">
+      <sbb-breadcrumb dir="ltr" id="sbb-breadcrumb-4">
         Breadcrumb
       </sbb-breadcrumb>
     `);

--- a/src/components/breadcrumb/breadcrumb/breadcrumb.spec.ts
+++ b/src/components/breadcrumb/breadcrumb/breadcrumb.spec.ts
@@ -21,8 +21,7 @@ describe('sbb-breadcrumb', () => {
         href="/test"
         target="_blank"
         download
-        rel="subsection"
-        id="sbb-breadcrumb-1">
+        rel="subsection">
         Breadcrumb
       </sbb-breadcrumb>
     `);
@@ -42,8 +41,7 @@ describe('sbb-breadcrumb', () => {
         role="link"
         tabindex="0"
         href="/"
-        icon-name="house-small"
-        id="sbb-breadcrumb-2"></sbb-breadcrumb>
+        icon-name="house-small"></sbb-breadcrumb>
     `);
 
     await expect(root).shadowDom.to.equalSnapshot();
@@ -61,8 +59,7 @@ describe('sbb-breadcrumb', () => {
         role="link"
         tabindex="0"
         href="/"
-        icon-name="house-small"
-        id="sbb-breadcrumb-3">
+        icon-name="house-small">
         Home
       </sbb-breadcrumb>
     `);
@@ -74,7 +71,7 @@ describe('sbb-breadcrumb', () => {
     const root = await fixture(html`<sbb-breadcrumb>Breadcrumb</sbb-breadcrumb>`);
 
     expect(root).dom.to.be.equal(`
-      <sbb-breadcrumb dir="ltr" id="sbb-breadcrumb-4">
+      <sbb-breadcrumb dir="ltr">
         Breadcrumb
       </sbb-breadcrumb>
     `);

--- a/src/components/breadcrumb/breadcrumb/breadcrumb.ts
+++ b/src/components/breadcrumb/breadcrumb/breadcrumb.ts
@@ -50,6 +50,7 @@ export class SbbBreadcrumbElement extends SlotChildObserver(LitElement) {
 
   public constructor() {
     super();
+    /** @ignore id is already a well known property. */
     this.id = this.id || `sbb-breadcrumb-${nextId++}`;
   }
 

--- a/src/components/breadcrumb/breadcrumb/breadcrumb.ts
+++ b/src/components/breadcrumb/breadcrumb/breadcrumb.ts
@@ -15,6 +15,8 @@ import style from './breadcrumb.scss?lit&inline';
 
 import '../../icon';
 
+let nextId = 1;
+
 /**
  * It displays a link to a page; used within a `sbb-breadcrumb-group` it can display the path to the current page.
  *
@@ -46,14 +48,16 @@ export class SbbBreadcrumbElement extends SlotChildObserver(LitElement) {
 
   @state() private _hasText = false;
 
+  public constructor() {
+    super();
+    this.id = this.id || `sbb-breadcrumb-${nextId++}`;
+  }
+
   private _language = new LanguageController(this);
   private _handlerRepository = new HandlerRepository(this, actionElementHandlerAspect);
 
   public override connectedCallback(): void {
     super.connectedCallback();
-    this._hasText = Array.from(this.childNodes ?? []).some(
-      (n) => !(n as Element).slot && n.textContent?.trim(),
-    );
     this._handlerRepository.connect();
   }
 
@@ -63,9 +67,9 @@ export class SbbBreadcrumbElement extends SlotChildObserver(LitElement) {
   }
 
   protected override checkChildren(): void {
-    this._hasText = !!this.shadowRoot!.querySelector<HTMLSlotElement>('slot:not([name])')
-      ?.assignedNodes()
-      .some((n) => !!n.textContent?.trim());
+    this._hasText = Array.from(this.childNodes ?? []).some(
+      (n) => !(n as Element).slot && n.textContent?.trim(),
+    );
   }
 
   protected override render(): TemplateResult {

--- a/src/components/breadcrumb/breadcrumb/breadcrumb.ts
+++ b/src/components/breadcrumb/breadcrumb/breadcrumb.ts
@@ -15,8 +15,6 @@ import style from './breadcrumb.scss?lit&inline';
 
 import '../../icon';
 
-let nextId = 1;
-
 /**
  * It displays a link to a page; used within a `sbb-breadcrumb-group` it can display the path to the current page.
  *
@@ -47,12 +45,6 @@ export class SbbBreadcrumbElement extends SlotChildObserver(LitElement) {
   @property({ attribute: 'icon-name' }) public iconName?: string;
 
   @state() private _hasText = false;
-
-  public constructor() {
-    super();
-    /** @ignore id is already a well known property. */
-    this.id = this.id || `sbb-breadcrumb-${nextId++}`;
-  }
 
   private _language = new LanguageController(this);
   private _handlerRepository = new HandlerRepository(this, actionElementHandlerAspect);

--- a/src/components/core/common-behaviors/index.ts
+++ b/src/components/core/common-behaviors/index.ts
@@ -1,5 +1,6 @@
 export * from './constructor';
 export * from './language-controller';
 export * from './named-slot-state-controller';
+export * from './named-slot-list-element';
 export * from './slot-child-observer';
 export * from './update-scheduler';

--- a/src/components/core/common-behaviors/named-slot-list-element.ts
+++ b/src/components/core/common-behaviors/named-slot-list-element.ts
@@ -5,7 +5,7 @@ import { state } from 'lit/decorators.js';
 import { SlotChildObserver } from './slot-child-observer';
 
 const SSR_CHILD_COUNT_ATTRIBUTE = 'data-ssr-child-count';
-const SLOTNAME_PREFIX = 'child';
+const SLOTNAME_PREFIX = 'li';
 
 /**
  * Helper type for willUpdate or similar checks.
@@ -58,16 +58,11 @@ export abstract class NamedSlotListElement<
       .filter((c) => !listChildren.includes(c))
       .forEach((c) => c.removeAttribute('slot'));
     this.listChildren = listChildren;
-    this.listChildren.forEach((child, index) => {
-      child.setAttribute('slot', `${SLOTNAME_PREFIX}-${index}`);
-      this.formatChild?.(child);
-    });
+    this.listChildren.forEach((c, index) => c.setAttribute('slot', `${SLOTNAME_PREFIX}-${index}`));
 
     // Remove the ssr attribute, once we have actually initialized the children elements.
     this.removeAttribute(SSR_CHILD_COUNT_ATTRIBUTE);
   }
-
-  protected formatChild?(child: C): void;
 
   /**
    * Renders list and list slots for slotted children or an amount of list slots

--- a/src/components/core/common-behaviors/named-slot-list-element.ts
+++ b/src/components/core/common-behaviors/named-slot-list-element.ts
@@ -106,7 +106,7 @@ export abstract class NamedSlotListElement<
   protected listSlotNames(): string[] {
     const listChildren = this.listChildren.length
       ? this.listChildren
-      : Array.from({ length: +this.getAttribute(SSR_CHILD_COUNT_ATTRIBUTE) });
+      : Array.from({ length: +(this.getAttribute(SSR_CHILD_COUNT_ATTRIBUTE) ?? 0) });
     return listChildren.map((_, i) => `${SLOTNAME_PREFIX}-${i}`);
   }
 
@@ -116,7 +116,7 @@ export abstract class NamedSlotListElement<
    * children should be marked as lists.
    */
   protected roleOverride(): 'presentation' | typeof nothing {
-    return (this.listChildren.length || +this.getAttribute(SSR_CHILD_COUNT_ATTRIBUTE)) >= 2
+    return (this.listChildren.length || +(this.getAttribute(SSR_CHILD_COUNT_ATTRIBUTE) ?? 0)) >= 2
       ? nothing
       : 'presentation';
   }

--- a/src/components/core/common-behaviors/named-slot-list-element.ts
+++ b/src/components/core/common-behaviors/named-slot-list-element.ts
@@ -1,0 +1,113 @@
+import type { TemplateResult } from 'lit';
+import { LitElement, html, nothing } from 'lit';
+import { state } from 'lit/decorators.js';
+
+import { SlotChildObserver } from './slot-child-observer';
+
+/**
+ * Helper type for willUpdate or similar checks.
+ * Allows the usage of the string literal 'listChildren'.
+ *
+ * @example
+ * protected override willUpdate(changedProperties: PropertyValueMap<WithListChildren<this>>): void {
+ *   if (changedProperties.has('listChildren')) {
+ *     ...
+ *   }
+ * }
+ */
+export type WithListChildren<
+  T extends NamedSlotListElement<C>,
+  C extends HTMLElement = HTMLElement,
+> = T & { listChildren: C[] };
+
+/**
+ * This base class provides named slot list observer functionality.
+ * This allows using the pattern of rendering a named slot for each child, which allows
+ * wrapping children in a ul/li list.
+ */
+export abstract class NamedSlotListElement<
+  C extends HTMLElement = HTMLElement,
+> extends SlotChildObserver(LitElement) {
+  /** A list of upper-cased tag names to match against. (e.g. SBB-LINK) */
+  protected abstract readonly listChildTagNames: string[];
+
+  /**
+   * A list of children with the defined tag names.
+   * This array is only updated, if there is an actual change
+   * to the child elements.
+   */
+  @state() protected listChildren: C[] = [];
+
+  protected override checkChildren(): void {
+    const listChildren = Array.from(this.children).filter((e): e is C =>
+      this.listChildTagNames.includes(e.tagName),
+    );
+    // If the slotted child instances have not changed, we can skip syncing and updating
+    // the link reference list.
+    if (
+      this.listChildren &&
+      listChildren.length === this.listChildren.length &&
+      this.listChildren.every((e, i) => listChildren[i] === e)
+    ) {
+      return;
+    }
+
+    this.listChildren
+      .filter((c) => !listChildren.includes(c))
+      .forEach((c) => c.removeAttribute('slot'));
+    this.listChildren = listChildren;
+    this.listChildren.forEach((child, index) => {
+      child.setAttribute('slot', `child-${index}`);
+      this.formatChild?.(child);
+    });
+  }
+
+  protected formatChild?(child: C): void;
+
+  /**
+   * Renders list slots for slotted children or an amount of list slots
+   * corresponding to the `data-ssr-child-count` attribute value.
+   *
+   * This is a possible optimization for SSR, as in an SSR Lit environment
+   * other elements are not available, but might be available in the meta
+   * framework wrapper (like e.g. React). This allows to provide the amount of
+   * children to be passed via the `data-ssr-child-count` attribute value.
+   */
+  protected renderListSlots(): TemplateResult {
+    return html`${this.listSlotNames().map((name) => html`<li><slot name=${name}></slot></li>`)}`;
+  }
+
+  /**
+   * Returns an array of list slot names with the length corresponding to the amount of matched
+   * children or the `data-ssr-child-count` attribute value.
+   *
+   * This is a possible optimization for SSR, as in an SSR Lit environment
+   * other elements are not available, but might be available in the meta
+   * framework wrapper (like e.g. React). This allows to provide the amount of
+   * children to be passed via the `data-ssr-child-count` attribute value.
+   */
+  protected listSlotNames(): string[] {
+    const listChildren = this.listChildren.length
+      ? this.listChildren
+      : Array.from({ length: +this.getAttribute('data-ssr-child-count') });
+    return listChildren.map((_, i) => `child-${i}`);
+  }
+
+  /**
+   * Returns a hidden slot, which is intended as the children change detection.
+   * When an element without a slot attribute is slotted to the element, it triggers
+   * the slotchange event, which can be used to assign it to the appropriate named slot.
+   */
+  protected renderHiddenSlot(): TemplateResult {
+    return html`<span hidden><slot></slot></span>`;
+  }
+
+  /**
+   * Returns 'presentation' when less than two children are available.
+   * This is an accessibility improvement, as only lists with more than one
+   * children should be marked as lists.
+   */
+  protected roleOverride(): 'presentation' | typeof nothing {
+    return this.listSlotNames().length > 1 ? nothing : 'presentation';
+  }
+}

--- a/src/components/core/common-behaviors/slot-child-observer.ts
+++ b/src/components/core/common-behaviors/slot-child-observer.ts
@@ -1,12 +1,10 @@
 import type { LitElement, PropertyValues } from 'lit';
 
-import { ConnectedAbortController } from '../eventing';
-
 import type { Constructor } from './constructor';
 
 // Define the interface for the mixin
-export declare class SlotChildObserverType {
-  protected checkChildren(): void;
+export declare abstract class SlotChildObserverType {
+  protected abstract checkChildren(): void;
 }
 
 /**
@@ -22,51 +20,52 @@ export const SlotChildObserver = <T extends Constructor<LitElement>>(
 ): Constructor<SlotChildObserverType> & T => {
   class SlotChildObserverClass extends base implements Partial<SlotChildObserverType> {
     /**
+     * Whether the component needs hydration.
+     * @see https://github.com/lit/lit/blob/main/packages/labs/ssr-client/src/lit-element-hydrate-support.ts
+     *
      * We have a problem with SSR, in that we don't have a reference to children.
      * Due to this, the SSR/hydration can fail, when internal elements depend on children
      * and will therefore not be rendered server side, but will be immediately rendered client side.
      * Due to this, we add this initialized property, which will prevent child detection
      * until it has been initialized/hydrated.
-     *
-     * https://github.com/lit/lit/discussions/4407
+     * @see https://github.com/lit/lit/discussions/4407
      */
-    private _hydrated = new Promise<void>((r) => (this._hydratedResolve = r));
-    private _hydratedResolve?: () => void;
-    private _hydratedResolved = false;
-    private _slotchangeAbortController = new ConnectedAbortController(this);
+    private _needsHydration = false;
+    private _slotchangeHandler = (): void => {
+      if (this._needsHydration) {
+        return;
+      }
+      this.checkChildren();
+    };
+
+    protected override createRenderRoot(): HTMLElement | DocumentFragment {
+      this._needsHydration = !!this.shadowRoot;
+      return super.createRenderRoot();
+    }
+
+    protected override update(changedProperties: PropertyValues): void {
+      super.update(changedProperties);
+      if (this._needsHydration) {
+        this._needsHydration = false;
+        Promise.resolve().then(() => this.checkChildren());
+      }
+    }
 
     public override connectedCallback(): void {
       super.connectedCallback();
-      if (this._hydratedResolved) {
+      if (!this._needsHydration) {
         this.checkChildren();
       }
-      this.shadowRoot?.addEventListener(
-        'slotchange',
-        () => {
-          if (!this._hydratedResolved) {
-            return;
-          }
-          this.checkChildren();
-        },
-        { signal: this._slotchangeAbortController.signal },
-      );
+      this.shadowRoot!.addEventListener('slotchange', this._slotchangeHandler);
+    }
+
+    public override disconnectedCallback(): void {
+      super.disconnectedCallback();
+      this.shadowRoot!.removeEventListener('slotchange', this._slotchangeHandler);
     }
 
     protected checkChildren(): void {
       // Needs to be implemented by inherited classes
-    }
-
-    protected override firstUpdated(changedProperties: PropertyValues): void {
-      super.firstUpdated(changedProperties);
-      this._hydratedResolved = true;
-      this._hydratedResolve?.();
-      Promise.resolve().then(() => this.checkChildren());
-    }
-
-    protected override async getUpdateComplete(): Promise<boolean> {
-      const result = await super.getUpdateComplete();
-      await this._hydrated;
-      return result;
     }
   }
   return SlotChildObserverClass as unknown as Constructor<SlotChildObserverType> & T;

--- a/src/components/core/common-behaviors/slot-child-observer.ts
+++ b/src/components/core/common-behaviors/slot-child-observer.ts
@@ -41,7 +41,7 @@ export const SlotChildObserver = <T extends Constructor<LitElement>>(
     protected override createRenderRoot(): HTMLElement | DocumentFragment {
       // Check whether hydration is needed by checking whether the shadow root
       // is available before createRenderRoot is called.
-      this._needsHydration = !!this.shadowRoot;
+      this._needsHydration = !!this.shadowRoot && 'litElementHydrateSupport' in globalThis;
       return super.createRenderRoot();
     }
 
@@ -49,7 +49,7 @@ export const SlotChildObserver = <T extends Constructor<LitElement>>(
       super.willUpdate(changedProperties);
       // If hydration is not needed we can immediately check for children
       // in the first update.
-      if (!this._needsHydration && !this.hasUpdated) {
+      if (!this.hasUpdated && !this._needsHydration) {
         this.checkChildren();
       }
     }

--- a/src/components/icon/icon-base.ts
+++ b/src/components/icon/icon-base.ts
@@ -2,12 +2,13 @@ import type { CSSResultGroup, TemplateResult } from 'lit';
 import { html, LitElement } from 'lit';
 import { property, state } from 'lit/decorators.js';
 
+import { UpdateScheduler } from '../core/common-behaviors';
 import { setAttribute } from '../core/dom';
 
 import { getSvgContent } from './icon-request';
 import style from './icon.scss?lit&inline';
 
-export abstract class SbbIconBase extends LitElement {
+export abstract class SbbIconBase extends UpdateScheduler(LitElement) {
   public static override styles: CSSResultGroup = style;
 
   @state() private _svgNamespace = 'default';
@@ -30,13 +31,18 @@ export abstract class SbbIconBase extends LitElement {
       return;
     }
 
+    this.startUpdate();
     const [namespace, name] = this._splitIconName(iconName);
 
     if (namespace) {
       this._svgNamespace = namespace;
     }
 
-    this._svgIcon = await this.fetchSvgIcon(this._svgNamespace, name);
+    try {
+      this._svgIcon = await this.fetchSvgIcon(this._svgNamespace, name);
+    } finally {
+      this.completeUpdate();
+    }
   }
 
   protected async fetchSvgIcon(namespace: string, name: string): Promise<string> {

--- a/src/components/icon/icon.spec.ts
+++ b/src/components/icon/icon.spec.ts
@@ -110,7 +110,7 @@ describe('sbb-icon', () => {
     await waitForLitRender(root);
 
     expect(root).dom.to.be.equal(`
-      <sbb-icon name="kom:heart-medium" aria-hidden="true" role="img" data-namespace="kom" data-empty>
+      <sbb-icon name="kom:heart-medium" aria-hidden="true" role="img" data-namespace="kom">
       </sbb-icon>
     `);
     await expect(root).shadowDom.to.equalSnapshot();

--- a/src/components/link-list/__snapshots__/link-list.spec.snap.js
+++ b/src/components/link-list/__snapshots__/link-list.spec.snap.js
@@ -16,15 +16,15 @@ snapshots["sbb-link-list should render named slots if data-ssr-child-count attri
   </sbb-title>
   <ul class="sbb-link-list">
     <li>
-      <slot name="child-0">
+      <slot name="li-0">
       </slot>
     </li>
     <li>
-      <slot name="child-1">
+      <slot name="li-1">
       </slot>
     </li>
     <li>
-      <slot name="child-2">
+      <slot name="li-2">
       </slot>
     </li>
   </ul>
@@ -38,7 +38,7 @@ snapshots["sbb-link-list should render named slots if data-ssr-child-count attri
 
 snapshots["sbb-link-list rendered with a slotted title in light DOM"] = 
 `<sbb-link-list
-  data-slot-names="child-0 child-1 child-2 child-3 child-4 title"
+  data-slot-names="li-0 li-1 li-2 li-3 li-4 title"
   orientation="vertical"
   size="s"
   title-level="2"
@@ -52,7 +52,7 @@ snapshots["sbb-link-list rendered with a slotted title in light DOM"] =
     href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
     role="link"
     size="s"
-    slot="child-0"
+    slot="li-0"
     tabindex="0"
     variant="block"
   >
@@ -64,7 +64,7 @@ snapshots["sbb-link-list rendered with a slotted title in light DOM"] =
     href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
     role="link"
     size="s"
-    slot="child-1"
+    slot="li-1"
     tabindex="0"
     variant="block"
   >
@@ -76,7 +76,7 @@ snapshots["sbb-link-list rendered with a slotted title in light DOM"] =
     href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
     role="link"
     size="s"
-    slot="child-2"
+    slot="li-2"
     tabindex="0"
     variant="block"
   >
@@ -88,7 +88,7 @@ snapshots["sbb-link-list rendered with a slotted title in light DOM"] =
     href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
     role="link"
     size="s"
-    slot="child-3"
+    slot="li-3"
     tabindex="0"
     variant="block"
   >
@@ -100,7 +100,7 @@ snapshots["sbb-link-list rendered with a slotted title in light DOM"] =
     href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
     role="link"
     size="s"
-    slot="child-4"
+    slot="li-4"
     tabindex="0"
     variant="block"
   >
@@ -128,23 +128,23 @@ snapshots["sbb-link-list rendered with a slotted title in shadow DOM"] =
     class="sbb-link-list"
   >
     <li>
-      <slot name="child-0">
+      <slot name="li-0">
       </slot>
     </li>
     <li>
-      <slot name="child-1">
+      <slot name="li-1">
       </slot>
     </li>
     <li>
-      <slot name="child-2">
+      <slot name="li-2">
       </slot>
     </li>
     <li>
-      <slot name="child-3">
+      <slot name="li-3">
       </slot>
     </li>
     <li>
-      <slot name="child-4">
+      <slot name="li-4">
       </slot>
     </li>
   </ul>
@@ -158,7 +158,7 @@ snapshots["sbb-link-list rendered with a slotted title in shadow DOM"] =
 
 snapshots["sbb-link-list rendered with a title from properties in light DOM"] = 
 `<sbb-link-list
-  data-slot-names="child-0 child-1 child-2 child-3 child-4"
+  data-slot-names="li-0 li-1 li-2 li-3 li-4"
   orientation="vertical"
   size="s"
   title-content="Help &amp; Contact"
@@ -170,7 +170,7 @@ snapshots["sbb-link-list rendered with a title from properties in light DOM"] =
     href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
     role="link"
     size="s"
-    slot="child-0"
+    slot="li-0"
     tabindex="0"
     variant="block"
   >
@@ -182,7 +182,7 @@ snapshots["sbb-link-list rendered with a title from properties in light DOM"] =
     href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
     role="link"
     size="s"
-    slot="child-1"
+    slot="li-1"
     tabindex="0"
     variant="block"
   >
@@ -194,7 +194,7 @@ snapshots["sbb-link-list rendered with a title from properties in light DOM"] =
     href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
     role="link"
     size="s"
-    slot="child-2"
+    slot="li-2"
     tabindex="0"
     variant="block"
   >
@@ -206,7 +206,7 @@ snapshots["sbb-link-list rendered with a title from properties in light DOM"] =
     href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
     role="link"
     size="s"
-    slot="child-3"
+    slot="li-3"
     tabindex="0"
     variant="block"
   >
@@ -218,7 +218,7 @@ snapshots["sbb-link-list rendered with a title from properties in light DOM"] =
     href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
     role="link"
     size="s"
-    slot="child-4"
+    slot="li-4"
     tabindex="0"
     variant="block"
   >
@@ -247,23 +247,23 @@ snapshots["sbb-link-list rendered with a title from properties in shadow DOM"] =
     class="sbb-link-list"
   >
     <li>
-      <slot name="child-0">
+      <slot name="li-0">
       </slot>
     </li>
     <li>
-      <slot name="child-1">
+      <slot name="li-1">
       </slot>
     </li>
     <li>
-      <slot name="child-2">
+      <slot name="li-2">
       </slot>
     </li>
     <li>
-      <slot name="child-3">
+      <slot name="li-3">
       </slot>
     </li>
     <li>
-      <slot name="child-4">
+      <slot name="li-4">
       </slot>
     </li>
   </ul>
@@ -277,7 +277,7 @@ snapshots["sbb-link-list rendered with a title from properties in shadow DOM"] =
 
 snapshots["sbb-link-list rendered without a title in light DOM"] = 
 `<sbb-link-list
-  data-slot-names="child-0 child-1 child-2 child-3 child-4"
+  data-slot-names="li-0 li-1 li-2 li-3 li-4"
   orientation="vertical"
   size="s"
 >
@@ -287,7 +287,7 @@ snapshots["sbb-link-list rendered without a title in light DOM"] =
     href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
     role="link"
     size="s"
-    slot="child-0"
+    slot="li-0"
     tabindex="0"
     variant="block"
   >
@@ -299,7 +299,7 @@ snapshots["sbb-link-list rendered without a title in light DOM"] =
     href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
     role="link"
     size="s"
-    slot="child-1"
+    slot="li-1"
     tabindex="0"
     variant="block"
   >
@@ -311,7 +311,7 @@ snapshots["sbb-link-list rendered without a title in light DOM"] =
     href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
     role="link"
     size="s"
-    slot="child-2"
+    slot="li-2"
     tabindex="0"
     variant="block"
   >
@@ -323,7 +323,7 @@ snapshots["sbb-link-list rendered without a title in light DOM"] =
     href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
     role="link"
     size="s"
-    slot="child-3"
+    slot="li-3"
     tabindex="0"
     variant="block"
   >
@@ -335,7 +335,7 @@ snapshots["sbb-link-list rendered without a title in light DOM"] =
     href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
     role="link"
     size="s"
-    slot="child-4"
+    slot="li-4"
     tabindex="0"
     variant="block"
   >
@@ -360,23 +360,23 @@ snapshots["sbb-link-list rendered without a title in shadow DOM"] =
   </sbb-title>
   <ul class="sbb-link-list">
     <li>
-      <slot name="child-0">
+      <slot name="li-0">
       </slot>
     </li>
     <li>
-      <slot name="child-1">
+      <slot name="li-1">
       </slot>
     </li>
     <li>
-      <slot name="child-2">
+      <slot name="li-2">
       </slot>
     </li>
     <li>
-      <slot name="child-3">
+      <slot name="li-3">
       </slot>
     </li>
     <li>
-      <slot name="child-4">
+      <slot name="li-4">
       </slot>
     </li>
   </ul>

--- a/src/components/link-list/__snapshots__/link-list.spec.snap.js
+++ b/src/components/link-list/__snapshots__/link-list.spec.snap.js
@@ -1,222 +1,6 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["sbb-link-list rendered with a slotted title"] = 
-`<sbb-link-list
-  data-slot-names="link-0 link-1 link-2 link-3 link-4 title"
-  orientation="vertical"
-  size="s"
-  title-level="2"
->
-  <span slot="title">
-    Help & Contact
-  </span>
-  <sbb-link
-    data-slot-names="unnamed"
-    dir="ltr"
-    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
-    role="link"
-    size="s"
-    slot="link-0"
-    tabindex="0"
-    variant="block"
-  >
-    Rückerstattungen
-  </sbb-link>
-  <sbb-link
-    data-slot-names="unnamed"
-    dir="ltr"
-    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
-    role="link"
-    size="s"
-    slot="link-1"
-    tabindex="0"
-    variant="block"
-  >
-    Fundbüro
-  </sbb-link>
-  <sbb-link
-    data-slot-names="unnamed"
-    dir="ltr"
-    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
-    role="link"
-    size="s"
-    slot="link-2"
-    tabindex="0"
-    variant="block"
-  >
-    Beschwerden
-  </sbb-link>
-  <sbb-link
-    data-slot-names="unnamed"
-    dir="ltr"
-    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
-    role="link"
-    size="s"
-    slot="link-3"
-    tabindex="0"
-    variant="block"
-  >
-    Lob aussprechen
-  </sbb-link>
-  <sbb-link
-    data-slot-names="unnamed"
-    dir="ltr"
-    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
-    role="link"
-    size="s"
-    slot="link-4"
-    tabindex="0"
-    variant="block"
-  >
-    Sachbeschädigung melden
-  </sbb-link>
-</sbb-link-list>
-`;
-/* end snapshot sbb-link-list rendered with a slotted title */
-
-snapshots["sbb-link-list rendered with a title from properties"] = 
-`<sbb-link-list
-  data-slot-names="link-0 link-1 link-2 link-3 link-4"
-  orientation="vertical"
-  size="s"
-  title-content="Help &amp; Contact"
-  title-level="2"
->
-  <sbb-link
-    data-slot-names="unnamed"
-    dir="ltr"
-    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
-    role="link"
-    size="s"
-    slot="link-0"
-    tabindex="0"
-    variant="block"
-  >
-    Rückerstattungen
-  </sbb-link>
-  <sbb-link
-    data-slot-names="unnamed"
-    dir="ltr"
-    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
-    role="link"
-    size="s"
-    slot="link-1"
-    tabindex="0"
-    variant="block"
-  >
-    Fundbüro
-  </sbb-link>
-  <sbb-link
-    data-slot-names="unnamed"
-    dir="ltr"
-    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
-    role="link"
-    size="s"
-    slot="link-2"
-    tabindex="0"
-    variant="block"
-  >
-    Beschwerden
-  </sbb-link>
-  <sbb-link
-    data-slot-names="unnamed"
-    dir="ltr"
-    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
-    role="link"
-    size="s"
-    slot="link-3"
-    tabindex="0"
-    variant="block"
-  >
-    Lob aussprechen
-  </sbb-link>
-  <sbb-link
-    data-slot-names="unnamed"
-    dir="ltr"
-    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
-    role="link"
-    size="s"
-    slot="link-4"
-    tabindex="0"
-    variant="block"
-  >
-    Sachbeschädigung melden
-  </sbb-link>
-</sbb-link-list>
-`;
-/* end snapshot sbb-link-list rendered with a title from properties */
-
-snapshots["sbb-link-list rendered without a title"] = 
-`<sbb-link-list
-  data-slot-names="link-0 link-1 link-2 link-3 link-4"
-  orientation="vertical"
-  size="s"
->
-  <sbb-link
-    data-slot-names="unnamed"
-    dir="ltr"
-    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
-    role="link"
-    size="s"
-    slot="link-0"
-    tabindex="0"
-    variant="block"
-  >
-    Rückerstattungen
-  </sbb-link>
-  <sbb-link
-    data-slot-names="unnamed"
-    dir="ltr"
-    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
-    role="link"
-    size="s"
-    slot="link-1"
-    tabindex="0"
-    variant="block"
-  >
-    Fundbüro
-  </sbb-link>
-  <sbb-link
-    data-slot-names="unnamed"
-    dir="ltr"
-    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
-    role="link"
-    size="s"
-    slot="link-2"
-    tabindex="0"
-    variant="block"
-  >
-    Beschwerden
-  </sbb-link>
-  <sbb-link
-    data-slot-names="unnamed"
-    dir="ltr"
-    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
-    role="link"
-    size="s"
-    slot="link-3"
-    tabindex="0"
-    variant="block"
-  >
-    Lob aussprechen
-  </sbb-link>
-  <sbb-link
-    data-slot-names="unnamed"
-    dir="ltr"
-    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
-    role="link"
-    size="s"
-    slot="link-4"
-    tabindex="0"
-    variant="block"
-  >
-    Sachbeschädigung melden
-  </sbb-link>
-</sbb-link-list>
-`;
-/* end snapshot sbb-link-list rendered without a title */
-
 snapshots["sbb-link-list should render named slots if data-ssr-child-count attribute is set"] = 
 `<div class="sbb-link-list-wrapper">
   <sbb-title
@@ -232,15 +16,15 @@ snapshots["sbb-link-list should render named slots if data-ssr-child-count attri
   </sbb-title>
   <ul class="sbb-link-list">
     <li>
-      <slot name="link-0">
+      <slot name="child-0">
       </slot>
     </li>
     <li>
-      <slot name="link-1">
+      <slot name="child-1">
       </slot>
     </li>
     <li>
-      <slot name="link-2">
+      <slot name="child-2">
       </slot>
     </li>
   </ul>
@@ -251,4 +35,356 @@ snapshots["sbb-link-list should render named slots if data-ssr-child-count attri
 </div>
 `;
 /* end snapshot sbb-link-list should render named slots if data-ssr-child-count attribute is set */
+
+snapshots["sbb-link-list rendered with a slotted title in light DOM"] = 
+`<sbb-link-list
+  data-slot-names="child-0 child-1 child-2 child-3 child-4 title"
+  orientation="vertical"
+  size="s"
+  title-level="2"
+>
+  <span slot="title">
+    Help & Contact
+  </span>
+  <sbb-link
+    data-slot-names="unnamed"
+    dir="ltr"
+    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
+    role="link"
+    size="s"
+    slot="child-0"
+    tabindex="0"
+    variant="block"
+  >
+    Rückerstattungen
+  </sbb-link>
+  <sbb-link
+    data-slot-names="unnamed"
+    dir="ltr"
+    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
+    role="link"
+    size="s"
+    slot="child-1"
+    tabindex="0"
+    variant="block"
+  >
+    Fundbüro
+  </sbb-link>
+  <sbb-link
+    data-slot-names="unnamed"
+    dir="ltr"
+    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
+    role="link"
+    size="s"
+    slot="child-2"
+    tabindex="0"
+    variant="block"
+  >
+    Beschwerden
+  </sbb-link>
+  <sbb-link
+    data-slot-names="unnamed"
+    dir="ltr"
+    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
+    role="link"
+    size="s"
+    slot="child-3"
+    tabindex="0"
+    variant="block"
+  >
+    Lob aussprechen
+  </sbb-link>
+  <sbb-link
+    data-slot-names="unnamed"
+    dir="ltr"
+    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
+    role="link"
+    size="s"
+    slot="child-4"
+    tabindex="0"
+    variant="block"
+  >
+    Sachbeschädigung melden
+  </sbb-link>
+</sbb-link-list>
+`;
+/* end snapshot sbb-link-list rendered with a slotted title in light DOM */
+
+snapshots["sbb-link-list rendered with a slotted title in shadow DOM"] = 
+`<div class="sbb-link-list-wrapper">
+  <sbb-title
+    aria-level="2"
+    class="sbb-link-list-title"
+    id="sbb-link-list-title-id"
+    level="2"
+    role="heading"
+    visual-level="5"
+  >
+    <slot name="title">
+    </slot>
+  </sbb-title>
+  <ul
+    aria-labelledby="sbb-link-list-title-id"
+    class="sbb-link-list"
+  >
+    <li>
+      <slot name="child-0">
+      </slot>
+    </li>
+    <li>
+      <slot name="child-1">
+      </slot>
+    </li>
+    <li>
+      <slot name="child-2">
+      </slot>
+    </li>
+    <li>
+      <slot name="child-3">
+      </slot>
+    </li>
+    <li>
+      <slot name="child-4">
+      </slot>
+    </li>
+  </ul>
+  <span hidden="">
+    <slot>
+    </slot>
+  </span>
+</div>
+`;
+/* end snapshot sbb-link-list rendered with a slotted title in shadow DOM */
+
+snapshots["sbb-link-list rendered with a title from properties in light DOM"] = 
+`<sbb-link-list
+  data-slot-names="child-0 child-1 child-2 child-3 child-4"
+  orientation="vertical"
+  size="s"
+  title-content="Help &amp; Contact"
+  title-level="2"
+>
+  <sbb-link
+    data-slot-names="unnamed"
+    dir="ltr"
+    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
+    role="link"
+    size="s"
+    slot="child-0"
+    tabindex="0"
+    variant="block"
+  >
+    Rückerstattungen
+  </sbb-link>
+  <sbb-link
+    data-slot-names="unnamed"
+    dir="ltr"
+    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
+    role="link"
+    size="s"
+    slot="child-1"
+    tabindex="0"
+    variant="block"
+  >
+    Fundbüro
+  </sbb-link>
+  <sbb-link
+    data-slot-names="unnamed"
+    dir="ltr"
+    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
+    role="link"
+    size="s"
+    slot="child-2"
+    tabindex="0"
+    variant="block"
+  >
+    Beschwerden
+  </sbb-link>
+  <sbb-link
+    data-slot-names="unnamed"
+    dir="ltr"
+    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
+    role="link"
+    size="s"
+    slot="child-3"
+    tabindex="0"
+    variant="block"
+  >
+    Lob aussprechen
+  </sbb-link>
+  <sbb-link
+    data-slot-names="unnamed"
+    dir="ltr"
+    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
+    role="link"
+    size="s"
+    slot="child-4"
+    tabindex="0"
+    variant="block"
+  >
+    Sachbeschädigung melden
+  </sbb-link>
+</sbb-link-list>
+`;
+/* end snapshot sbb-link-list rendered with a title from properties in light DOM */
+
+snapshots["sbb-link-list rendered with a title from properties in shadow DOM"] = 
+`<div class="sbb-link-list-wrapper">
+  <sbb-title
+    aria-level="2"
+    class="sbb-link-list-title"
+    id="sbb-link-list-title-id"
+    level="2"
+    role="heading"
+    visual-level="5"
+  >
+    <slot name="title">
+      Help & Contact
+    </slot>
+  </sbb-title>
+  <ul
+    aria-labelledby="sbb-link-list-title-id"
+    class="sbb-link-list"
+  >
+    <li>
+      <slot name="child-0">
+      </slot>
+    </li>
+    <li>
+      <slot name="child-1">
+      </slot>
+    </li>
+    <li>
+      <slot name="child-2">
+      </slot>
+    </li>
+    <li>
+      <slot name="child-3">
+      </slot>
+    </li>
+    <li>
+      <slot name="child-4">
+      </slot>
+    </li>
+  </ul>
+  <span hidden="">
+    <slot>
+    </slot>
+  </span>
+</div>
+`;
+/* end snapshot sbb-link-list rendered with a title from properties in shadow DOM */
+
+snapshots["sbb-link-list rendered without a title in light DOM"] = 
+`<sbb-link-list
+  data-slot-names="child-0 child-1 child-2 child-3 child-4"
+  orientation="vertical"
+  size="s"
+>
+  <sbb-link
+    data-slot-names="unnamed"
+    dir="ltr"
+    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
+    role="link"
+    size="s"
+    slot="child-0"
+    tabindex="0"
+    variant="block"
+  >
+    Rückerstattungen
+  </sbb-link>
+  <sbb-link
+    data-slot-names="unnamed"
+    dir="ltr"
+    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
+    role="link"
+    size="s"
+    slot="child-1"
+    tabindex="0"
+    variant="block"
+  >
+    Fundbüro
+  </sbb-link>
+  <sbb-link
+    data-slot-names="unnamed"
+    dir="ltr"
+    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
+    role="link"
+    size="s"
+    slot="child-2"
+    tabindex="0"
+    variant="block"
+  >
+    Beschwerden
+  </sbb-link>
+  <sbb-link
+    data-slot-names="unnamed"
+    dir="ltr"
+    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
+    role="link"
+    size="s"
+    slot="child-3"
+    tabindex="0"
+    variant="block"
+  >
+    Lob aussprechen
+  </sbb-link>
+  <sbb-link
+    data-slot-names="unnamed"
+    dir="ltr"
+    href="https://www.sbb.ch/de/hilfe-und-kontakt/erstattung-entschaedigung/rueckerstattung-von-billetten.html"
+    role="link"
+    size="s"
+    slot="child-4"
+    tabindex="0"
+    variant="block"
+  >
+    Sachbeschädigung melden
+  </sbb-link>
+</sbb-link-list>
+`;
+/* end snapshot sbb-link-list rendered without a title in light DOM */
+
+snapshots["sbb-link-list rendered without a title in shadow DOM"] = 
+`<div class="sbb-link-list-wrapper">
+  <sbb-title
+    aria-level="2"
+    class="sbb-link-list-title"
+    id="sbb-link-list-title-id"
+    level="2"
+    role="heading"
+    visual-level="5"
+  >
+    <slot name="title">
+    </slot>
+  </sbb-title>
+  <ul class="sbb-link-list">
+    <li>
+      <slot name="child-0">
+      </slot>
+    </li>
+    <li>
+      <slot name="child-1">
+      </slot>
+    </li>
+    <li>
+      <slot name="child-2">
+      </slot>
+    </li>
+    <li>
+      <slot name="child-3">
+      </slot>
+    </li>
+    <li>
+      <slot name="child-4">
+      </slot>
+    </li>
+  </ul>
+  <span hidden="">
+    <slot>
+    </slot>
+  </span>
+</div>
+`;
+/* end snapshot sbb-link-list rendered without a title in shadow DOM */
 

--- a/src/components/link-list/__snapshots__/link-list.spec.snap.js
+++ b/src/components/link-list/__snapshots__/link-list.spec.snap.js
@@ -14,7 +14,10 @@ snapshots["sbb-link-list should render named slots if data-ssr-child-count attri
     <slot name="title">
     </slot>
   </sbb-title>
-  <ul class="sbb-link-list">
+  <ul
+    aria-labelledby="sbb-link-list-title-id"
+    class="sbb-link-list"
+  >
     <li>
       <slot name="li-0">
       </slot>
@@ -358,7 +361,10 @@ snapshots["sbb-link-list rendered without a title in shadow DOM"] =
     <slot name="title">
     </slot>
   </sbb-title>
-  <ul class="sbb-link-list">
+  <ul
+    aria-labelledby="sbb-link-list-title-id"
+    class="sbb-link-list"
+  >
     <li>
       <slot name="li-0">
       </slot>

--- a/src/components/link-list/link-list.spec.ts
+++ b/src/components/link-list/link-list.spec.ts
@@ -34,97 +34,55 @@ describe('sbb-link-list', () => {
     >
   `;
 
-  it('rendered with a slotted title', async () => {
-    element = await fixture(
-      html` <sbb-link-list title-level="2">
-        <span slot="title">Help &amp; Contact</span>
-        ${sbbLinkSnippet}
-      </sbb-link-list>`,
-    );
+  describe('rendered with a slotted title', () => {
+    before(async () => {
+      element = await fixture(
+        html` <sbb-link-list title-level="2">
+          <span slot="title">Help &amp; Contact</span>
+          ${sbbLinkSnippet}
+        </sbb-link-list>`,
+      );
+    });
 
-    await expect(element).dom.to.equalSnapshot();
-    expect(element).shadowDom.to.be.equal(
-      `
-            <div class="sbb-link-list-wrapper">
-              <sbb-title id="sbb-link-list-title-id" level="2" visual-level="5" class="sbb-link-list-title" aria-level="2" role="heading">
-                <slot name="title"></slot>
-              </sbb-title>
-              <ul aria-labelledby="sbb-link-list-title-id" class="sbb-link-list">
-                <li><slot name="link-0"></slot></li>
-                <li><slot name="link-1"></slot></li>
-                <li><slot name="link-2"></slot></li>
-                <li><slot name="link-3"></slot></li>
-                <li><slot name="link-4"></slot></li>
-              </ul>
-              <span hidden>
-                <slot></slot>
-              </span>
-            </div>
-          `,
-    );
+    it('in light DOM', async () => {
+      await expect(element).dom.to.equalSnapshot();
+    });
+
+    it('in shadow DOM', async () => {
+      await expect(element).shadowDom.to.equalSnapshot();
+    });
   });
 
-  it('rendered with a title from properties', async () => {
-    element = await fixture(
-      html` <sbb-link-list title-level="2" title-content="Help &amp; Contact">
-        ${sbbLinkSnippet}
-      </sbb-link-list>`,
-    );
+  describe('rendered with a title from properties', () => {
+    before(async () => {
+      element = await fixture(
+        html` <sbb-link-list title-level="2" title-content="Help &amp; Contact">
+          ${sbbLinkSnippet}
+        </sbb-link-list>`,
+      );
+    });
 
-    await expect(element).dom.to.equalSnapshot();
-    expect(element).shadowDom.to.be.equal(
-      `
-            <div class="sbb-link-list-wrapper">
-              <sbb-title id="sbb-link-list-title-id" level="2" visual-level="5" class="sbb-link-list-title" role="heading" aria-level="2">
-                <slot name="title">
-                Help &amp; Contact
-              </sbb-title>
-              <ul aria-labelledby="sbb-link-list-title-id" class="sbb-link-list">
-                <li><slot name="link-0"></slot></li>
-                <li><slot name="link-1"></slot></li>
-                <li><slot name="link-2"></slot></li>
-                <li><slot name="link-3"></slot></li>
-                <li><slot name="link-4"></slot></li>
-              </ul>
-              <span hidden>
-                <slot></slot>
-              </span>
-            </div>
-          `,
-    );
+    it('in light DOM', async () => {
+      await expect(element).dom.to.equalSnapshot();
+    });
+
+    it('in shadow DOM', async () => {
+      await expect(element).shadowDom.to.equalSnapshot();
+    });
   });
 
-  it('rendered without a title', async () => {
-    element = await fixture(html` <sbb-link-list> ${sbbLinkSnippet} </sbb-link-list>`);
+  describe('rendered without a title', () => {
+    before(async () => {
+      element = await fixture(html`<sbb-link-list>${sbbLinkSnippet}</sbb-link-list>`);
+    });
 
-    await expect(element).dom.to.equalSnapshot();
-    expect(element).shadowDom.to.be.equal(
-      `
-            <div class="sbb-link-list-wrapper">
-              <sbb-title
-                aria-level="2"
-                class="sbb-link-list-title"
-                id="sbb-link-list-title-id"
-                level="2"
-                role="heading"
-                visual-level="5"
-              >
-                <slot name="title">
-                </slot>
-              </sbb-title>
-              <ul class="sbb-link-list">
-                <li><slot name="link-0"></slot></li>
-                <li><slot name="link-1"></slot></li>
-                <li><slot name="link-2"></slot></li>
-                <li><slot name="link-3"></slot></li>
-                <li><slot name="link-4"></slot></li>
-              </ul>
-              <span hidden>
-                <slot></slot>
-              </span>
-            </div>
-          `,
-    );
+    it('in light DOM', async () => {
+      await expect(element).dom.to.equalSnapshot();
+    });
+
+    it('in shadow DOM', async () => {
+      await expect(element).shadowDom.to.equalSnapshot();
+    });
   });
 
   it('should render named slots if data-ssr-child-count attribute is set', async () => {

--- a/src/components/link-list/link-list.ts
+++ b/src/components/link-list/link-list.ts
@@ -51,6 +51,7 @@ export class SbbLinkListElement extends NamedSlotListElement<SbbLinkElement> {
   private _namedSlots = new NamedSlotStateController(this);
 
   protected override willUpdate(changedProperties: PropertyValues<WithListChildren<this>>): void {
+    super.willUpdate(changedProperties);
     if (
       changedProperties.has('size') ||
       changedProperties.has('negative') ||

--- a/src/components/link-list/link-list.ts
+++ b/src/components/link-list/link-list.ts
@@ -48,7 +48,10 @@ export class SbbLinkListElement extends NamedSlotListElement<SbbLinkElement> {
   /** The orientation in which the list will be shown vertical or horizontal. */
   @property({ reflect: true }) public orientation: SbbOrientation = 'vertical';
 
-  private _namedSlots = new NamedSlotStateController(this);
+  public constructor() {
+    super();
+    new NamedSlotStateController(this);
+  }
 
   protected override willUpdate(changedProperties: PropertyValues<WithListChildren<this>>): void {
     super.willUpdate(changedProperties);
@@ -75,14 +78,9 @@ export class SbbLinkListElement extends NamedSlotListElement<SbbLinkElement> {
           ?negative=${this.negative}
           id="sbb-link-list-title-id"
         >
-          <slot name="title" @slotchange=${() => this.requestUpdate()}>${this.titleContent}</slot>
+          <slot name="title">${this.titleContent}</slot>
         </sbb-title>
-        ${this.renderList({
-          ariaLabelledby:
-            this._namedSlots.slots.has('title') || this.titleContent
-              ? 'sbb-link-list-title-id'
-              : undefined,
-        })}
+        ${this.renderList({ ariaLabelledby: 'sbb-link-list-title-id' })}
       </div>
     `;
   }

--- a/src/components/link-list/link-list.ts
+++ b/src/components/link-list/link-list.ts
@@ -76,16 +76,12 @@ export class SbbLinkListElement extends NamedSlotListElement<SbbLinkElement> {
         >
           <slot name="title" @slotchange=${() => this.requestUpdate()}>${this.titleContent}</slot>
         </sbb-title>
-        <ul
-          aria-labelledby=${this._namedSlots.slots.has('title') || this.titleContent
-            ? 'sbb-link-list-title-id'
-            : nothing}
-          class="sbb-link-list"
-          role=${this.roleOverride()}
-        >
-          ${this.renderListSlots()}
-        </ul>
-        ${this.renderHiddenSlot()}
+        ${this.renderList({
+          ariaLabelledby:
+            this._namedSlots.slots.has('title') || this.titleContent
+              ? 'sbb-link-list-title-id'
+              : undefined,
+        })}
       </div>
     `;
   }

--- a/src/components/menu/menu/__snapshots__/menu.spec.snap.js
+++ b/src/components/menu/menu/__snapshots__/menu.spec.snap.js
@@ -60,19 +60,19 @@ snapshots["sbb-menu renders with list"] =
     <div class="sbb-menu__content">
       <ul class="sbb-menu-list">
         <li>
-          <slot name="child-0">
+          <slot name="li-0">
           </slot>
         </li>
         <li>
-          <slot name="child-1">
+          <slot name="li-1">
           </slot>
         </li>
         <li>
-          <slot name="child-2">
+          <slot name="li-2">
           </slot>
         </li>
         <li>
-          <slot name="child-3">
+          <slot name="li-3">
           </slot>
         </li>
       </ul>

--- a/src/components/menu/menu/__snapshots__/menu.spec.snap.js
+++ b/src/components/menu/menu/__snapshots__/menu.spec.snap.js
@@ -4,7 +4,7 @@ export const snapshots = {};
 snapshots["sbb-menu renders"] = 
 `<sbb-menu
   data-state="closed"
-  id="sbb-menu-1"
+  id="sbb-menu-0"
   trigger="menu-trigger"
 >
   <sbb-link
@@ -60,19 +60,19 @@ snapshots["sbb-menu renders with list"] =
     <div class="sbb-menu__content">
       <ul class="sbb-menu-list">
         <li>
-          <slot name="action-0">
+          <slot name="child-0">
           </slot>
         </li>
         <li>
-          <slot name="action-1">
+          <slot name="child-1">
           </slot>
         </li>
         <li>
-          <slot name="action-2">
+          <slot name="child-2">
           </slot>
         </li>
         <li>
-          <slot name="action-3">
+          <slot name="child-3">
           </slot>
         </li>
       </ul>

--- a/src/components/menu/menu/menu.spec.ts
+++ b/src/components/menu/menu/menu.spec.ts
@@ -51,16 +51,16 @@ describe('sbb-menu', () => {
       `
     <sbb-menu data-state="closed" id="sbb-menu-1" trigger="menu-trigger">
 
-      <sbb-menu-action dir="ltr" icon="tick-small" role="button" slot="child-0" tabindex="0">
+      <sbb-menu-action dir="ltr" icon="tick-small" role="button" slot="li-0" tabindex="0">
         View
       </sbb-menu-action>
-      <sbb-menu-action aria-disabled="true" dir="ltr" amount="1" disabled icon="pen-small" role="button" slot="child-1">
+      <sbb-menu-action aria-disabled="true" dir="ltr" amount="1" disabled icon="pen-small" role="button" slot="li-1">
         Edit
       </sbb-menu-action>
-      <sbb-menu-action dir="ltr" amount="2" icon="swisspass-small" role="button" slot="child-2" tabindex="0">
+      <sbb-menu-action dir="ltr" amount="2" icon="swisspass-small" role="button" slot="li-2" tabindex="0">
         Details
       </sbb-menu-action>
-      <sbb-menu-action dir="ltr" icon="cross-small" role="button" slot="child-3" tabindex="0">
+      <sbb-menu-action dir="ltr" icon="cross-small" role="button" slot="li-3" tabindex="0">
         Cancel
       </sbb-menu-action>
     </sbb-menu>

--- a/src/components/menu/menu/menu.spec.ts
+++ b/src/components/menu/menu/menu.spec.ts
@@ -49,18 +49,18 @@ describe('sbb-menu', () => {
 
     expect(menu).dom.to.be.equal(
       `
-    <sbb-menu data-state="closed" id="sbb-menu-2" trigger="menu-trigger">
+    <sbb-menu data-state="closed" id="sbb-menu-1" trigger="menu-trigger">
 
-      <sbb-menu-action dir="ltr" icon="tick-small" role="button" slot="action-0" tabindex="0">
+      <sbb-menu-action dir="ltr" icon="tick-small" role="button" slot="child-0" tabindex="0">
         View
       </sbb-menu-action>
-      <sbb-menu-action aria-disabled="true" dir="ltr" amount="1" disabled icon="pen-small" role="button" slot="action-1">
+      <sbb-menu-action aria-disabled="true" dir="ltr" amount="1" disabled icon="pen-small" role="button" slot="child-1">
         Edit
       </sbb-menu-action>
-      <sbb-menu-action dir="ltr" amount="2" icon="swisspass-small" role="button" slot="action-2" tabindex="0">
+      <sbb-menu-action dir="ltr" amount="2" icon="swisspass-small" role="button" slot="child-2" tabindex="0">
         Details
       </sbb-menu-action>
-      <sbb-menu-action dir="ltr" icon="cross-small" role="button" slot="action-3" tabindex="0">
+      <sbb-menu-action dir="ltr" icon="cross-small" role="button" slot="child-3" tabindex="0">
         Cancel
       </sbb-menu-action>
     </sbb-menu>

--- a/src/components/menu/menu/menu.ts
+++ b/src/components/menu/menu/menu.ts
@@ -111,12 +111,6 @@ export class SbbMenuElement extends NamedSlotListElement<SbbMenuActionElement> {
   private _focusHandler = new FocusHandler();
   private _scrollHandler = new ScrollHandler();
 
-  public constructor() {
-    super();
-    /** @ignore id is already a well known property. */
-    this.id = this.id || `sbb-menu-${nextId++}`;
-  }
-
   /**
    * Opens the menu on trigger click.
    */
@@ -253,6 +247,7 @@ export class SbbMenuElement extends NamedSlotListElement<SbbMenuActionElement> {
       return;
     }
 
+    this.id = this.id || `sbb-menu-${nextId++}`;
     setAriaOverlayTriggerAttributes(this._triggerElement, 'menu', this.id, this._state);
     this._menuController?.abort();
     this._menuController = new AbortController();

--- a/src/components/menu/menu/menu.ts
+++ b/src/components/menu/menu/menu.ts
@@ -229,7 +229,7 @@ export class SbbMenuElement extends NamedSlotListElement<SbbMenuActionElement> {
     // If all children are sbb-menu-action instances, we render them as a list.
     if (
       this.children?.length &&
-      Array.from(this.children).every((c) => c.tagName === 'SBB-MENU-ACTION')
+      Array.from(this.children ?? []).every((c) => c.tagName === 'SBB-MENU-ACTION')
     ) {
       super.checkChildren();
     } else if (this.listChildren.length) {
@@ -383,14 +383,7 @@ export class SbbMenuElement extends NamedSlotListElement<SbbMenuActionElement> {
             class="sbb-menu__content"
           >
             ${this.listChildren.length
-              ? html`<ul
-                    class="sbb-menu-list"
-                    aria-label=${this.listAccessibilityLabel ?? nothing}
-                    role=${this.roleOverride()}
-                  >
-                    ${this.renderListSlots()}
-                  </ul>
-                  ${this.renderHiddenSlot()}`
+              ? this.renderList({ class: 'sbb-menu-list', ariaLabel: this.listAccessibilityLabel })
               : html`<slot></slot>`}
           </div>
         </div>

--- a/src/components/menu/menu/menu.ts
+++ b/src/components/menu/menu/menu.ts
@@ -113,6 +113,7 @@ export class SbbMenuElement extends NamedSlotListElement<SbbMenuActionElement> {
 
   public constructor() {
     super();
+    /** @ignore id is already a well known property. */
     this.id = this.id || `sbb-menu-${nextId++}`;
   }
 

--- a/src/components/menu/menu/menu.ts
+++ b/src/components/menu/menu/menu.ts
@@ -1,5 +1,5 @@
 import type { CSSResultGroup, TemplateResult } from 'lit';
-import { html, nothing } from 'lit';
+import { html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { ref } from 'lit/directives/ref.js';
 

--- a/src/components/navigation/navigation-list/__snapshots__/navigation-list.spec.snap.js
+++ b/src/components/navigation/navigation-list/__snapshots__/navigation-list.spec.snap.js
@@ -13,16 +13,16 @@ snapshots["sbb-navigation-list should render named slots if data-ssr-child-count
   aria-labelledby="sbb-navigation-link-label-id"
   class="sbb-navigation-list__content"
 >
-  <li class="sbb-navigation-list__action">
-    <slot name="action-0">
+  <li>
+    <slot name="child-0">
     </slot>
   </li>
-  <li class="sbb-navigation-list__action">
-    <slot name="action-1">
+  <li>
+    <slot name="child-1">
     </slot>
   </li>
-  <li class="sbb-navigation-list__action">
-    <slot name="action-2">
+  <li>
+    <slot name="child-2">
     </slot>
   </li>
 </ul>
@@ -45,20 +45,20 @@ snapshots["sbb-navigation-list renders"] =
   aria-labelledby="sbb-navigation-link-label-id"
   class="sbb-navigation-list__content"
 >
-  <li class="sbb-navigation-list__action">
-    <slot name="action-0">
+  <li>
+    <slot name="child-0">
     </slot>
   </li>
-  <li class="sbb-navigation-list__action">
-    <slot name="action-1">
+  <li>
+    <slot name="child-1">
     </slot>
   </li>
-  <li class="sbb-navigation-list__action">
-    <slot name="action-2">
+  <li>
+    <slot name="child-2">
     </slot>
   </li>
-  <li class="sbb-navigation-list__action">
-    <slot name="action-3">
+  <li>
+    <slot name="child-3">
     </slot>
   </li>
 </ul>

--- a/src/components/navigation/navigation-list/__snapshots__/navigation-list.spec.snap.js
+++ b/src/components/navigation/navigation-list/__snapshots__/navigation-list.spec.snap.js
@@ -14,15 +14,15 @@ snapshots["sbb-navigation-list should render named slots if data-ssr-child-count
   class="sbb-navigation-list__content"
 >
   <li>
-    <slot name="child-0">
+    <slot name="li-0">
     </slot>
   </li>
   <li>
-    <slot name="child-1">
+    <slot name="li-1">
     </slot>
   </li>
   <li>
-    <slot name="child-2">
+    <slot name="li-2">
     </slot>
   </li>
 </ul>
@@ -46,19 +46,19 @@ snapshots["sbb-navigation-list renders"] =
   class="sbb-navigation-list__content"
 >
   <li>
-    <slot name="child-0">
+    <slot name="li-0">
     </slot>
   </li>
   <li>
-    <slot name="child-1">
+    <slot name="li-1">
     </slot>
   </li>
   <li>
-    <slot name="child-2">
+    <slot name="li-2">
     </slot>
   </li>
   <li>
-    <slot name="child-3">
+    <slot name="li-3">
     </slot>
   </li>
 </ul>

--- a/src/components/navigation/navigation-list/navigation-list.e2e.ts
+++ b/src/components/navigation/navigation-list/navigation-list.e2e.ts
@@ -23,8 +23,8 @@ describe('sbb-navigation-list', () => {
     const list = element.shadowRoot!.querySelector('ul')!;
     expect(list.className).to.be.equal('sbb-navigation-list__content');
 
-    const listItem = list.querySelector('li');
-    expect(listItem).to.have.class('sbb-navigation-list__action');
+    const listItems = list.querySelectorAll('li');
+    expect(listItems.length).to.equal(1);
   });
 
   it('force size on children elements', () => {

--- a/src/components/navigation/navigation-list/navigation-list.spec.ts
+++ b/src/components/navigation/navigation-list/navigation-list.spec.ts
@@ -15,17 +15,17 @@ describe('sbb-navigation-list', () => {
 
     expect(root).dom.to.be.equal(
       `
-        <sbb-navigation-list data-slot-names="child-0 child-1 child-2 child-3">
-          <sbb-navigation-action slot="child-0">
+        <sbb-navigation-list data-slot-names="li-0 li-1 li-2 li-3">
+          <sbb-navigation-action slot="li-0">
             Tickets &amp; Offers
           </sbb-navigation-action>
-          <sbb-navigation-action slot="child-1">
+          <sbb-navigation-action slot="li-1">
             Vacations &amp; Recreation
           </sbb-navigation-action>
-          <sbb-navigation-action slot="child-2">
+          <sbb-navigation-action slot="li-2">
             Travel information
           </sbb-navigation-action>
-          <sbb-navigation-action slot="child-3">
+          <sbb-navigation-action slot="li-3">
             Help &amp; Contact
           </sbb-navigation-action>
         </sbb-navigation-list>

--- a/src/components/navigation/navigation-list/navigation-list.spec.ts
+++ b/src/components/navigation/navigation-list/navigation-list.spec.ts
@@ -15,17 +15,17 @@ describe('sbb-navigation-list', () => {
 
     expect(root).dom.to.be.equal(
       `
-        <sbb-navigation-list data-slot-names="action-0 action-1 action-2 action-3">
-          <sbb-navigation-action slot="action-0">
+        <sbb-navigation-list data-slot-names="child-0 child-1 child-2 child-3">
+          <sbb-navigation-action slot="child-0">
             Tickets &amp; Offers
           </sbb-navigation-action>
-          <sbb-navigation-action slot="action-1">
+          <sbb-navigation-action slot="child-1">
             Vacations &amp; Recreation
           </sbb-navigation-action>
-          <sbb-navigation-action slot="action-2">
+          <sbb-navigation-action slot="child-2">
             Travel information
           </sbb-navigation-action>
-          <sbb-navigation-action slot="action-3">
+          <sbb-navigation-action slot="child-3">
             Help &amp; Contact
           </sbb-navigation-action>
         </sbb-navigation-list>

--- a/src/components/navigation/navigation-list/navigation-list.ts
+++ b/src/components/navigation/navigation-list/navigation-list.ts
@@ -37,14 +37,10 @@ export class SbbNavigationListElement extends NamedSlotListElement<SbbNavigation
       <span class="sbb-navigation-list__label" id="sbb-navigation-link-label-id">
         <slot name="label">${this.label}</slot>
       </span>
-      <ul
-        class="sbb-navigation-list__content"
-        aria-labelledby="sbb-navigation-link-label-id"
-        role=${this.roleOverride()}
-      >
-        ${this.renderListSlots()}
-      </ul>
-      ${this.renderHiddenSlot()}
+      ${this.renderList({
+        class: 'sbb-navigation-list__content',
+        ariaLabelledby: 'sbb-navigation-link-label-id',
+      })}
     `;
   }
 }

--- a/src/components/navigation/navigation-list/navigation-list.ts
+++ b/src/components/navigation/navigation-list/navigation-list.ts
@@ -1,8 +1,12 @@
-import type { CSSResultGroup, TemplateResult } from 'lit';
+import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import { html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { NamedSlotListElement, NamedSlotStateController } from '../../core/common-behaviors';
+import {
+  NamedSlotListElement,
+  NamedSlotStateController,
+  type WithListChildren,
+} from '../../core/common-behaviors';
 import type { SbbNavigationActionElement } from '../navigation-action';
 
 import style from './navigation-list.scss?lit&inline';
@@ -28,8 +32,11 @@ export class SbbNavigationListElement extends NamedSlotListElement<SbbNavigation
     new NamedSlotStateController(this);
   }
 
-  protected override formatChild(child: SbbNavigationActionElement): void {
-    child.size = 'm';
+  protected override willUpdate(changedProperties: PropertyValues<WithListChildren<this>>): void {
+    super.willUpdate(changedProperties);
+    if (changedProperties.has('listChildren')) {
+      this.listChildren.forEach((c) => (c.size = 'm'));
+    }
   }
 
   protected override render(): TemplateResult {

--- a/src/components/navigation/navigation-marker/navigation-marker.e2e.ts
+++ b/src/components/navigation/navigation-marker/navigation-marker.e2e.ts
@@ -46,8 +46,8 @@ describe('sbb-navigation-marker', () => {
     const list = element.shadowRoot!.querySelector('ul')!;
     expect(list.className).to.be.equal('sbb-navigation-marker');
 
-    const listItem = list.querySelector('li');
-    expect(listItem).to.have.class('sbb-navigation-marker__action');
+    const listItems = list.querySelectorAll('li');
+    expect(listItems.length).to.equal(4);
   });
 
   it('force size on children elements', () => {

--- a/src/components/navigation/navigation-marker/navigation-marker.spec.ts
+++ b/src/components/navigation/navigation-marker/navigation-marker.spec.ts
@@ -9,7 +9,7 @@ describe('sbb-navigation-marker', () => {
     expect(root).dom.to.be.equal(`<sbb-navigation-marker size="l"></sbb-navigation-marker>`);
     expect(root).shadowDom.to.be.equal(
       `
-        <ul class="sbb-navigation-marker"></ul>
+        <ul class="sbb-navigation-marker" role="presentation"></ul>
         <span hidden="">
           <slot></slot>
         </span>

--- a/src/components/navigation/navigation-marker/navigation-marker.ts
+++ b/src/components/navigation/navigation-marker/navigation-marker.ts
@@ -23,17 +23,14 @@ export class SbbNavigationMarkerElement extends NamedSlotListElement<SbbNavigati
    */
   @property({ reflect: true }) public size?: 'l' | 's' = 'l';
 
-  /**
-   * Whether the list has an active action.
-   */
-  @state() private _hasActiveAction = false;
+  @state() private _currentActiveAction?: SbbNavigationActionElement;
 
-  private _currentActiveAction?: SbbNavigationActionElement;
   private _navigationMarkerResizeObserver = new AgnosticResizeObserver(() =>
     this._setMarkerPosition(),
   );
 
   protected override willUpdate(changedProperties: PropertyValues<WithListChildren<this>>): void {
+    setAttribute(this, 'data-has-active-action', !!this._currentActiveAction);
     if (changedProperties.has('size') || changedProperties.has('listChildren')) {
       this._updateMarkerActions();
     }
@@ -45,7 +42,6 @@ export class SbbNavigationMarkerElement extends NamedSlotListElement<SbbNavigati
     }
 
     this._currentActiveAction = this.listChildren.find((action) => action.active);
-    this._hasActiveAction = !!this._currentActiveAction;
     this._setMarkerPosition();
   }
 
@@ -63,33 +59,29 @@ export class SbbNavigationMarkerElement extends NamedSlotListElement<SbbNavigati
     this.reset();
     action.active = true;
     this._currentActiveAction = action;
-    this._hasActiveAction = true;
     setTimeout(() => this._setMarkerPosition());
   }
 
   public reset(): void {
-    if (!this._hasActiveAction) {
-      return;
-    }
     if (this._currentActiveAction) {
       this._currentActiveAction.active = false;
+      this._currentActiveAction = undefined;
     }
-    this._hasActiveAction = false;
   }
 
   private _setMarkerPosition(): void {
-    if (this._hasActiveAction) {
+    if (this._currentActiveAction) {
       const index = this.listChildren.indexOf(this._currentActiveAction)!;
       this.style?.setProperty(
         '--sbb-navigation-marker-position-y',
-        `${this.shadowRoot.querySelector<HTMLLIElement>(`li:nth-child(${index + 1})`).offsetTop}px`,
+        `${
+          this.shadowRoot!.querySelector<HTMLLIElement>(`li:nth-child(${index + 1})`)!.offsetTop
+        }px`,
       );
     }
   }
 
   protected override render(): TemplateResult {
-    setAttribute(this, 'data-has-active-action', this._hasActiveAction);
-
     return this.renderList();
   }
 }

--- a/src/components/navigation/navigation-marker/navigation-marker.ts
+++ b/src/components/navigation/navigation-marker/navigation-marker.ts
@@ -30,6 +30,7 @@ export class SbbNavigationMarkerElement extends NamedSlotListElement<SbbNavigati
   );
 
   protected override willUpdate(changedProperties: PropertyValues<WithListChildren<this>>): void {
+    super.willUpdate(changedProperties);
     setAttribute(this, 'data-has-active-action', !!this._currentActiveAction);
     if (changedProperties.has('size') || changedProperties.has('listChildren')) {
       this._updateMarkerActions();

--- a/src/components/navigation/navigation-marker/navigation-marker.ts
+++ b/src/components/navigation/navigation-marker/navigation-marker.ts
@@ -2,7 +2,6 @@ import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 import { NamedSlotListElement, type WithListChildren } from '../../core/common-behaviors';
-import { setAttribute } from '../../core/dom';
 import { AgnosticResizeObserver } from '../../core/observers';
 import type { SbbNavigationActionElement } from '../navigation-action';
 
@@ -31,10 +30,10 @@ export class SbbNavigationMarkerElement extends NamedSlotListElement<SbbNavigati
 
   protected override willUpdate(changedProperties: PropertyValues<WithListChildren<this>>): void {
     super.willUpdate(changedProperties);
-    setAttribute(this, 'data-has-active-action', !!this._currentActiveAction);
     if (changedProperties.has('size') || changedProperties.has('listChildren')) {
       this._updateMarkerActions();
     }
+    this.toggleAttribute('data-has-active-action', !!this._currentActiveAction);
   }
 
   private _updateMarkerActions(): void {
@@ -63,6 +62,11 @@ export class SbbNavigationMarkerElement extends NamedSlotListElement<SbbNavigati
     setTimeout(() => this._setMarkerPosition());
   }
 
+  protected override firstUpdated(changedProperties: PropertyValues<WithListChildren<this>>): void {
+    super.firstUpdated(changedProperties);
+    setTimeout(() => this._setMarkerPosition());
+  }
+
   public reset(): void {
     if (this._currentActiveAction) {
       this._currentActiveAction.active = false;
@@ -71,14 +75,16 @@ export class SbbNavigationMarkerElement extends NamedSlotListElement<SbbNavigati
   }
 
   private _setMarkerPosition(): void {
-    if (this._currentActiveAction) {
-      const index = this.listChildren.indexOf(this._currentActiveAction)!;
-      this.style?.setProperty(
-        '--sbb-navigation-marker-position-y',
-        `${
-          this.shadowRoot!.querySelector<HTMLLIElement>(`li:nth-child(${index + 1})`)!.offsetTop
-        }px`,
-      );
+    if (!this._currentActiveAction) {
+      return;
+    }
+
+    const index = this.listChildren.indexOf(this._currentActiveAction)!;
+    const value = this.shadowRoot!.querySelector<HTMLLIElement>(
+      `li:nth-child(${index + 1})`,
+    )?.offsetTop;
+    if (value != null) {
+      this.style?.setProperty('--sbb-navigation-marker-position-y', `${value}px`);
     }
   }
 

--- a/src/components/navigation/navigation-marker/navigation-marker.ts
+++ b/src/components/navigation/navigation-marker/navigation-marker.ts
@@ -1,5 +1,4 @@
 import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
-import { html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 import { NamedSlotListElement } from '../../core/common-behaviors';

--- a/src/components/navigation/navigation-marker/navigation-marker.ts
+++ b/src/components/navigation/navigation-marker/navigation-marker.ts
@@ -98,12 +98,7 @@ export class SbbNavigationMarkerElement extends NamedSlotListElement<SbbNavigati
   protected override render(): TemplateResult {
     setAttribute(this, 'data-has-active-action', this._hasActiveAction);
 
-    return html`
-      <ul class="sbb-navigation-marker" role=${this.roleOverride()}>
-        ${this.renderListSlots()}
-      </ul>
-      ${this.renderHiddenSlot()}
-    `;
+    return this.renderList();
   }
 }
 

--- a/src/components/navigation/navigation-marker/navigation-marker.ts
+++ b/src/components/navigation/navigation-marker/navigation-marker.ts
@@ -41,7 +41,9 @@ export class SbbNavigationMarkerElement extends NamedSlotListElement<SbbNavigati
       action.size = this.size;
     }
 
-    this._currentActiveAction = this.listChildren.find((action) => action.active);
+    this._currentActiveAction = this.listChildren.find(
+      (action) => action.active ?? action.getAttribute('active'),
+    );
     this._setMarkerPosition();
   }
 

--- a/src/components/option/optgroup/optgroup.ts
+++ b/src/components/option/optgroup/optgroup.ts
@@ -64,6 +64,7 @@ export class SbbOptGroupElement extends SlotChildObserver(LitElement) {
   }
 
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
+    super.willUpdate(changedProperties);
     if (changedProperties.has('disabled')) {
       this._proxyDisabledToOptions();
     }

--- a/src/components/skiplink-list/__snapshots__/skiplink-list.spec.snap.js
+++ b/src/components/skiplink-list/__snapshots__/skiplink-list.spec.snap.js
@@ -21,15 +21,15 @@ snapshots["sbb-skiplink-list should render named slots if data-ssr-child-count a
     class="sbb-skiplink-list"
   >
     <li>
-      <slot name="link-0">
+      <slot name="child-0">
       </slot>
     </li>
     <li>
-      <slot name="link-1">
+      <slot name="child-1">
       </slot>
     </li>
     <li>
-      <slot name="link-2">
+      <slot name="child-2">
       </slot>
     </li>
   </ul>
@@ -61,15 +61,15 @@ snapshots["sbb-skiplink-list renders"] =
     class="sbb-skiplink-list"
   >
     <li>
-      <slot name="link-0">
+      <slot name="child-0">
       </slot>
     </li>
     <li>
-      <slot name="link-1">
+      <slot name="child-1">
       </slot>
     </li>
     <li>
-      <slot name="link-2">
+      <slot name="child-2">
       </slot>
     </li>
   </ul>
@@ -102,15 +102,15 @@ snapshots["sbb-skiplink-list renders with title"] =
     class="sbb-skiplink-list"
   >
     <li>
-      <slot name="link-0">
+      <slot name="child-0">
       </slot>
     </li>
     <li>
-      <slot name="link-1">
+      <slot name="child-1">
       </slot>
     </li>
     <li>
-      <slot name="link-2">
+      <slot name="child-2">
       </slot>
     </li>
   </ul>

--- a/src/components/skiplink-list/__snapshots__/skiplink-list.spec.snap.js
+++ b/src/components/skiplink-list/__snapshots__/skiplink-list.spec.snap.js
@@ -21,15 +21,15 @@ snapshots["sbb-skiplink-list should render named slots if data-ssr-child-count a
     class="sbb-skiplink-list"
   >
     <li>
-      <slot name="child-0">
+      <slot name="li-0">
       </slot>
     </li>
     <li>
-      <slot name="child-1">
+      <slot name="li-1">
       </slot>
     </li>
     <li>
-      <slot name="child-2">
+      <slot name="li-2">
       </slot>
     </li>
   </ul>
@@ -61,15 +61,15 @@ snapshots["sbb-skiplink-list renders"] =
     class="sbb-skiplink-list"
   >
     <li>
-      <slot name="child-0">
+      <slot name="li-0">
       </slot>
     </li>
     <li>
-      <slot name="child-1">
+      <slot name="li-1">
       </slot>
     </li>
     <li>
-      <slot name="child-2">
+      <slot name="li-2">
       </slot>
     </li>
   </ul>
@@ -102,15 +102,15 @@ snapshots["sbb-skiplink-list renders with title"] =
     class="sbb-skiplink-list"
   >
     <li>
-      <slot name="child-0">
+      <slot name="li-0">
       </slot>
     </li>
     <li>
-      <slot name="child-1">
+      <slot name="li-1">
       </slot>
     </li>
     <li>
-      <slot name="child-2">
+      <slot name="li-2">
       </slot>
     </li>
   </ul>

--- a/src/components/skiplink-list/skiplink-list.e2e.ts
+++ b/src/components/skiplink-list/skiplink-list.e2e.ts
@@ -33,12 +33,12 @@ describe('sbb-skiplink-list', () => {
     expect(listItemLinks[0]).to.have.style('height', '0px');
     expect(listItemLinks[0]).to.have.style('overflow', 'hidden');
 
-    const firstLink = element.querySelector<SbbLinkElement>('#sbb-skiplink-list-link-0')!;
+    const firstLink: SbbLinkElement = element.querySelector('sbb-link:nth-child(1)')!;
     firstLink.focus();
     expect(listItemLinks[0]).not.to.have.style('height', '0px');
     expect(listItemLinks[0]).to.have.style('overflow', 'visible');
 
-    const secondLink = element.querySelector<SbbLinkElement>('#sbb-skiplink-list-link-1')!;
+    const secondLink: SbbLinkElement = element.querySelector('sbb-link:nth-child(2)')!;
     secondLink.focus();
     expect(listItemLinks[0]).to.have.style('height', '0px');
     expect(listItemLinks[0]).to.have.style('overflow', 'hidden');
@@ -55,7 +55,6 @@ describe('sbb-skiplink-list', () => {
 
     await waitForLitRender(element);
 
-    expect(element.querySelector('sbb-link')).to.have.attribute('id');
     expect(element.querySelector('sbb-link')).to.have.attribute('slot');
   });
 });

--- a/src/components/skiplink-list/skiplink-list.spec.ts
+++ b/src/components/skiplink-list/skiplink-list.spec.ts
@@ -16,10 +16,10 @@ describe('sbb-skiplink-list', () => {
 
     expect(root).dom.to.be.equal(
       `
-      <sbb-skiplink-list data-slot-names="link-0 link-1 link-2">
-        <sbb-link dir="ltr" href='#' id="sbb-skiplink-list-link-0" negative="" role="link" size="m" slot="link-0" tabindex="0" variant="block" data-slot-names="unnamed">Link 1</sbb-link>
-        <sbb-link dir="ltr" href='#' id="sbb-skiplink-list-link-1" negative="" role="link" size="m" slot="link-1" tabindex="0" variant="block" data-slot-names="unnamed">Link 2</sbb-link>
-        <sbb-link dir="ltr" href='#' id="sbb-skiplink-list-link-2" negative="" role="link" size="m" slot="link-2" tabindex="0" variant="block" data-slot-names="unnamed">Link 3</sbb-link>
+      <sbb-skiplink-list data-slot-names="child-0 child-1 child-2">
+        <sbb-link dir="ltr" href='#' negative="" role="link" size="m" slot="child-0" tabindex="0" variant="block" data-slot-names="unnamed">Link 1</sbb-link>
+        <sbb-link dir="ltr" href='#' negative="" role="link" size="m" slot="child-1" tabindex="0" variant="block" data-slot-names="unnamed">Link 2</sbb-link>
+        <sbb-link dir="ltr" href='#' negative="" role="link" size="m" slot="child-2" tabindex="0" variant="block" data-slot-names="unnamed">Link 3</sbb-link>
       </sbb-skiplink-list>
     `,
     );
@@ -37,10 +37,10 @@ describe('sbb-skiplink-list', () => {
 
     expect(root).dom.to.be.equal(
       `
-      <sbb-skiplink-list title-content="Skip to" title-level="3" data-slot-names="link-0 link-1 link-2">
-        <sbb-link dir="ltr" href='#' id="sbb-skiplink-list-link-0" negative="" role="link" size="m" slot="link-0" tabindex="0" variant="block" data-slot-names="unnamed">Link 1</sbb-link>
-        <sbb-link dir="ltr" href='#' id="sbb-skiplink-list-link-1" negative="" role="link" size="m" slot="link-1" tabindex="0" variant="block" data-slot-names="unnamed">Link 2</sbb-link>
-        <sbb-link dir="ltr" href='#' id="sbb-skiplink-list-link-2" negative="" role="link" size="m" slot="link-2" tabindex="0" variant="block" data-slot-names="unnamed">Link 3</sbb-link>
+      <sbb-skiplink-list title-content="Skip to" title-level="3" data-slot-names="child-0 child-1 child-2">
+        <sbb-link dir="ltr" href='#' negative="" role="link" size="m" slot="child-0" tabindex="0" variant="block" data-slot-names="unnamed">Link 1</sbb-link>
+        <sbb-link dir="ltr" href='#' negative="" role="link" size="m" slot="child-1" tabindex="0" variant="block" data-slot-names="unnamed">Link 2</sbb-link>
+        <sbb-link dir="ltr" href='#' negative="" role="link" size="m" slot="child-2" tabindex="0" variant="block" data-slot-names="unnamed">Link 3</sbb-link>
       </sbb-skiplink-list>
     `,
     );

--- a/src/components/skiplink-list/skiplink-list.spec.ts
+++ b/src/components/skiplink-list/skiplink-list.spec.ts
@@ -16,10 +16,10 @@ describe('sbb-skiplink-list', () => {
 
     expect(root).dom.to.be.equal(
       `
-      <sbb-skiplink-list data-slot-names="child-0 child-1 child-2">
-        <sbb-link dir="ltr" href='#' negative="" role="link" size="m" slot="child-0" tabindex="0" variant="block" data-slot-names="unnamed">Link 1</sbb-link>
-        <sbb-link dir="ltr" href='#' negative="" role="link" size="m" slot="child-1" tabindex="0" variant="block" data-slot-names="unnamed">Link 2</sbb-link>
-        <sbb-link dir="ltr" href='#' negative="" role="link" size="m" slot="child-2" tabindex="0" variant="block" data-slot-names="unnamed">Link 3</sbb-link>
+      <sbb-skiplink-list data-slot-names="li-0 li-1 li-2">
+        <sbb-link dir="ltr" href='#' negative="" role="link" size="m" slot="li-0" tabindex="0" variant="block" data-slot-names="unnamed">Link 1</sbb-link>
+        <sbb-link dir="ltr" href='#' negative="" role="link" size="m" slot="li-1" tabindex="0" variant="block" data-slot-names="unnamed">Link 2</sbb-link>
+        <sbb-link dir="ltr" href='#' negative="" role="link" size="m" slot="li-2" tabindex="0" variant="block" data-slot-names="unnamed">Link 3</sbb-link>
       </sbb-skiplink-list>
     `,
     );
@@ -37,10 +37,10 @@ describe('sbb-skiplink-list', () => {
 
     expect(root).dom.to.be.equal(
       `
-      <sbb-skiplink-list title-content="Skip to" title-level="3" data-slot-names="child-0 child-1 child-2">
-        <sbb-link dir="ltr" href='#' negative="" role="link" size="m" slot="child-0" tabindex="0" variant="block" data-slot-names="unnamed">Link 1</sbb-link>
-        <sbb-link dir="ltr" href='#' negative="" role="link" size="m" slot="child-1" tabindex="0" variant="block" data-slot-names="unnamed">Link 2</sbb-link>
-        <sbb-link dir="ltr" href='#' negative="" role="link" size="m" slot="child-2" tabindex="0" variant="block" data-slot-names="unnamed">Link 3</sbb-link>
+      <sbb-skiplink-list title-content="Skip to" title-level="3" data-slot-names="li-0 li-1 li-2">
+        <sbb-link dir="ltr" href='#' negative="" role="link" size="m" slot="li-0" tabindex="0" variant="block" data-slot-names="unnamed">Link 1</sbb-link>
+        <sbb-link dir="ltr" href='#' negative="" role="link" size="m" slot="li-1" tabindex="0" variant="block" data-slot-names="unnamed">Link 2</sbb-link>
+        <sbb-link dir="ltr" href='#' negative="" role="link" size="m" slot="li-2" tabindex="0" variant="block" data-slot-names="unnamed">Link 3</sbb-link>
       </sbb-skiplink-list>
     `,
     );

--- a/src/components/skiplink-list/skiplink-list.ts
+++ b/src/components/skiplink-list/skiplink-list.ts
@@ -1,8 +1,12 @@
-import type { CSSResultGroup, TemplateResult } from 'lit';
+import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import { html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { NamedSlotListElement, NamedSlotStateController } from '../core/common-behaviors';
+import {
+  NamedSlotListElement,
+  NamedSlotStateController,
+  type WithListChildren,
+} from '../core/common-behaviors';
 import type { SbbLinkElement } from '../link';
 import type { TitleLevel } from '../title';
 
@@ -31,9 +35,14 @@ export class SbbSkiplinkListElement extends NamedSlotListElement<SbbLinkElement>
     new NamedSlotStateController(this);
   }
 
-  protected override formatChild(child: SbbLinkElement): void {
-    child.size = 'm';
-    child.negative = true;
+  protected override willUpdate(changedProperties: PropertyValues<WithListChildren<this>>): void {
+    super.willUpdate(changedProperties);
+    if (changedProperties.has('listChildren')) {
+      for (const child of this.listChildren) {
+        child.size = 'm';
+        child.negative = true;
+      }
+    }
   }
 
   protected override render(): TemplateResult {

--- a/src/components/skiplink-list/skiplink-list.ts
+++ b/src/components/skiplink-list/skiplink-list.ts
@@ -1,5 +1,5 @@
 import type { CSSResultGroup, TemplateResult } from 'lit';
-import { html } from 'lit';
+import { html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { NamedSlotListElement, NamedSlotStateController } from '../core/common-behaviors';

--- a/src/components/skiplink-list/skiplink-list.ts
+++ b/src/components/skiplink-list/skiplink-list.ts
@@ -49,14 +49,7 @@ export class SbbSkiplinkListElement extends NamedSlotListElement<SbbLinkElement>
         >
           <slot name="title">${this.titleContent}</slot>
         </sbb-title>
-        <ul
-          class="sbb-skiplink-list"
-          aria-labelledby="sbb-skiplink-list-title-id"
-          role=${this.roleOverride()}
-        >
-          ${this.renderListSlots()}
-        </ul>
-        ${this.renderHiddenSlot()}
+        ${this.renderList({ ariaLabelledby: 'sbb-skiplink-list-title-id' })}
       </div>
     `;
   }

--- a/src/components/tag/tag-group/tag-group.scss
+++ b/src/components/tag/tag-group/tag-group.scss
@@ -12,7 +12,9 @@
   gap: var(--sbb-spacing-fixed-3x);
 }
 
-.sbb-tag-group__list-item {
+// Using ... li selector, because the li generation
+// is handled in the component base class.
+.sbb-tag-group__list li {
   display: flex;
   max-width: 100%;
 }

--- a/src/components/tag/tag-group/tag-group.spec.ts
+++ b/src/components/tag/tag-group/tag-group.spec.ts
@@ -16,14 +16,14 @@ describe('sbb-tag-group', () => {
     expect(root).dom.to.be.equal(
       `
         <sbb-tag-group role="group">
-          <sbb-tag slot="tag-0" value="tag-1">
+          <sbb-tag slot="child-0" value="tag-1">
             First tag
           </sbb-tag>
-          <sbb-tag slot="tag-1" value="tag-2">
+          <sbb-tag slot="child-1" value="tag-2">
             Second tag
           </sbb-tag>
-          <div slot="tag-2"></div>
-          <sbb-tag slot="tag-3" value="tag-3">
+          <div slot="child-2"></div>
+          <sbb-tag slot="child-3" value="tag-3">
             Third tag
           </sbb-tag>
         </sbb-tag-group>
@@ -33,17 +33,17 @@ describe('sbb-tag-group', () => {
       `
         <div class="sbb-tag-group">
           <ul class="sbb-tag-group__list">
-            <li class="sbb-tag-group__list-item">
-              <slot name="tag-0"></slot>
+            <li>
+              <slot name="child-0"></slot>
             </li>
-            <li class="sbb-tag-group__list-item">
-              <slot name="tag-1"></slot>
+            <li>
+              <slot name="child-1"></slot>
             </li>
-            <li class="sbb-tag-group__list-item">
-              <slot name="tag-2"></slot>
+            <li>
+              <slot name="child-2"></slot>
             </li>
-            <li class="sbb-tag-group__list-item">
-              <slot name="tag-3"></slot>
+            <li>
+              <slot name="child-3"></slot>
             </li>
           </ul>
           <span hidden="">

--- a/src/components/tag/tag-group/tag-group.spec.ts
+++ b/src/components/tag/tag-group/tag-group.spec.ts
@@ -16,14 +16,14 @@ describe('sbb-tag-group', () => {
     expect(root).dom.to.be.equal(
       `
         <sbb-tag-group role="group">
-          <sbb-tag slot="child-0" value="tag-1">
+          <sbb-tag slot="li-0" value="tag-1">
             First tag
           </sbb-tag>
-          <sbb-tag slot="child-1" value="tag-2">
+          <sbb-tag slot="li-1" value="tag-2">
             Second tag
           </sbb-tag>
-          <div slot="child-2"></div>
-          <sbb-tag slot="child-3" value="tag-3">
+          <div slot="li-2"></div>
+          <sbb-tag slot="li-3" value="tag-3">
             Third tag
           </sbb-tag>
         </sbb-tag-group>
@@ -34,16 +34,16 @@ describe('sbb-tag-group', () => {
         <div class="sbb-tag-group">
           <ul class="sbb-tag-group__list">
             <li>
-              <slot name="child-0"></slot>
+              <slot name="li-0"></slot>
             </li>
             <li>
-              <slot name="child-1"></slot>
+              <slot name="li-1"></slot>
             </li>
             <li>
-              <slot name="child-2"></slot>
+              <slot name="li-2"></slot>
             </li>
             <li>
-              <slot name="child-3"></slot>
+              <slot name="li-3"></slot>
             </li>
           </ul>
           <span hidden="">

--- a/src/components/tag/tag-group/tag-group.ts
+++ b/src/components/tag/tag-group/tag-group.ts
@@ -1,8 +1,9 @@
-import type { CSSResultGroup, TemplateResult } from 'lit';
-import { html, LitElement, nothing } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import type { CSSResultGroup, TemplateResult, PropertyValueMap } from 'lit';
+import { html, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 
-import { SlotChildObserver } from '../../core/common-behaviors';
+import type { WithListChildren } from '../../core/common-behaviors';
+import { NamedSlotListElement } from '../../core/common-behaviors';
 import { setAttribute } from '../../core/dom';
 import { ConnectedAbortController } from '../../core/eventing';
 import type { SbbStateChange } from '../../core/interfaces';
@@ -16,8 +17,10 @@ import style from './tag-group.scss?lit&inline';
  * @slot - Use the unnamed slot to add one or more 'sbb-tag' elements to the `sbb-tag-group`.
  */
 @customElement('sbb-tag-group')
-export class SbbTagGroupElement extends SlotChildObserver(LitElement) {
+export class SbbTagGroupElement extends NamedSlotListElement<SbbTagElement> {
   public static override styles: CSSResultGroup = style;
+  // DIV is added here due to special requirements from sbb.ch.
+  protected override readonly listChildTagNames = ['SBB-TAG', 'DIV'];
 
   /**
    * This will be forwarded as aria-label to the inner list.
@@ -48,12 +51,6 @@ export class SbbTagGroupElement extends SlotChildObserver(LitElement) {
   private _value: string | string[] | null = null;
 
   private _abort = new ConnectedAbortController(this);
-
-  /**
-   * We hold the slotted elements in a separate state than the tags itself.
-   * In rare usages, consumers need to slot other elements than tags into the tag group.
-   */
-  @state() private _slottedElements: HTMLElement[] = [];
 
   private _valueChanged(value: string | string[] | null): void {
     if (this._tags.some((tag) => !tag.value)) {
@@ -143,32 +140,26 @@ export class SbbTagGroupElement extends SlotChildObserver(LitElement) {
     return Array.from(this.querySelectorAll?.('sbb-tag') ?? []) as SbbTagElement[];
   }
 
-  protected override checkChildren(): void {
-    this._slottedElements = Array.from(this.children ?? []).filter(
-      (e): e is HTMLElement => e instanceof window.HTMLElement,
-    );
-    this._ensureOnlyOneTagSelected();
-    this._updateValueByReadingTags();
+  protected override willUpdate(changedProperties: PropertyValueMap<WithListChildren<this>>): void {
+    if (changedProperties.has('listChildren')) {
+      this._ensureOnlyOneTagSelected();
+      this._updateValueByReadingTags();
+    }
   }
 
   protected override render(): TemplateResult {
-    this._slottedElements.forEach((tag, index) => tag.setAttribute('slot', `tag-${index}`));
-
     setAttribute(this, 'role', this.listAccessibilityLabel ? '' : 'group');
 
     return html`
       <div class="sbb-tag-group">
-        <ul class="sbb-tag-group__list" aria-label=${this.listAccessibilityLabel ?? nothing}>
-          ${this._slottedElements.map(
-            (_, index) =>
-              html`<li class="sbb-tag-group__list-item">
-                <slot name=${`tag-${index}`}></slot>
-              </li>`,
-          )}
+        <ul
+          class="sbb-tag-group__list"
+          aria-label=${this.listAccessibilityLabel ?? nothing}
+          role=${this.roleOverride()}
+        >
+          ${this.renderListSlots()}
         </ul>
-        <span hidden>
-          <slot></slot>
-        </span>
+        ${this.renderHiddenSlot()}
       </div>
     `;
   }

--- a/src/components/tag/tag-group/tag-group.ts
+++ b/src/components/tag/tag-group/tag-group.ts
@@ -152,14 +152,10 @@ export class SbbTagGroupElement extends NamedSlotListElement<SbbTagElement> {
 
     return html`
       <div class="sbb-tag-group">
-        <ul
-          class="sbb-tag-group__list"
-          aria-label=${this.listAccessibilityLabel ?? nothing}
-          role=${this.roleOverride()}
-        >
-          ${this.renderListSlots()}
-        </ul>
-        ${this.renderHiddenSlot()}
+        ${this.renderList({
+          class: 'sbb-tag-group__list',
+          ariaLabel: this.listAccessibilityLabel,
+        })}
       </div>
     `;
   }

--- a/src/components/tag/tag-group/tag-group.ts
+++ b/src/components/tag/tag-group/tag-group.ts
@@ -1,5 +1,5 @@
 import type { CSSResultGroup, TemplateResult, PropertyValueMap } from 'lit';
-import { html, nothing } from 'lit';
+import { html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import type { WithListChildren } from '../../core/common-behaviors';

--- a/src/components/tag/tag-group/tag-group.ts
+++ b/src/components/tag/tag-group/tag-group.ts
@@ -141,6 +141,7 @@ export class SbbTagGroupElement extends NamedSlotListElement<SbbTagElement> {
   }
 
   protected override willUpdate(changedProperties: PropertyValueMap<WithListChildren<this>>): void {
+    super.willUpdate(changedProperties);
     if (changedProperties.has('listChildren')) {
       this._ensureOnlyOneTagSelected();
       this._updateValueByReadingTags();

--- a/src/components/train/train-formation/__snapshots__/train-formation.spec.snap.js
+++ b/src/components/train/train-formation/__snapshots__/train-formation.spec.snap.js
@@ -28,7 +28,7 @@ snapshots["sbb-train-formation should render with one train"] =
       role="presentation"
     >
       <li>
-        <slot name="child-0">
+        <slot name="li-0">
         </slot>
       </li>
     </ul>
@@ -67,11 +67,11 @@ snapshots["sbb-train-formation should render with multiple trains"] =
       class="sbb-train-formation__train-list"
     >
       <li>
-        <slot name="child-0">
+        <slot name="li-0">
         </slot>
       </li>
       <li>
-        <slot name="child-1">
+        <slot name="li-1">
         </slot>
       </li>
     </ul>

--- a/src/components/train/train-formation/__snapshots__/train-formation.spec.snap.js
+++ b/src/components/train/train-formation/__snapshots__/train-formation.spec.snap.js
@@ -22,7 +22,17 @@ snapshots["sbb-train-formation should render with one train"] =
     </span>
   </div>
   <div class="sbb-train-formation__trains">
-    <span class="sbb-train-formation__single-train">
+    <ul
+      aria-label="Trains"
+      class="sbb-train-formation__train-list"
+      role="presentation"
+    >
+      <li>
+        <slot name="child-0">
+        </slot>
+      </li>
+    </ul>
+    <span hidden="">
       <slot>
       </slot>
     </span>
@@ -56,19 +66,16 @@ snapshots["sbb-train-formation should render with multiple trains"] =
       aria-label="Trains"
       class="sbb-train-formation__train-list"
     >
-      <li class="sbb-train-formation__train-list-item">
-        <slot name="train-0">
+      <li>
+        <slot name="child-0">
         </slot>
       </li>
-      <li class="sbb-train-formation__train-list-item">
-        <slot name="train-1">
+      <li>
+        <slot name="child-1">
         </slot>
       </li>
     </ul>
-    <span
-      class="sbb-train-formation__single-train"
-      hidden=""
-    >
+    <span hidden="">
       <slot>
       </slot>
     </span>

--- a/src/components/train/train-formation/train-formation.scss
+++ b/src/components/train/train-formation/train-formation.scss
@@ -101,14 +101,11 @@
 
 .sbb-train-formation__train-list {
   @include sbb.list-reset;
+
+  display: flex;
+  gap: var(--sbb-train-formation-wagon-gap);
 }
 
 .sbb-train-formation__train-list-item {
   display: inline-flex;
-}
-
-.sbb-train-formation__single-train,
-.sbb-train-formation__train-list {
-  display: flex;
-  gap: var(--sbb-train-formation-wagon-gap);
 }

--- a/src/components/train/train-formation/train-formation.scss
+++ b/src/components/train/train-formation/train-formation.scss
@@ -106,6 +106,8 @@
   gap: var(--sbb-train-formation-wagon-gap);
 }
 
-.sbb-train-formation__train-list-item {
+// Using ... li selector, because the li generation
+// is handled in the component base class.
+.sbb-train-formation__train-list li {
   display: inline-flex;
 }

--- a/src/components/train/train-formation/train-formation.spec.ts
+++ b/src/components/train/train-formation/train-formation.spec.ts
@@ -15,7 +15,7 @@ describe('sbb-train-formation', () => {
     expect(root).dom.to.be.equal(
       `
         <sbb-train-formation>
-          <sbb-train slot="child-0">
+          <sbb-train slot="li-0">
             <sbb-train-wagon></sbb-train-wagon>
           </sbb-train>
         </sbb-train-formation>
@@ -39,10 +39,10 @@ describe('sbb-train-formation', () => {
     expect(root).dom.to.be.equal(
       `
         <sbb-train-formation>
-          <sbb-train slot="child-0">
+          <sbb-train slot="li-0">
             <sbb-train-wagon></sbb-train-wagon>
           </sbb-train>
-          <sbb-train slot="child-1">
+          <sbb-train slot="li-1">
             <sbb-train-wagon></sbb-train-wagon>
           </sbb-train>
         </sbb-train-formation>

--- a/src/components/train/train-formation/train-formation.spec.ts
+++ b/src/components/train/train-formation/train-formation.spec.ts
@@ -15,7 +15,7 @@ describe('sbb-train-formation', () => {
     expect(root).dom.to.be.equal(
       `
         <sbb-train-formation>
-          <sbb-train>
+          <sbb-train slot="child-0">
             <sbb-train-wagon></sbb-train-wagon>
           </sbb-train>
         </sbb-train-formation>
@@ -39,10 +39,10 @@ describe('sbb-train-formation', () => {
     expect(root).dom.to.be.equal(
       `
         <sbb-train-formation>
-          <sbb-train slot="train-0">
+          <sbb-train slot="child-0">
             <sbb-train-wagon></sbb-train-wagon>
           </sbb-train>
-          <sbb-train slot="train-1">
+          <sbb-train slot="child-1">
             <sbb-train-wagon></sbb-train-wagon>
           </sbb-train>
         </sbb-train-formation>

--- a/src/components/train/train-formation/train-formation.stories.ts
+++ b/src/components/train/train-formation/train-formation.stories.ts
@@ -15,7 +15,6 @@ import './train-formation';
 const MountedFormationTemplate = (args: Args): TemplateResult => html`
   <sbb-train-formation ${sbbSpread(args)}>
     <sbb-train
-      directionLabel="This attribute seems to be necessary due to a bug"
       direction-label="Direction of travel"
       station="Bern"
       direction="left"
@@ -125,7 +124,6 @@ const MountedFormationTemplate = (args: Args): TemplateResult => html`
       ></sbb-train-wagon>
     </sbb-train>
     <sbb-train
-      directionLabel="This attribute seems to be necessary due to a bug"
       direction-label="Direction of travel"
       station="Luzern"
       direction="left"
@@ -217,7 +215,6 @@ const MountedFormationTemplate = (args: Args): TemplateResult => html`
 const SingleFormationTemplate = (args: Args): TemplateResult => html`
   <sbb-train-formation ${sbbSpread(args)}>
     <sbb-train
-      directionLabel="This attribute seems to be necessary due to a bug"
       direction-label="Direction of travel"
       station=""
       direction="left"

--- a/src/components/train/train-formation/train-formation.ts
+++ b/src/components/train/train-formation/train-formation.ts
@@ -119,6 +119,7 @@ export class SbbTrainFormationElement extends NamedSlotListElement<SbbTrainEleme
   }
 
   protected override willUpdate(changedProperties: PropertyValueMap<WithListChildren<this>>): void {
+    super.willUpdate(changedProperties);
     if (changedProperties.has('listChildren')) {
       this._readSectors();
     }

--- a/src/components/train/train-formation/train-formation.ts
+++ b/src/components/train/train-formation/train-formation.ts
@@ -104,7 +104,7 @@ export class SbbTrainFormationElement extends NamedSlotListElement<SbbTrainEleme
     );
   }
 
-  private async _updateFormationDiv(el: HTMLDivElement): Promise<void> {
+  private async _updateFormationDiv(el: Element | undefined): Promise<void> {
     if (!el) {
       return;
     }

--- a/src/components/train/train-formation/train-formation.ts
+++ b/src/components/train/train-formation/train-formation.ts
@@ -1,9 +1,10 @@
-import type { CSSResultGroup, TemplateResult } from 'lit';
-import { html, LitElement, nothing } from 'lit';
+import type { CSSResultGroup, PropertyValueMap, TemplateResult } from 'lit';
+import { html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { ref } from 'lit/directives/ref.js';
 
-import { LanguageController, SlotChildObserver } from '../../core/common-behaviors';
+import type { WithListChildren } from '../../core/common-behaviors';
+import { LanguageController, NamedSlotListElement } from '../../core/common-behaviors';
 import { ConnectedAbortController } from '../../core/eventing';
 import { i18nSector, i18nSectorShort, i18nTrains } from '../../core/i18n';
 import { AgnosticResizeObserver } from '../../core/observers';
@@ -25,16 +26,15 @@ interface AggregatedSector {
  * @slot - Use the unnamed slot to add 'sbb-train' elements to the `sbb-train-formation`.
  */
 @customElement('sbb-train-formation')
-export class SbbTrainFormationElement extends SlotChildObserver(LitElement) {
+export class SbbTrainFormationElement extends NamedSlotListElement<SbbTrainElement> {
   public static override styles: CSSResultGroup = style;
+  protected override readonly listChildTagNames = ['SBB-TRAIN'];
 
   /** Option to hide all wagon labels. */
   @property({ attribute: 'hide-wagon-label', reflect: true, type: Boolean }) public hideWagonLabel =
     false;
 
   @state() private _sectors: AggregatedSector[] = [];
-
-  @state() private _trains: SbbTrainElement[] = [];
 
   /** Element that defines the visible content width. */
   private _formationDiv!: HTMLDivElement;
@@ -104,14 +104,7 @@ export class SbbTrainFormationElement extends SlotChildObserver(LitElement) {
     );
   }
 
-  protected override checkChildren(): void {
-    this._readSectors();
-    this._trains = Array.from(this.children ?? []).filter(
-      (e): e is SbbTrainElement => e.tagName === 'SBB-TRAIN',
-    );
-  }
-
-  private async _updateFormationDiv(el?: Element): Promise<void> {
+  private async _updateFormationDiv(el: HTMLDivElement): Promise<void> {
     if (!el) {
       return;
     }
@@ -125,14 +118,13 @@ export class SbbTrainFormationElement extends SlotChildObserver(LitElement) {
     this._applyCssWidth();
   }
 
-  protected override render(): TemplateResult {
-    // We should avoid lists with only one entry
-    if (this._trains?.length > 1) {
-      this._trains.forEach((train, index) => train.setAttribute('slot', `train-${index}`));
-    } else {
-      this._trains?.forEach((train) => train.removeAttribute('slot'));
+  protected override willUpdate(changedProperties: PropertyValueMap<WithListChildren<this>>): void {
+    if (changedProperties.has('listChildren')) {
+      this._readSectors();
     }
+  }
 
+  protected override render(): TemplateResult {
     return html`
       <div class="sbb-train-formation" ${ref(this._updateFormationDiv)}>
         <div class="sbb-train-formation__sectors" aria-hidden="true">
@@ -156,23 +148,14 @@ export class SbbTrainFormationElement extends SlotChildObserver(LitElement) {
         </div>
 
         <div class="sbb-train-formation__trains">
-          ${this._trains?.length > 1
-            ? html`<ul
-                class="sbb-train-formation__train-list"
-                aria-label=${i18nTrains[this._language.current]}
-              >
-                ${this._trains.map(
-                  (_, index) =>
-                    html`<li class="sbb-train-formation__train-list-item">
-                      <slot name=${`train-${index}`}></slot>
-                    </li>`,
-                )}
-              </ul>`
-            : nothing}
-
-          <span class="sbb-train-formation__single-train" ?hidden=${this._trains?.length !== 1}>
-            <slot></slot>
-          </span>
+          <ul
+            class="sbb-train-formation__train-list"
+            aria-label=${i18nTrains[this._language.current]}
+            role=${this.roleOverride()}
+          >
+            ${this.renderListSlots()}
+          </ul>
+          ${this.renderHiddenSlot()}
         </div>
       </div>
     `;

--- a/src/components/train/train-formation/train-formation.ts
+++ b/src/components/train/train-formation/train-formation.ts
@@ -148,14 +148,10 @@ export class SbbTrainFormationElement extends NamedSlotListElement<SbbTrainEleme
         </div>
 
         <div class="sbb-train-formation__trains">
-          <ul
-            class="sbb-train-formation__train-list"
-            aria-label=${i18nTrains[this._language.current]}
-            role=${this.roleOverride()}
-          >
-            ${this.renderListSlots()}
-          </ul>
-          ${this.renderHiddenSlot()}
+          ${this.renderList({
+            class: 'sbb-train-formation__train-list',
+            ariaLabel: i18nTrains[this._language.current],
+          })}
         </div>
       </div>
     `;

--- a/src/components/train/train-wagon/train-wagon.e2e.ts
+++ b/src/components/train/train-wagon/train-wagon.e2e.ts
@@ -31,20 +31,16 @@ describe('sbb-train-wagon', () => {
       </sbb-train-wagon>`,
     );
 
-    expect(
-      Array.from(element.querySelectorAll<SbbIconElement>('sbb-icon')).every((icon) =>
-        icon.getAttribute('slot')!.startsWith('sbb-train-wagon-icon-'),
-      ),
-    ).to.be.true;
+    Array.from(element.querySelectorAll('sbb-icon')).forEach((icon, index) => {
+      expect(icon.getAttribute('slot')).to.equal(`child-${index}`);
+    });
 
     // Remove one icon
     (element.querySelector('sbb-icon') as SbbIconElement).remove();
     await waitForLitRender(element);
 
-    expect(
-      Array.from(element.querySelectorAll('sbb-icon')).every(
-        (icon) => icon.getAttribute('slot') === null,
-      ),
-    ).to.be.true;
+    Array.from(element.querySelectorAll('sbb-icon')).forEach((icon, index) => {
+      expect(icon.getAttribute('slot')).to.equal(`child-${index}`);
+    });
   });
 });

--- a/src/components/train/train-wagon/train-wagon.e2e.ts
+++ b/src/components/train/train-wagon/train-wagon.e2e.ts
@@ -32,7 +32,7 @@ describe('sbb-train-wagon', () => {
     );
 
     Array.from(element.querySelectorAll('sbb-icon')).forEach((icon, index) => {
-      expect(icon.getAttribute('slot')).to.equal(`child-${index}`);
+      expect(icon.getAttribute('slot')).to.equal(`li-${index}`);
     });
 
     // Remove one icon
@@ -40,7 +40,7 @@ describe('sbb-train-wagon', () => {
     await waitForLitRender(element);
 
     Array.from(element.querySelectorAll('sbb-icon')).forEach((icon, index) => {
-      expect(icon.getAttribute('slot')).to.equal(`child-${index}`);
+      expect(icon.getAttribute('slot')).to.equal(`li-${index}`);
     });
   });
 });

--- a/src/components/train/train-wagon/train-wagon.scss
+++ b/src/components/train/train-wagon/train-wagon.scss
@@ -122,7 +122,9 @@
   justify-content: center;
 }
 
-.sbb-train-wagon__icons-item {
+// Using ... li selector, because the li generation
+// is handled in the component base class.
+.sbb-train-wagon__icons-list li {
   display: inline-flex;
 }
 

--- a/src/components/train/train-wagon/train-wagon.spec.ts
+++ b/src/components/train/train-wagon/train-wagon.spec.ts
@@ -124,7 +124,7 @@ describe('sbb-train-wagon', () => {
               data-namespace="default"
               name="sa-rs"
               role="img"
-              slot="child-0"
+              slot="li-0"
             ></sbb-icon>
           </sbb-train-wagon>
         `,
@@ -152,7 +152,7 @@ describe('sbb-train-wagon', () => {
                 role="presentation"
               >
                 <li>
-                  <slot name="child-0">
+                  <slot name="li-0">
                   </slot>
                 </li>
               </ul>
@@ -181,13 +181,13 @@ describe('sbb-train-wagon', () => {
             data-namespace="default"
             name="sa-rs"
             role="img"
-            slot="child-0"></sbb-icon>
+            slot="li-0"></sbb-icon>
           <sbb-icon
             aria-hidden="true"
             data-namespace="default"
             name="sa-rs"
             role="img"
-            slot="child-1"></sbb-icon>
+            slot="li-1"></sbb-icon>
         </sbb-train-wagon>
       `,
       );
@@ -210,10 +210,10 @@ describe('sbb-train-wagon', () => {
             <span class="sbb-train-wagon__icons">
               <ul aria-label="Additional wagon information" class="sbb-train-wagon__icons-list">
                 <li>
-                  <slot name="child-0"></slot>
+                  <slot name="li-0"></slot>
                 </li>
                 <li>
-                  <slot name="child-1"></slot>
+                  <slot name="li-1"></slot>
                 </li>
               </ul>
               <span hidden>

--- a/src/components/train/train-wagon/train-wagon.spec.ts
+++ b/src/components/train/train-wagon/train-wagon.spec.ts
@@ -99,7 +99,11 @@ describe('sbb-train-wagon', () => {
               <li class="sbb-screenreaderonly">No passage to the previous train coach</li>
             </ul>
             <span class="sbb-train-wagon__icons" hidden>
-              <span class="sbb-train-wagon__icons-item" hidden><slot></slot></span>
+              <ul
+                aria-label="Additional wagon information"
+                class="sbb-train-wagon__icons-list"
+                role="presentation"></ul>
+              <span hidden><slot></slot></span>
             </span>
           </div>
         `,
@@ -111,6 +115,7 @@ describe('sbb-train-wagon', () => {
         html`<sbb-train-wagon><sbb-icon name="sa-rs"></sbb-icon></sbb-train-wagon>`,
       );
 
+      await waitForLitRender(root);
       expect(root).dom.to.be.equal(
         `
           <sbb-train-wagon data-has-visible-wagon-content type="wagon">
@@ -119,6 +124,7 @@ describe('sbb-train-wagon', () => {
               data-namespace="default"
               name="sa-rs"
               role="img"
+              slot="child-0"
             ></sbb-icon>
           </sbb-train-wagon>
         `,
@@ -140,8 +146,17 @@ describe('sbb-train-wagon', () => {
               </sbb-timetable-occupancy-icon>
             </ul>
             <span class="sbb-train-wagon__icons">
-              <span class="sbb-train-wagon__icons-item">
-                <span class="sbb-screenreaderonly">Additional wagon information</span>
+              <ul
+                aria-label="Additional wagon information"
+                class="sbb-train-wagon__icons-list"
+                role="presentation"
+              >
+                <li>
+                  <slot name="child-0">
+                  </slot>
+                </li>
+              </ul>
+              <span hidden>
                 <slot></slot>
               </span>
             </span>
@@ -157,6 +172,7 @@ describe('sbb-train-wagon', () => {
         ></sbb-train-wagon>`,
       );
 
+      await waitForLitRender(root);
       expect(root).dom.to.be.equal(
         `
         <sbb-train-wagon data-has-visible-wagon-content type="wagon">
@@ -165,13 +181,13 @@ describe('sbb-train-wagon', () => {
             data-namespace="default"
             name="sa-rs"
             role="img"
-            slot="sbb-train-wagon-icon-0"></sbb-icon>
+            slot="child-0"></sbb-icon>
           <sbb-icon
             aria-hidden="true"
             data-namespace="default"
             name="sa-rs"
             role="img"
-            slot="sbb-train-wagon-icon-1"></sbb-icon>
+            slot="child-1"></sbb-icon>
         </sbb-train-wagon>
       `,
       );
@@ -193,14 +209,14 @@ describe('sbb-train-wagon', () => {
             </ul>
             <span class="sbb-train-wagon__icons">
               <ul aria-label="Additional wagon information" class="sbb-train-wagon__icons-list">
-                <li class="sbb-train-wagon__icons-item">
-                  <slot name="sbb-train-wagon-icon-0"></slot>
+                <li>
+                  <slot name="child-0"></slot>
                 </li>
-                <li class="sbb-train-wagon__icons-item">
-                  <slot name="sbb-train-wagon-icon-1"></slot>
+                <li>
+                  <slot name="child-1"></slot>
                 </li>
               </ul>
-              <span class="sbb-train-wagon__icons-item" hidden>
+              <span hidden>
                 <slot></slot>
               </span>
             </span>

--- a/src/components/train/train-wagon/train-wagon.ts
+++ b/src/components/train/train-wagon/train-wagon.ts
@@ -185,14 +185,10 @@ export class SbbTrainWagonElement extends NamedSlotListElement<SbbIconElement> {
           : nothing}
         ${this.type === 'wagon'
           ? html`<span class="sbb-train-wagon__icons" ?hidden=${this.listChildren.length === 0}>
-              <ul
-                class="sbb-train-wagon__icons-list"
-                aria-label=${i18nAdditionalWagonInformationHeading[this._language.current]}
-                role=${this.roleOverride()}
-              >
-                ${this.renderListSlots()}
-              </ul>
-              ${this.renderHiddenSlot()}
+              ${this.renderList({
+                class: 'sbb-train-wagon__icons-list',
+                ariaLabel: i18nAdditionalWagonInformationHeading[this._language.current],
+              })}
             </span>`
           : nothing}
       </div>

--- a/src/components/train/train/train.spec.ts
+++ b/src/components/train/train/train.spec.ts
@@ -1,5 +1,8 @@
 import { expect, fixture } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
+
+import { waitForLitRender } from '../../core/testing';
+
 import './train';
 import '../../icon';
 
@@ -9,6 +12,7 @@ describe('sbb-train', () => {
       html`<sbb-train direction-label="Driving direction" station="Bern"></sbb-train>`,
     );
 
+    await waitForLitRender(root);
     expect(root).dom.to.be.equal(
       `<sbb-train direction-label="Driving direction" station="Bern" direction="left"></sbb-train>`,
     );
@@ -16,7 +20,7 @@ describe('sbb-train', () => {
       `
       <div class="sbb-train">
         <h6 class="sbb-train__direction-label-sr">Train, Driving direction Bern.</h6>
-        <ul class="sbb-train__wagons" aria-label="Coaches of the train"></ul>
+        <ul class="sbb-train__wagons" aria-label="Coaches of the train" role="presentation"></ul>
         <span hidden>
           <slot></slot>
         </span>

--- a/src/components/train/train/train.ts
+++ b/src/components/train/train/train.ts
@@ -92,14 +92,10 @@ export class SbbTrainElement extends NamedSlotListElement<
         <${unsafeStatic(TITLE_TAG_NAME)} class="sbb-train__direction-label-sr">
           ${this._getDirectionAriaLabel()}
         </${unsafeStatic(TITLE_TAG_NAME)}>
-        <ul 
-          class="sbb-train__wagons"
-          aria-label=${i18nWagonsLabel[this._language.current]} 
-          role=${this.roleOverride()}
-        >
-          ${this.renderListSlots()}
-        </ul>
-        ${this.renderHiddenSlot()}
+        ${this.renderList({
+          class: 'sbb-train__wagons',
+          ariaLabel: i18nWagonsLabel[this._language.current],
+        })}
 
         ${
           this.directionLabel

--- a/src/components/train/train/train.ts
+++ b/src/components/train/train/train.ts
@@ -78,6 +78,7 @@ export class SbbTrainElement extends NamedSlotListElement<
   }
 
   protected override willUpdate(changedProperties: PropertyValueMap<WithListChildren<this>>): void {
+    super.willUpdate(changedProperties);
     if (changedProperties.has('listChildren')) {
       this._trainSlotChange.emit();
     }

--- a/src/components/train/train/train.ts
+++ b/src/components/train/train/train.ts
@@ -1,9 +1,10 @@
-import type { CSSResultGroup, TemplateResult } from 'lit';
-import { LitElement, nothing } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import type { CSSResultGroup, PropertyValueMap, TemplateResult } from 'lit';
+import { nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 import { html, unsafeStatic } from 'lit/static-html.js';
 
-import { LanguageController, SlotChildObserver } from '../../core/common-behaviors';
+import type { WithListChildren } from '../../core/common-behaviors';
+import { LanguageController, NamedSlotListElement } from '../../core/common-behaviors';
 import { EventEmitter } from '../../core/eventing';
 import { i18nTrain, i18nWagonsLabel } from '../../core/i18n';
 import type { TitleLevel } from '../../title';
@@ -20,11 +21,14 @@ import '../../icon';
  * @slot - Use the unnamed slot to add 'sbb-train-wagon' elements to the `sbb-train`.
  */
 @customElement('sbb-train')
-export class SbbTrainElement extends SlotChildObserver(LitElement) {
+export class SbbTrainElement extends NamedSlotListElement<
+  SbbTrainWagonElement | SbbTrainBlockedPassageElement
+> {
   public static override styles: CSSResultGroup = style;
   public static readonly events = {
     trainSlotChange: 'trainSlotChange',
   } as const;
+  protected override readonly listChildTagNames = ['SBB-TRAIN-WAGON', 'SBB-TRAIN-BLOCKED-PASSAGE'];
 
   /** General label for "driving direction". */
   @property({ attribute: 'direction-label' }) public directionLabel!: string;
@@ -40,8 +44,6 @@ export class SbbTrainElement extends SlotChildObserver(LitElement) {
 
   /** Controls the direction indicator to show the arrow left or right. Default is left.  */
   @property({ reflect: true }) public direction: 'left' | 'right' = 'left';
-
-  @state() private _wagons: (SbbTrainBlockedPassageElement | SbbTrainWagonElement)[] = [];
 
   private _language = new LanguageController(this);
 
@@ -75,28 +77,14 @@ export class SbbTrainElement extends SlotChildObserver(LitElement) {
     return `${textParts.join(', ')}.`;
   }
 
-  protected override checkChildren(): void {
-    const wagons = Array.from(this.children ?? []).filter(
-      (e): e is SbbTrainBlockedPassageElement | SbbTrainWagonElement =>
-        e.tagName === 'SBB-TRAIN-WAGON' || e.tagName === 'SBB-TRAIN-BLOCKED-PASSAGE',
-    );
-    // If the slotted sbb-train-wagon and sbb-train-blocked-passage instances have not changed, we can skip syncing and updating
-    // the link reference list.
-    if (
-      this._wagons &&
-      wagons.length === this._wagons.length &&
-      this._wagons.every((e, i) => wagons[i] === e)
-    ) {
-      return;
+  protected override willUpdate(changedProperties: PropertyValueMap<WithListChildren<this>>): void {
+    if (changedProperties.has('listChildren')) {
+      this._trainSlotChange.emit();
     }
-
-    this._trainSlotChange.emit();
-    this._wagons = wagons;
   }
 
   protected override render(): TemplateResult {
     const TITLE_TAG_NAME = `h${this.directionLabelLevel}`;
-    this._wagons.forEach((wagon, index) => wagon.setAttribute('slot', `wagon-${index}`));
 
     /* eslint-disable lit/binding-positions */
     return html`
@@ -104,17 +92,14 @@ export class SbbTrainElement extends SlotChildObserver(LitElement) {
         <${unsafeStatic(TITLE_TAG_NAME)} class="sbb-train__direction-label-sr">
           ${this._getDirectionAriaLabel()}
         </${unsafeStatic(TITLE_TAG_NAME)}>
-        <ul class="sbb-train__wagons" aria-label=${i18nWagonsLabel[this._language.current]}>
-          ${this._wagons.map(
-            (_, index) =>
-              html`<li>
-                <slot name=${`wagon-${index}`}></slot>
-              </li>`,
-          )}
+        <ul 
+          class="sbb-train__wagons"
+          aria-label=${i18nWagonsLabel[this._language.current]} 
+          role=${this.roleOverride()}
+        >
+          ${this.renderListSlots()}
         </ul>
-        <span hidden>
-          <slot></slot>
-        </span>
+        ${this.renderHiddenSlot()}
 
         ${
           this.directionLabel


### PR DESCRIPTION
This PR refactors the list components, by extracting the common functionality into the `NamedSlotListElement` base class.
It also refactors the `SlotChildObserver` to be mostly synchronous, instead of asynchronous.