### PR TITLE
refactor(selection-panel): improved open/close flow and animation

### DIFF
--- a/scripts/chromatic-stories-generator.ts
+++ b/scripts/chromatic-stories-generator.ts
@@ -63,7 +63,7 @@ async function generateChromaticStory(
     return 'no params found';
   }
 
-  const { disableSnapshot, ...chromaticParameters } = parameters?.chromatic ?? {};
+  const { disableSnapshot, fixedHeight, ...chromaticParameters } = parameters?.chromatic ?? {};
   if (!parameters) {
     return 'no params found';
   } else if (disableSnapshot !== undefined) {
@@ -74,14 +74,23 @@ async function generateChromaticStory(
   const relativeImport = basename(storyFile).replace(/\.ts$/, '');
   const chromaticImport = relative(dirname(targetStoryFile), chromaticFile).replace(/\.ts$/, '');
 
+  /**
+   * TODO Document fixedHeight
+   */
+  const fixedHeightStyle = fixedHeight ? `style="min-height: ${fixedHeight}"` : '';
+
   const chromaticConfig = Object.entries(chromaticParameters)
     .map(([key, value]) => `${key}: ${JSON.stringify(value)}, `)
     .join('');
   const storyFileContent = `import type { Meta, StoryObj } from '@storybook/web-components';
 import config, * as stories from './${relativeImport}';
 import { combineStories } from '${chromaticImport}';
+import { html } from 'lit';
 
 const meta: Meta = {
+  decorators: [
+    (story) => html\` <div ${fixedHeightStyle}>\${story()}</div> \`,
+  ],
   parameters: {
     backgrounds: {
       disable: true,

--- a/scripts/chromatic-stories-generator.ts
+++ b/scripts/chromatic-stories-generator.ts
@@ -75,7 +75,19 @@ async function generateChromaticStory(
   const chromaticImport = relative(dirname(targetStoryFile), chromaticFile).replace(/\.ts$/, '');
 
   /**
-   * TODO Document fixedHeight
+   * The `fixedHeight` param forces the height of the snapshot on chromatic.
+   * It might be useful in cases where some content is cut off at the end of a snapshot
+   * The max fixedHeight we can use is 17'000 (17k * 1440 =~ 25kk)
+   * Now, the max snapshot size is 25'000'000px.
+   *
+   * Example:
+   * ```
+   *  ...
+   *  parameters: {
+   *    chromatic: { fixedHeight: '17000px', ... },
+   *    ...
+   *  }
+   * ```
    */
   const fixedHeightStyle = fixedHeight ? `style="min-height: ${fixedHeight}"` : '';
 

--- a/src/components/checkbox/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox/checkbox.ts
@@ -111,7 +111,13 @@ export class SbbCheckboxElement extends UpdateScheduler(LitElement) {
   }
   private _size: SbbCheckboxSize = 'm';
 
-  /** Whether the input is the main input of a selection panel. */
+  /**
+   * Whether the input is the main input of a selection panel.
+   * @internal
+   */
+  public get isSelectionPanelInput(): boolean {
+    return this._isSelectionPanelInput;
+  }
   @state() private _isSelectionPanelInput = false;
 
   /** The label describing whether the selection panel is expanded (for screen readers only). */

--- a/src/components/checkbox/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox/checkbox.ts
@@ -183,7 +183,6 @@ export class SbbCheckboxElement extends UpdateScheduler(LitElement) {
     this.addEventListener('click', (e) => this._handleClick(e), { signal });
     this.addEventListener('keyup', (e) => this._handleKeyup(e), { signal });
     this._handlerRepository.connect();
-    this._checkboxLoaded.emit();
 
     // We need to call requestUpdate to update the reflected attributes
     ['disabled', 'required', 'size'].forEach((p) => this.requestUpdate(p));
@@ -202,6 +201,7 @@ export class SbbCheckboxElement extends UpdateScheduler(LitElement) {
     // We need to wait for the selection-panel to be fully initialized
     this.startUpdate();
     setTimeout(() => {
+      this._checkboxLoaded.emit();
       this._isSelectionPanelInput && this._updateExpandedLabel();
       this.completeUpdate();
     });

--- a/src/components/checkbox/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox/checkbox.ts
@@ -189,6 +189,7 @@ export class SbbCheckboxElement extends UpdateScheduler(LitElement) {
     this.addEventListener('click', (e) => this._handleClick(e), { signal });
     this.addEventListener('keyup', (e) => this._handleKeyup(e), { signal });
     this._handlerRepository.connect();
+    this._checkboxLoaded.emit();
 
     // We need to call requestUpdate to update the reflected attributes
     ['disabled', 'required', 'size'].forEach((p) => this.requestUpdate(p));
@@ -207,7 +208,6 @@ export class SbbCheckboxElement extends UpdateScheduler(LitElement) {
     // We need to wait for the selection-panel to be fully initialized
     this.startUpdate();
     setTimeout(() => {
-      this._checkboxLoaded.emit();
       this._isSelectionPanelInput && this._updateExpandedLabel();
       this.completeUpdate();
     });

--- a/src/components/notification/notification.stories.ts
+++ b/src/components/notification/notification.stories.ts
@@ -237,9 +237,7 @@ const meta: Meta = {
   decorators: [
     (story, context) =>
       html`<div
-        style="padding: 2rem;display: flex;gap: var(--sbb-spacing-fixed-4x);flex-direction: column;${isChromatic()
-          ? 'min-height: 1000px;'
-          : ''}"
+        style="padding: 2rem;display: flex;gap: var(--sbb-spacing-fixed-4x);flex-direction: column;"
       >
         ${trigger(context.args)}
         <div class="notification-container" style="display: flex; flex-direction: column;">
@@ -250,6 +248,7 @@ const meta: Meta = {
     withActions as Decorator,
   ],
   parameters: {
+    chromatic: { fixedHeight: '7500px' },
     actions: {
       handles: [
         SbbNotificationElement.events.didOpen,

--- a/src/components/radio-button/radio-button/radio-button.ts
+++ b/src/components/radio-button/radio-button/radio-button.ts
@@ -115,7 +115,11 @@ export class SbbRadioButtonElement extends UpdateScheduler(LitElement) {
 
   /**
    * Whether the input is the main input of a selection panel.
+   * @internal
    */
+  public get isSelectionPanelInput(): boolean {
+    return this._isSelectionPanelInput;
+  }
   @state() private _isSelectionPanelInput = false;
 
   /**
@@ -150,6 +154,7 @@ export class SbbRadioButtonElement extends UpdateScheduler(LitElement) {
 
   private _handleCheckedChange(currentValue: boolean, previousValue: boolean): void {
     if (currentValue !== previousValue) {
+      console.log('checked change');
       this._stateChange.emit({ type: 'checked', checked: currentValue });
       this._isSelectionPanelInput && this._updateExpandedLabel();
     }

--- a/src/components/radio-button/radio-button/radio-button.ts
+++ b/src/components/radio-button/radio-button/radio-button.ts
@@ -197,7 +197,6 @@ export class SbbRadioButtonElement extends UpdateScheduler(LitElement) {
     this.addEventListener('click', (e) => this._handleClick(e), { signal });
     this.addEventListener('keydown', (e) => this._handleKeyDown(e), { signal });
     this._handlerRepository.connect();
-    this._radioButtonLoaded.emit();
 
     // We need to call requestUpdate to update the reflected attributes
     ['disabled', 'required', 'size'].forEach((p) => this.requestUpdate(p));
@@ -216,6 +215,7 @@ export class SbbRadioButtonElement extends UpdateScheduler(LitElement) {
     // We need to wait for the selection-panel to be fully initialized
     this.startUpdate();
     setTimeout(() => {
+      this._radioButtonLoaded.emit();
       this._isSelectionPanelInput && this._updateExpandedLabel();
       this.completeUpdate();
     });

--- a/src/components/radio-button/radio-button/radio-button.ts
+++ b/src/components/radio-button/radio-button/radio-button.ts
@@ -154,7 +154,6 @@ export class SbbRadioButtonElement extends UpdateScheduler(LitElement) {
 
   private _handleCheckedChange(currentValue: boolean, previousValue: boolean): void {
     if (currentValue !== previousValue) {
-      console.log('checked change');
       this._stateChange.emit({ type: 'checked', checked: currentValue });
       this._isSelectionPanelInput && this._updateExpandedLabel();
     }

--- a/src/components/radio-button/radio-button/radio-button.ts
+++ b/src/components/radio-button/radio-button/radio-button.ts
@@ -201,6 +201,7 @@ export class SbbRadioButtonElement extends UpdateScheduler(LitElement) {
     this.addEventListener('click', (e) => this._handleClick(e), { signal });
     this.addEventListener('keydown', (e) => this._handleKeyDown(e), { signal });
     this._handlerRepository.connect();
+    this._radioButtonLoaded.emit();
 
     // We need to call requestUpdate to update the reflected attributes
     ['disabled', 'required', 'size'].forEach((p) => this.requestUpdate(p));
@@ -219,7 +220,6 @@ export class SbbRadioButtonElement extends UpdateScheduler(LitElement) {
     // We need to wait for the selection-panel to be fully initialized
     this.startUpdate();
     setTimeout(() => {
-      this._radioButtonLoaded.emit();
       this._isSelectionPanelInput && this._updateExpandedLabel();
       this.completeUpdate();
     });

--- a/src/components/selection-panel/readme.md
+++ b/src/components/selection-panel/readme.md
@@ -86,12 +86,12 @@ It's also possible to display the `sbb-selection-panel` without border by settin
 
 ## Events
 
-| Name        | Type                                        | Description                                                       | Inherited From |
-| ----------- | ------------------------------------------- | ----------------------------------------------------------------- | -------------- |
-| `willOpen`  | `CustomEvent<void>`                         | Emits whenever the content section starts the opening transition. |                |
-| `didOpen`   | `CustomEvent<void>`                         | Emits whenever the content section is opened.                     |                |
-| `willClose` | `CustomEvent<{ closeTarget: HTMLElement }>` | Emits whenever the content section begins the closing transition. |                |
-| `didClose`  | `CustomEvent<{ closeTarget: HTMLElement }>` | Emits whenever the content section is closed.                     |                |
+| Name        | Type                | Description                                                       | Inherited From |
+| ----------- | ------------------- | ----------------------------------------------------------------- | -------------- |
+| `willOpen`  | `CustomEvent<void>` | Emits whenever the content section starts the opening transition. |                |
+| `didOpen`   | `CustomEvent<void>` | Emits whenever the content section is opened.                     |                |
+| `willClose` | `CustomEvent<void>` | Emits whenever the content section begins the closing transition. |                |
+| `didClose`  | `CustomEvent<void>` | Emits whenever the content section is closed.                     |                |
 
 ## Slots
 

--- a/src/components/selection-panel/selection-panel.e2e.ts
+++ b/src/components/selection-panel/selection-panel.e2e.ts
@@ -57,7 +57,10 @@ describe('sbb-selection-panel', () => {
     /* eslint-enable lit/binding-positions */
   };
 
-  const forceOpenTest = async (wrapper: SbbRadioButtonGroupElement | SbbCheckboxGroupElement, secondInput: SbbRadioButtonElement | SbbCheckboxElement): Promise<void> => {
+  const forceOpenTest = async (
+    wrapper: SbbRadioButtonGroupElement | SbbCheckboxGroupElement,
+    secondInput: SbbRadioButtonElement | SbbCheckboxElement,
+  ): Promise<void> => {
     elements.forEach((e) => (e.forceOpen = true));
     await waitForLitRender(wrapper);
 
@@ -124,7 +127,8 @@ describe('sbb-selection-panel', () => {
     let secondPanel: SbbSelectionPanelElement;
     let secondInput: SbbRadioButtonElement;
     let disabledInput: SbbRadioButtonElement;
-    let willOpenEventSpy, didOpenEventSpy: EventSpy<Event>;
+    let willOpenEventSpy: EventSpy<Event>;
+    let didOpenEventSpy: EventSpy<Event>;
 
     beforeEach(async () => {
       willOpenEventSpy = new EventSpy(SbbSelectionPanelElement.events.willOpen);
@@ -317,7 +321,10 @@ describe('sbb-selection-panel', () => {
     let nestedElement: SbbRadioButtonGroupElement;
     let panel1: SbbSelectionPanelElement;
     let panel2: SbbSelectionPanelElement;
-    let willOpenEventSpy, didOpenEventSpy, willCloseEventSpy, didCloseEventSpy: EventSpy<Event>;
+    let willOpenEventSpy: EventSpy<Event>;
+    let didOpenEventSpy: EventSpy<Event>;
+    let willCloseEventSpy: EventSpy<Event>;
+    let didCloseEventSpy: EventSpy<Event>;
 
     beforeEach(async () => {
       willOpenEventSpy = new EventSpy(SbbSelectionPanelElement.events.willOpen);
@@ -501,7 +508,10 @@ describe('sbb-selection-panel', () => {
     let secondPanel: SbbSelectionPanelElement;
     let secondInput: SbbCheckboxElement;
     let disabledInput: SbbCheckboxElement;
-    let willOpenEventSpy, didOpenEventSpy, willCloseEventSpy, didCloseEventSpy: EventSpy<Event>;
+    let willOpenEventSpy: EventSpy<Event>;
+    let didOpenEventSpy: EventSpy<Event>;
+    let willCloseEventSpy: EventSpy<Event>;
+    let didCloseEventSpy: EventSpy<Event>;
 
     beforeEach(async () => {
       willOpenEventSpy = new EventSpy(SbbSelectionPanelElement.events.willOpen);

--- a/src/components/selection-panel/selection-panel.scss
+++ b/src/components/selection-panel/selection-panel.scss
@@ -4,6 +4,12 @@
 // travel the shadow boundary are defined through this mixin
 @include sbb.host-component-properties;
 
+// Open/Close animation vars
+$open-anim-rows-from: 0fr;
+$open-anim-rows-to: 1fr;
+$open-anim-opacity-from: 0;
+$open-anim-opacity-to: 1;
+
 :host {
   --sbb-selection-panel-cursor: pointer;
   --sbb-selection-panel-background: var(--sbb-color-white-default);
@@ -15,6 +21,9 @@
     var(--sbb-spacing-responsive-xxs);
   --sbb-selection-panel-content-visibility: hidden;
   --sbb-selection-panel-content-padding-inline: var(--sbb-spacing-responsive-xxs);
+
+  // As the selection panel has always a white/milk background, we have to fix the focus outline color
+  // to default color for cases where the selection panel is used in a negative context.
   --sbb-focus-outline-color: var(--sbb-focus-outline-color-default);
 
   display: contents;
@@ -85,10 +94,15 @@
 .sbb-selection-panel__content--wrapper {
   display: grid;
   visibility: var(--sbb-selection-panel-content-visibility);
-  grid-template-rows: 0fr;
-  opacity: 0;
+  grid-template-rows: #{$open-anim-rows-from};
+  opacity: #{$open-anim-opacity-from};
 
-  :host(:where([data-state='opening'], [data-state='opened'])) & {
+  :host([data-state='opened']) & {
+    grid-template-rows: #{$open-anim-rows-to};
+    opacity: #{$open-anim-opacity-to};
+  }
+
+  :host([data-state='opening']) & {
     animation-name: open, open-opacity;
     animation-fill-mode: forwards;
     animation-duration: var(--sbb-selection-panel-animation-duration);
@@ -96,7 +110,7 @@
     animation-delay: 0s, var(--sbb-selection-panel-animation-duration);
   }
 
-  :host(:where([data-state='closing'])) & {
+  :host([data-state='closing']) & {
     animation-name: close;
     animation-duration: var(--sbb-selection-panel-animation-duration);
     animation-timing-function: var(--sbb-animation-easing);
@@ -133,32 +147,32 @@ sbb-divider {
 
 @keyframes open {
   from {
-    grid-template-rows: 0fr;
+    grid-template-rows: #{$open-anim-rows-from};
   }
 
   to {
-    grid-template-rows: 1fr;
+    grid-template-rows: #{$open-anim-rows-to};
   }
 }
 
 @keyframes open-opacity {
   from {
-    opacity: 0;
+    opacity: #{$open-anim-opacity-from};
   }
 
   to {
-    opacity: 1;
+    opacity: #{$open-anim-opacity-to};
   }
 }
 
 @keyframes close {
   from {
-    grid-template-rows: 1fr;
-    opacity: 1;
+    grid-template-rows: #{$open-anim-rows-to};
+    opacity: #{$open-anim-opacity-to};
   }
 
   to {
-    grid-template-rows: 0fr;
-    opacity: 0;
+    grid-template-rows: #{$open-anim-rows-from};
+    opacity: #{$open-anim-opacity-from};
   }
 }

--- a/src/components/selection-panel/selection-panel.scss
+++ b/src/components/selection-panel/selection-panel.scss
@@ -14,15 +14,7 @@
   --sbb-selection-panel-input-padding: var(--sbb-spacing-responsive-xs)
     var(--sbb-spacing-responsive-xxs);
   --sbb-selection-panel-content-visibility: hidden;
-  --sbb-selection-panel-content-grid-template-rows: 0fr;
-  --sbb-selection-panel-content-opacity: 0;
   --sbb-selection-panel-content-padding-inline: var(--sbb-spacing-responsive-xxs);
-  --sbb-selection-panel-content-transition: grid-template-rows
-      var(--sbb-selection-panel-animation-duration) var(--sbb-animation-easing),
-    opacity var(--sbb-selection-panel-animation-duration) var(--sbb-animation-easing);
-
-  // As the selection panel has always a white/milk background, we have to fix the focus outline color
-  // to default color for cases where the selection panel is used in a negative context.
   --sbb-focus-outline-color: var(--sbb-focus-outline-color-default);
 
   display: contents;
@@ -53,8 +45,7 @@
   --sbb-selection-panel-animation-duration: 0.1ms;
 }
 
-:host([data-slot-names~='content'][force-open]),
-:host([data-slot-names~='content'][data-checked]) {
+:host([data-slot-names~='content']:where([data-state='opening'], [data-state='opened'])) {
   --sbb-selection-panel-input-padding: var(--sbb-spacing-responsive-xs)
     var(--sbb-spacing-responsive-xxs) var(--sbb-spacing-responsive-xxs)
     var(--sbb-spacing-responsive-xxs);
@@ -93,10 +84,23 @@
 
 .sbb-selection-panel__content--wrapper {
   display: grid;
-  grid-template-rows: var(--sbb-selection-panel-content-grid-template-rows);
   visibility: var(--sbb-selection-panel-content-visibility);
-  opacity: var(--sbb-selection-panel-content-opacity);
-  transition: var(--sbb-selection-panel-content-transition);
+  grid-template-rows: 0fr;
+  opacity: 0;
+
+  :host(:where([data-state='opening'], [data-state='opened'])) & {
+    animation-name: open, open-opacity;
+    animation-fill-mode: forwards;
+    animation-duration: var(--sbb-selection-panel-animation-duration);
+    animation-timing-function: var(--sbb-animation-easing);
+    animation-delay: 0s, var(--sbb-selection-panel-animation-duration);
+  }
+
+  :host(:where([data-state='closing'])) & {
+    animation-name: close;
+    animation-duration: var(--sbb-selection-panel-animation-duration);
+    animation-timing-function: var(--sbb-animation-easing);
+  }
 
   :host(:not([data-slot-names~='content'])) & {
     display: none;
@@ -124,5 +128,37 @@ sbb-divider {
     duration: var(--sbb-selection-panel-animation-duration);
     timing-function: var(--sbb-animation-easing);
     property: padding;
+  }
+}
+
+@keyframes open {
+  from {
+    grid-template-rows: 0fr;
+  }
+
+  to {
+    grid-template-rows: 1fr;
+  }
+}
+
+@keyframes open-opacity {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes close {
+  from {
+    grid-template-rows: 1fr;
+    opacity: 1;
+  }
+
+  to {
+    grid-template-rows: 0fr;
+    opacity: 0;
   }
 }

--- a/src/components/selection-panel/selection-panel.stories.ts
+++ b/src/components/selection-panel/selection-panel.stories.ts
@@ -433,6 +433,7 @@ const WithRadiosErrorMessageTemplate = ({
       horizontal-from="large"
       allow-empty-selection
       id="sbb-radio-group"
+      style="${isChromatic() ? 'min-height: 800px;' : nothing}"
       @change=${(event: CustomEvent<SbbRadioButtonGroupEventDetail>) => {
         if (event.detail.value) {
           sbbFormError.remove();
@@ -494,7 +495,11 @@ const WithNoContentGroupTemplate = ({
   disabledInput,
   ...args
 }: Args): TemplateResult => html`
-  <sbb-radio-button-group orientation="vertical" horizontal-from="large">
+  <sbb-radio-button-group
+    orientation="vertical"
+    horizontal-from="large"
+    style="${isChromatic() ? 'min-height: 500px;' : nothing}"
+  >
     <sbb-selection-panel ${sbbSpread(args)}>
       ${cardBadge()}
       <sbb-radio-button value="Value one" ?disabled=${disabledInput}>

--- a/src/components/selection-panel/selection-panel.stories.ts
+++ b/src/components/selection-panel/selection-panel.stories.ts
@@ -733,9 +733,7 @@ export const NestedCheckboxes: StoryObj = {
 
 const meta: Meta = {
   decorators: [
-    (story) => html`
-      <div style="padding: 2rem;${isChromatic() ? 'min-height: 850px;' : ''}">${story()}</div>
-    `,
+    (story) => html` <div style="padding: 2rem;">${story()}</div> `,
     withActions as Decorator,
   ],
   parameters: {

--- a/src/components/selection-panel/selection-panel.stories.ts
+++ b/src/components/selection-panel/selection-panel.stories.ts
@@ -121,7 +121,10 @@ const WithCheckboxTemplate = ({
   disabledInput,
   ...args
 }: Args): TemplateResult => html`
-  <sbb-selection-panel ${sbbSpread(args)} style="${isChromatic() ? 'min-height: 250px;' : nothing}">
+  <sbb-selection-panel
+    ${sbbSpread(args)}
+    style="${isChromatic() ? 'min-height: 250px; display: block;' : nothing}"
+  >
     ${cardBadge()}
     <sbb-checkbox ?checked=${checkedInput} ?disabled=${disabledInput}>
       Value one ${suffixAndSubtext()}
@@ -135,7 +138,10 @@ const WithRadioButtonTemplate = ({
   disabledInput,
   ...args
 }: Args): TemplateResult => html`
-  <sbb-selection-panel ${sbbSpread(args)} style="${isChromatic() ? 'min-height: 250px;' : nothing}">
+  <sbb-selection-panel
+    ${sbbSpread(args)}
+    style="${isChromatic() ? 'min-height: 250px; display: block;' : nothing}"
+  >
     ${cardBadge()}
     <sbb-radio-button value="Value one" ?checked=${checkedInput} ?disabled=${disabledInput}>
       Value one ${suffixAndSubtext()}

--- a/src/components/selection-panel/selection-panel.stories.ts
+++ b/src/components/selection-panel/selection-panel.stories.ts
@@ -3,7 +3,7 @@ import type { InputType } from '@storybook/types';
 import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/web-components';
 import isChromatic from 'chromatic';
 import type { TemplateResult } from 'lit';
-import { html, nothing } from 'lit';
+import { html } from 'lit';
 import type { StyleInfo } from 'lit/directives/style-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
 

--- a/src/components/selection-panel/selection-panel.stories.ts
+++ b/src/components/selection-panel/selection-panel.stories.ts
@@ -3,7 +3,7 @@ import type { InputType } from '@storybook/types';
 import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/web-components';
 import isChromatic from 'chromatic';
 import type { TemplateResult } from 'lit';
-import { html } from 'lit';
+import { html, nothing } from 'lit';
 import type { StyleInfo } from 'lit/directives/style-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
@@ -152,7 +152,7 @@ const WithCheckboxGroupTemplate = ({
   <sbb-checkbox-group
     orientation="vertical"
     horizontal-from="large"
-    style="${isChromatic() ? 'min-height: 750px;' : ''}"
+    style="${isChromatic() ? 'min-height: 750px;' : nothing}"
   >
     <sbb-selection-panel ${sbbSpread(args)}>
       ${cardBadge()}
@@ -184,7 +184,7 @@ const WithRadioButtonGroupTemplate = ({
     orientation="vertical"
     horizontal-from="large"
     ?allow-empty-selection=${allowEmptySelection}
-    style="${isChromatic() ? 'min-height: 750px;' : ''}"
+    style="${isChromatic() ? 'min-height: 750px;' : nothing}"
   >
     <sbb-selection-panel ${sbbSpread(args)}>
       ${cardBadge()}
@@ -218,7 +218,7 @@ const TicketsOptionsExampleTemplate = ({
   <sbb-checkbox-group
     orientation="vertical"
     horizontal-from="large"
-    style="${isChromatic() ? 'min-height: 750px;' : ''}"
+    style="${isChromatic() ? 'min-height: 750px;' : nothing}"
   >
     <sbb-selection-panel ${sbbSpread(args)}>
       ${cardBadge()}
@@ -350,7 +350,7 @@ const NestedCheckboxTemplate = ({
   <sbb-checkbox-group
     orientation="vertical"
     horizontal-from="large"
-    style="${isChromatic() ? 'min-height: 350px;' : ''}"
+    style="${isChromatic() ? 'min-height: 350px;' : nothing}"
   >
     <sbb-selection-panel ${sbbSpread(args)}>
       <sbb-checkbox value="mainoption1" ?checked=${checkedInput}> Main Option 1 </sbb-checkbox>
@@ -383,7 +383,7 @@ const WithCheckboxesErrorMessageTemplate = ({
     <sbb-checkbox-group
       orientation="vertical"
       horizontal-from="large"
-      style="${isChromatic() ? 'min-height: 750px;' : ''}"
+      style="${isChromatic() ? 'min-height: 750px;' : nothing}"
       @change=${(event: Event) => {
         const checkboxGroup = event.currentTarget as HTMLElement;
         const hasChecked = Array.from(checkboxGroup.querySelectorAll('sbb-checkbox')).some(

--- a/src/components/selection-panel/selection-panel.stories.ts
+++ b/src/components/selection-panel/selection-panel.stories.ts
@@ -121,7 +121,7 @@ const WithCheckboxTemplate = ({
   disabledInput,
   ...args
 }: Args): TemplateResult => html`
-  <sbb-selection-panel ${sbbSpread(args)}>
+  <sbb-selection-panel ${sbbSpread(args)} style="${isChromatic() ? 'min-height: 250px;' : nothing}">
     ${cardBadge()}
     <sbb-checkbox ?checked=${checkedInput} ?disabled=${disabledInput}>
       Value one ${suffixAndSubtext()}
@@ -135,7 +135,7 @@ const WithRadioButtonTemplate = ({
   disabledInput,
   ...args
 }: Args): TemplateResult => html`
-  <sbb-selection-panel ${sbbSpread(args)}>
+  <sbb-selection-panel ${sbbSpread(args)} style="${isChromatic() ? 'min-height: 250px;' : nothing}">
     ${cardBadge()}
     <sbb-radio-button value="Value one" ?checked=${checkedInput} ?disabled=${disabledInput}>
       Value one ${suffixAndSubtext()}
@@ -319,7 +319,11 @@ const NestedRadioTemplate = ({
   disabledInput,
   ...args
 }: Args): TemplateResult => html`
-  <sbb-radio-button-group orientation="vertical" horizontal-from="large">
+  <sbb-radio-button-group
+    orientation="vertical"
+    horizontal-from="large"
+    style="${isChromatic() ? 'min-height: 350px;' : nothing}"
+  >
     <sbb-selection-panel ${sbbSpread(args)}>
       <sbb-radio-button value="mainoption1" ?checked=${checkedInput}>
         Main Option 1

--- a/src/components/selection-panel/selection-panel.stories.ts
+++ b/src/components/selection-panel/selection-panel.stories.ts
@@ -733,9 +733,7 @@ export const NestedCheckboxes: StoryObj = {
 
 const meta: Meta = {
   decorators: [
-    (story) => html`
-      <div style="padding: 2rem;${isChromatic() ? 'min-height: 750px;' : ''}">${story()}</div>
-    `,
+    (story) => html` <div style="padding: 2rem;">${story()}</div> `,
     withActions as Decorator,
   ],
   parameters: {

--- a/src/components/selection-panel/selection-panel.stories.ts
+++ b/src/components/selection-panel/selection-panel.stories.ts
@@ -121,10 +121,7 @@ const WithCheckboxTemplate = ({
   disabledInput,
   ...args
 }: Args): TemplateResult => html`
-  <sbb-selection-panel
-    ${sbbSpread(args)}
-    style="${isChromatic() ? 'min-height: 250px; display: block;' : nothing}"
-  >
+  <sbb-selection-panel ${sbbSpread(args)}>
     ${cardBadge()}
     <sbb-checkbox ?checked=${checkedInput} ?disabled=${disabledInput}>
       Value one ${suffixAndSubtext()}
@@ -138,10 +135,7 @@ const WithRadioButtonTemplate = ({
   disabledInput,
   ...args
 }: Args): TemplateResult => html`
-  <sbb-selection-panel
-    ${sbbSpread(args)}
-    style="${isChromatic() ? 'min-height: 250px; display: block;' : nothing}"
-  >
+  <sbb-selection-panel ${sbbSpread(args)}>
     ${cardBadge()}
     <sbb-radio-button value="Value one" ?checked=${checkedInput} ?disabled=${disabledInput}>
       Value one ${suffixAndSubtext()}
@@ -155,11 +149,7 @@ const WithCheckboxGroupTemplate = ({
   disabledInput,
   ...args
 }: Args): TemplateResult => html`
-  <sbb-checkbox-group
-    orientation="vertical"
-    horizontal-from="large"
-    style="${isChromatic() ? 'min-height: 750px;' : nothing}"
-  >
+  <sbb-checkbox-group orientation="vertical" horizontal-from="large">
     <sbb-selection-panel ${sbbSpread(args)}>
       ${cardBadge()}
       <sbb-checkbox ?checked=${checkedInput}> Value one ${suffixAndSubtext()} </sbb-checkbox>
@@ -190,7 +180,6 @@ const WithRadioButtonGroupTemplate = ({
     orientation="vertical"
     horizontal-from="large"
     ?allow-empty-selection=${allowEmptySelection}
-    style="${isChromatic() ? 'min-height: 750px;' : nothing}"
   >
     <sbb-selection-panel ${sbbSpread(args)}>
       ${cardBadge()}
@@ -221,11 +210,7 @@ const TicketsOptionsExampleTemplate = ({
   disabledInput,
   ...args
 }: Args): TemplateResult => html`
-  <sbb-checkbox-group
-    orientation="vertical"
-    horizontal-from="large"
-    style="${isChromatic() ? 'min-height: 750px;' : nothing}"
-  >
+  <sbb-checkbox-group orientation="vertical" horizontal-from="large">
     <sbb-selection-panel ${sbbSpread(args)}>
       ${cardBadge()}
       <sbb-checkbox ?checked=${checkedInput}> Saving ${suffixAndSubtext()} </sbb-checkbox>
@@ -325,11 +310,7 @@ const NestedRadioTemplate = ({
   disabledInput,
   ...args
 }: Args): TemplateResult => html`
-  <sbb-radio-button-group
-    orientation="vertical"
-    horizontal-from="large"
-    style="${isChromatic() ? 'min-height: 350px;' : nothing}"
-  >
+  <sbb-radio-button-group orientation="vertical" horizontal-from="large">
     <sbb-selection-panel ${sbbSpread(args)}>
       <sbb-radio-button value="mainoption1" ?checked=${checkedInput}>
         Main Option 1
@@ -357,11 +338,7 @@ const NestedCheckboxTemplate = ({
   disabledInput,
   ...args
 }: Args): TemplateResult => html`
-  <sbb-checkbox-group
-    orientation="vertical"
-    horizontal-from="large"
-    style="${isChromatic() ? 'min-height: 350px;' : nothing}"
-  >
+  <sbb-checkbox-group orientation="vertical" horizontal-from="large">
     <sbb-selection-panel ${sbbSpread(args)}>
       <sbb-checkbox value="mainoption1" ?checked=${checkedInput}> Main Option 1 </sbb-checkbox>
       <sbb-checkbox-group orientation="vertical" slot="content">
@@ -393,7 +370,6 @@ const WithCheckboxesErrorMessageTemplate = ({
     <sbb-checkbox-group
       orientation="vertical"
       horizontal-from="large"
-      style="${isChromatic() ? 'min-height: 750px;' : nothing}"
       @change=${(event: Event) => {
         const checkboxGroup = event.currentTarget as HTMLElement;
         const hasChecked = Array.from(checkboxGroup.querySelectorAll('sbb-checkbox')).some(
@@ -443,7 +419,6 @@ const WithRadiosErrorMessageTemplate = ({
       horizontal-from="large"
       allow-empty-selection
       id="sbb-radio-group"
-      style="${isChromatic() ? 'min-height: 800px;' : nothing}"
       @change=${(event: CustomEvent<SbbRadioButtonGroupEventDetail>) => {
         if (event.detail.value) {
           sbbFormError.remove();
@@ -505,11 +480,7 @@ const WithNoContentGroupTemplate = ({
   disabledInput,
   ...args
 }: Args): TemplateResult => html`
-  <sbb-radio-button-group
-    orientation="vertical"
-    horizontal-from="large"
-    style="${isChromatic() ? 'min-height: 500px;' : nothing}"
-  >
+  <sbb-radio-button-group orientation="vertical" horizontal-from="large">
     <sbb-selection-panel ${sbbSpread(args)}>
       ${cardBadge()}
       <sbb-radio-button value="Value one" ?disabled=${disabledInput}>
@@ -752,7 +723,7 @@ const meta: Meta = {
     withActions as Decorator,
   ],
   parameters: {
-    chromatic: { delay: 9000 },
+    chromatic: { delay: 9000, fixedHeight: '17000px' },
     actions: {
       handles: [
         SbbSelectionPanelElement.events.didOpen,

--- a/src/components/selection-panel/selection-panel.stories.ts
+++ b/src/components/selection-panel/selection-panel.stories.ts
@@ -734,7 +734,7 @@ export const NestedCheckboxes: StoryObj = {
 const meta: Meta = {
   decorators: [
     (story) => html`
-      <div style="padding: 2rem;${isChromatic() ? 'min-height: 550px;' : ''}">${story()}</div>
+      <div style="padding: 2rem;${isChromatic() ? 'min-height: 850px;' : ''}">${story()}</div>
     `,
     withActions as Decorator,
   ],

--- a/src/components/selection-panel/selection-panel.stories.ts
+++ b/src/components/selection-panel/selection-panel.stories.ts
@@ -723,7 +723,7 @@ const meta: Meta = {
     withActions as Decorator,
   ],
   parameters: {
-    chromatic: { delay: 9000, fixedHeight: '17000px' },
+    chromatic: { delay: 9000, fixedHeight: '14500px' },
     actions: {
       handles: [
         SbbSelectionPanelElement.events.didOpen,

--- a/src/components/selection-panel/selection-panel.stories.ts
+++ b/src/components/selection-panel/selection-panel.stories.ts
@@ -733,7 +733,9 @@ export const NestedCheckboxes: StoryObj = {
 
 const meta: Meta = {
   decorators: [
-    (story) => html` <div style="padding: 2rem;">${story()}</div> `,
+    (story) => html`
+      <div style="padding: 2rem;${isChromatic() ? 'min-height: 550px;' : ''}">${story()}</div>
+    `,
     withActions as Decorator,
   ],
   parameters: {

--- a/src/components/selection-panel/selection-panel.stories.ts
+++ b/src/components/selection-panel/selection-panel.stories.ts
@@ -149,7 +149,11 @@ const WithCheckboxGroupTemplate = ({
   disabledInput,
   ...args
 }: Args): TemplateResult => html`
-  <sbb-checkbox-group orientation="vertical" horizontal-from="large">
+  <sbb-checkbox-group
+    orientation="vertical"
+    horizontal-from="large"
+    style="${isChromatic() ? 'min-height: 750px;' : ''}"
+  >
     <sbb-selection-panel ${sbbSpread(args)}>
       ${cardBadge()}
       <sbb-checkbox ?checked=${checkedInput}> Value one ${suffixAndSubtext()} </sbb-checkbox>
@@ -180,6 +184,7 @@ const WithRadioButtonGroupTemplate = ({
     orientation="vertical"
     horizontal-from="large"
     ?allow-empty-selection=${allowEmptySelection}
+    style="${isChromatic() ? 'min-height: 750px;' : ''}"
   >
     <sbb-selection-panel ${sbbSpread(args)}>
       ${cardBadge()}
@@ -210,7 +215,11 @@ const TicketsOptionsExampleTemplate = ({
   disabledInput,
   ...args
 }: Args): TemplateResult => html`
-  <sbb-checkbox-group orientation="vertical" horizontal-from="large">
+  <sbb-checkbox-group
+    orientation="vertical"
+    horizontal-from="large"
+    style="${isChromatic() ? 'min-height: 750px;' : ''}"
+  >
     <sbb-selection-panel ${sbbSpread(args)}>
       ${cardBadge()}
       <sbb-checkbox ?checked=${checkedInput}> Saving ${suffixAndSubtext()} </sbb-checkbox>
@@ -338,7 +347,11 @@ const NestedCheckboxTemplate = ({
   disabledInput,
   ...args
 }: Args): TemplateResult => html`
-  <sbb-checkbox-group orientation="vertical" horizontal-from="large">
+  <sbb-checkbox-group
+    orientation="vertical"
+    horizontal-from="large"
+    style="${isChromatic() ? 'min-height: 350px;' : ''}"
+  >
     <sbb-selection-panel ${sbbSpread(args)}>
       <sbb-checkbox value="mainoption1" ?checked=${checkedInput}> Main Option 1 </sbb-checkbox>
       <sbb-checkbox-group orientation="vertical" slot="content">
@@ -370,6 +383,7 @@ const WithCheckboxesErrorMessageTemplate = ({
     <sbb-checkbox-group
       orientation="vertical"
       horizontal-from="large"
+      style="${isChromatic() ? 'min-height: 750px;' : ''}"
       @change=${(event: Event) => {
         const checkboxGroup = event.currentTarget as HTMLElement;
         const hasChecked = Array.from(checkboxGroup.querySelectorAll('sbb-checkbox')).some(
@@ -719,7 +733,9 @@ export const NestedCheckboxes: StoryObj = {
 
 const meta: Meta = {
   decorators: [
-    (story) => html` <div style="padding: 2rem;">${story()}</div> `,
+    (story) => html`
+      <div style="padding: 2rem;${isChromatic() ? 'min-height: 750px;' : ''}">${story()}</div>
+    `,
     withActions as Decorator,
   ],
   parameters: {

--- a/src/components/selection-panel/selection-panel.ts
+++ b/src/components/selection-panel/selection-panel.ts
@@ -147,6 +147,11 @@ export class SbbSelectionPanelElement extends LitElement {
 
   private _initFromInput(event: Event): void {
     const input = event.target as SbbCheckboxElement | SbbRadioButtonElement;
+
+    if (!input.isSelectionPanelInput) {
+      return;
+    }
+
     this._checked = input.checked;
     this._disabled = input.disabled;
     this._updateState();
@@ -155,6 +160,12 @@ export class SbbSelectionPanelElement extends LitElement {
   private _onInputStateChange(
     event: CustomEvent<SbbRadioButtonStateChange | SbbCheckboxStateChange>,
   ): void {
+    const input = event.target as SbbCheckboxElement | SbbRadioButtonElement;
+
+    if (!input.isSelectionPanelInput) {
+      return;
+    }
+
     if (event.detail.type === 'disabled') {
       this._disabled = event.detail.disabled;
       return;
@@ -192,7 +203,7 @@ export class SbbSelectionPanelElement extends LitElement {
         </div>
         <div
           class="sbb-selection-panel__content--wrapper"
-          .inert="${!this._checked && !this.forceOpen};"
+          .inert=${this._state !== 'opened'}
           @animationend=${(event: AnimationEvent) => this._onAnimationEnd(event)}
         >
           <div class="sbb-selection-panel__content">

--- a/src/components/selection-panel/selection-panel.ts
+++ b/src/components/selection-panel/selection-panel.ts
@@ -97,7 +97,7 @@ export class SbbSelectionPanelElement extends LitElement {
    */
   public get hasContent(): boolean {
     // We cannot use the NamedSlots because it's too slow to initialize
-    return this.querySelectorAll?.('[slot="content"').length > 0;
+    return this.querySelectorAll?.('[slot="content"]').length > 0;
   }
 
   public constructor() {

--- a/src/components/selection-panel/selection-panel.ts
+++ b/src/components/selection-panel/selection-panel.ts
@@ -2,12 +2,12 @@ import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import { html, LitElement } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
-import type { SbbCheckboxElement, SbbCheckboxStateChange } from '../checkbox';
+import type { SbbCheckboxElement } from '../checkbox';
 import { NamedSlotStateController } from '../core/common-behaviors';
 import { setAttribute } from '../core/dom';
 import { EventEmitter, ConnectedAbortController } from '../core/eventing';
 import type { SbbStateChange } from '../core/interfaces';
-import type { SbbRadioButtonElement, SbbRadioButtonStateChange } from '../radio-button';
+import type { SbbRadioButtonElement } from '../radio-button';
 
 import style from './selection-panel.scss?lit&inline';
 import '../divider';
@@ -157,9 +157,7 @@ export class SbbSelectionPanelElement extends LitElement {
     this._updateState();
   }
 
-  private _onInputStateChange(
-    event: CustomEvent<SbbRadioButtonStateChange | SbbCheckboxStateChange>,
-  ): void {
+  private _onInputStateChange(event: CustomEvent<SbbStateChange>): void {
     const input = event.target as SbbCheckboxElement | SbbRadioButtonElement;
 
     if (!input.isSelectionPanelInput) {

--- a/src/components/selection-panel/selection-panel.ts
+++ b/src/components/selection-panel/selection-panel.ts
@@ -1,7 +1,6 @@
 import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import { html, LitElement } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { ref } from 'lit/directives/ref.js';
 
 import type { SbbCheckboxElement, SbbCheckboxStateChange } from '../checkbox';
 import { NamedSlotStateController } from '../core/common-behaviors';
@@ -90,7 +89,6 @@ export class SbbSelectionPanelElement extends LitElement {
     { bubbles: true, composed: true },
   );
 
-  private _contentElement?: HTMLElement;
   private _abort = new ConnectedAbortController(this);
 
   /**
@@ -194,13 +192,8 @@ export class SbbSelectionPanelElement extends LitElement {
         </div>
         <div
           class="sbb-selection-panel__content--wrapper"
+          .inert="${!this._checked && !this.forceOpen};"
           @animationend=${(event: AnimationEvent) => this._onAnimationEnd(event)}
-          ${ref((el: HTMLElement) => {
-            this._contentElement = el;
-            if (this._contentElement) {
-              this._contentElement.inert = !this._checked && !this.forceOpen;
-            }
-          })}
         >
           <div class="sbb-selection-panel__content">
             <sbb-divider></sbb-divider>

--- a/src/components/selection-panel/selection-panel.ts
+++ b/src/components/selection-panel/selection-panel.ts
@@ -1,4 +1,4 @@
-import type { CSSResultGroup, TemplateResult } from 'lit';
+import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import { html, LitElement } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { ref } from 'lit/directives/ref.js';
@@ -38,7 +38,7 @@ export class SbbSelectionPanelElement extends LitElement {
   @property() public color: 'white' | 'milk' = 'white';
 
   /** Whether the content section is always visible. */
-  @property({ attribute: 'force-open', reflect: true, type: Boolean }) public forceOpen = false;
+  @property({ attribute: 'force-open', type: Boolean }) public forceOpen = false;
 
   /** Whether the unselected panel has a border. */
   @property({ reflect: true, type: Boolean }) public borderless = false;
@@ -48,7 +48,7 @@ export class SbbSelectionPanelElement extends LitElement {
   public disableAnimation = false;
 
   /** The state of the selection panel. */
-  @state() private _state?: 'closed' | 'opening' | 'opened' | 'closing';
+  @state() private _state: 'closed' | 'opening' | 'opened' | 'closing' = 'closed';
 
   /** Whether the selection panel is checked. */
   @state() private _checked = false;
@@ -91,31 +91,72 @@ export class SbbSelectionPanelElement extends LitElement {
   );
 
   private _contentElement?: HTMLElement;
-  private _didLoad = false;
   private _abort = new ConnectedAbortController(this);
-  private _namedSlots = new NamedSlotStateController(this);
 
   /**
    * Whether it has an expandable content
    * @internal
    */
   public get hasContent(): boolean {
-    return this._namedSlots.slots.has('content');
+    // We cannot use the NamedSlots because it's too slow to initialize
+    return this.querySelectorAll?.('[slot="content"').length > 0;
   }
 
-  private get _input(): SbbCheckboxElement | SbbRadioButtonElement {
-    return this.querySelector('sbb-checkbox, sbb-radio-button') as
-      | SbbCheckboxElement
-      | SbbRadioButtonElement;
+  public constructor() {
+    super();
+    new NamedSlotStateController(this);
   }
 
-  private _onInputChange(
-    event: CustomEvent<SbbRadioButtonStateChange | SbbCheckboxStateChange>,
-  ): void {
-    if (!this._state || !this._didLoad) {
+  public override connectedCallback(): void {
+    super.connectedCallback();
+    const signal = this._abort.signal;
+    this.addEventListener('stateChange', this._onInputStateChange.bind(this), { signal });
+    this.addEventListener('checkboxLoaded', this._initFromInput.bind(this), { signal });
+    this.addEventListener('radioButtonLoaded', this._initFromInput.bind(this), { signal });
+  }
+
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
+    if (changedProperties.has('forceOpen')) {
+      this._updateState();
+    }
+  }
+
+  private _updateState(): void {
+    if (!this.hasContent) {
       return;
     }
 
+    this.forceOpen || this._checked ? this._open() : this._close();
+  }
+
+  private _open(): void {
+    if (this._state !== 'closed' && this._state !== 'closing') {
+      return;
+    }
+
+    this._state = 'opening';
+    this._willOpen.emit();
+  }
+
+  private _close(): void {
+    if (this._state !== 'opened' && this._state !== 'opening') {
+      return;
+    }
+
+    this._state = 'closing';
+    this._willClose.emit();
+  }
+
+  private _initFromInput(event: Event): void {
+    const input = event.target as SbbCheckboxElement | SbbRadioButtonElement;
+    this._checked = input.checked;
+    this._disabled = input.disabled;
+    this._updateState();
+  }
+
+  private _onInputStateChange(
+    event: CustomEvent<SbbRadioButtonStateChange | SbbCheckboxStateChange>,
+  ): void {
     if (event.detail.type === 'disabled') {
       this._disabled = event.detail.disabled;
       return;
@@ -124,66 +165,17 @@ export class SbbSelectionPanelElement extends LitElement {
     }
 
     this._checked = event.detail.checked;
+    this._updateState();
+  }
 
-    if (!this._namedSlots.slots.has('content') || this.forceOpen) {
-      return;
+  private _onAnimationEnd(event: AnimationEvent): void {
+    if (event.animationName === 'open-opacity' && this._state === 'opening') {
+      this._state = 'opened';
+      this._didOpen.emit();
+    } else if (event.animationName === 'close' && this._state === 'closing') {
+      this._state = 'closed';
+      this._didClose.emit();
     }
-
-    if (this._checked) {
-      this._state = 'opening';
-      this._willOpen.emit();
-    } else {
-      this._state = 'closing';
-      this._willClose.emit();
-    }
-  }
-
-  public override connectedCallback(): void {
-    super.connectedCallback();
-    const signal = this._abort.signal;
-    this.addEventListener(
-      'stateChange',
-      (e: CustomEvent<SbbStateChange>) =>
-        this._onInputChange(e as CustomEvent<SbbRadioButtonStateChange | SbbCheckboxStateChange>),
-      { signal, passive: true },
-    );
-    this.addEventListener('checkboxLoaded', () => this._updateSelectionPanel(), { signal });
-    this.addEventListener('radioButtonLoaded', () => this._updateSelectionPanel(), { signal });
-  }
-
-  protected override firstUpdated(): void {
-    this._didLoad = true;
-  }
-
-  private _updateSelectionPanel(): void {
-    this._checked = this._input?.checked;
-    this._state =
-      this.forceOpen || (this._namedSlots.slots.has('content') && this._checked)
-        ? 'opened'
-        : 'closed';
-    this._disabled = this._input?.disabled;
-  }
-
-  private _onTransitionEnd(event: TransitionEvent): void {
-    if (event.target !== this._contentElement || event.propertyName !== 'opacity') {
-      return;
-    }
-
-    if (this._checked) {
-      this._handleOpening();
-    } else {
-      this._handleClosing();
-    }
-  }
-
-  private _handleOpening(): void {
-    this._state = 'opened';
-    this._didOpen.emit();
-  }
-
-  private _handleClosing(): void {
-    this._state = 'closed';
-    this._didClose.emit();
   }
 
   protected override render(): TemplateResult {
@@ -202,10 +194,9 @@ export class SbbSelectionPanelElement extends LitElement {
         </div>
         <div
           class="sbb-selection-panel__content--wrapper"
-          ?data-expanded=${this._checked || this.forceOpen}
-          @transitionend=${(event: TransitionEvent) => this._onTransitionEnd(event)}
-          ${ref((el?: Element) => {
-            this._contentElement = el as HTMLElement;
+          @animationend=${(event: AnimationEvent) => this._onAnimationEnd(event)}
+          ${ref((el: HTMLElement) => {
+            this._contentElement = el;
             if (this._contentElement) {
               this._contentElement.inert = !this._checked && !this.forceOpen;
             }

--- a/src/components/selection-panel/selection-panel.ts
+++ b/src/components/selection-panel/selection-panel.ts
@@ -20,8 +20,8 @@ import '../divider';
  * @slot content - Use this slot to provide custom content for the panel (optional).
  * @event {CustomEvent<void>} willOpen - Emits whenever the content section starts the opening transition.
  * @event {CustomEvent<void>} didOpen - Emits whenever the content section is opened.
- * @event {CustomEvent<{ closeTarget: HTMLElement }>} willClose - Emits whenever the content section begins the closing transition.
- * @event {CustomEvent<{ closeTarget: HTMLElement }>} didClose - Emits whenever the content section is closed.
+ * @event {CustomEvent<void>} willClose - Emits whenever the content section begins the closing transition.
+ * @event {CustomEvent<void>} didClose - Emits whenever the content section is closed.
  */
 @customElement('sbb-selection-panel')
 export class SbbSelectionPanelElement extends LitElement {
@@ -68,13 +68,13 @@ export class SbbSelectionPanelElement extends LitElement {
   );
 
   /** Emits whenever the content section begins the closing transition. */
-  private _willClose: EventEmitter<{ closeTarget: HTMLElement }> = new EventEmitter(
+  private _willClose: EventEmitter<void> = new EventEmitter(
     this,
     SbbSelectionPanelElement.events.willClose,
   );
 
   /** Emits whenever the content section is closed. */
-  private _didClose: EventEmitter<{ closeTarget: HTMLElement }> = new EventEmitter(
+  private _didClose: EventEmitter<void> = new EventEmitter(
     this,
     SbbSelectionPanelElement.events.didClose,
   );

--- a/src/components/selection-panel/selection-panel.ts
+++ b/src/components/selection-panel/selection-panel.ts
@@ -59,37 +59,28 @@ export class SbbSelectionPanelElement extends LitElement {
   private _willOpen: EventEmitter<void> = new EventEmitter(
     this,
     SbbSelectionPanelElement.events.willOpen,
-    {
-      bubbles: true,
-      composed: true,
-    },
   );
 
   /** Emits whenever the content section is opened. */
   private _didOpen: EventEmitter<void> = new EventEmitter(
     this,
     SbbSelectionPanelElement.events.didOpen,
-    {
-      bubbles: true,
-      composed: true,
-    },
   );
 
   /** Emits whenever the content section begins the closing transition. */
   private _willClose: EventEmitter<{ closeTarget: HTMLElement }> = new EventEmitter(
     this,
     SbbSelectionPanelElement.events.willClose,
-    { bubbles: true, composed: true },
   );
 
   /** Emits whenever the content section is closed. */
   private _didClose: EventEmitter<{ closeTarget: HTMLElement }> = new EventEmitter(
     this,
     SbbSelectionPanelElement.events.didClose,
-    { bubbles: true, composed: true },
   );
 
   private _abort = new ConnectedAbortController(this);
+  private _initialized: boolean = false;
 
   /**
    * Whether it has an expandable content
@@ -119,21 +110,30 @@ export class SbbSelectionPanelElement extends LitElement {
     }
   }
 
+  protected override firstUpdated(): void {
+    this._initialized = true;
+  }
+
   private _updateState(): void {
     if (!this.hasContent) {
       return;
     }
 
-    this.forceOpen || this._checked ? this._open() : this._close();
+    this.forceOpen || this._checked ? this._open(!this._initialized) : this._close();
   }
 
-  private _open(): void {
+  private _open(skipAnimation = false): void {
     if (this._state !== 'closed' && this._state !== 'closing') {
       return;
     }
 
     this._state = 'opening';
     this._willOpen.emit();
+
+    if (skipAnimation) {
+      this._state = 'opened';
+      this._didOpen.emit();
+    }
   }
 
   private _close(): void {


### PR DESCRIPTION
This PR aims to solve the problems relative to the open/close events emitted by the `selection-panel`.
We have received no complaints, so I expect nobody is using them so far.
Might solve #2309 

### Changes ###
- Converted the open/close animation from `css-transition` to `css-animation`. CSS animation provides a more consistent behavior and always emits `animationend` events.
- Refactored the code so that we have a single method that takes care of checking the state and to open/close the panel

### To discuss ###
- Should a panel that uses `force-open` emit events?
- Should a panel that uses `force-open` animate?