### PR TITLE
fix(scrollbar): fix track color in nested context

### DIFF
--- a/src/components/core/styles/mixins/scrollbar.scss
+++ b/src/components/core/styles/mixins/scrollbar.scss
@@ -72,6 +72,10 @@
   --sbb-scrollbar-track-color: var(--sbb-color-iron-default);
 }
 
+@mixin scrollbar-variables--track-invisible {
+  --sbb-scrollbar-track-color: transparent;
+}
+
 @mixin scrollbar-variables($size: thin, $negative: false, $track-visible: false) {
   @if $size == thin {
     @include scrollbar-variables--size-thin;
@@ -89,6 +93,8 @@
     @include scrollbar-variables--color-negative-track-visible;
   } @else if $track-visible {
     @include scrollbar-variables--color-positive-track-visible;
+  } @else {
+    @include scrollbar-variables--track-invisible;
   }
 }
 


### PR DESCRIPTION
Previously, when having a visible track on an outer scrollbar, the inner scrollbar inherits the track color.
With this change, all variables are always redefined to allow nested scrollbars.