### PR TITLE
fix(sbb-select): hide placeholder when using floating label in HCM

### DIFF
--- a/src/components/form-field/form-field/form-field.scss
+++ b/src/components/form-field/form-field/form-field.scss
@@ -148,6 +148,10 @@
 
 :host([floating-label]) {
   --sbb-select-placeholder-color: transparent;
+
+  @include sbb.if-forced-colors {
+    --sbb-select-placeholder-color: Canvas;
+  }
 }
 
 // Should be after other definitions to override overflow and background


### PR DESCRIPTION
Closes #2326 