### PR TITLE
chore: update 'test:snapshot' command and dotReporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "start": "storybook dev -p 6006",
     "test": "wtr --coverage --group default",
     "test:spec": "wtr --group spec",
-    "test:snapshot": "yarn test --update-snapshots",
+    "test:snapshot": "yarn test --ci --update-snapshots",
     "test:e2e": "wtr --group e2e",
     "prepare": "husky install"
   },

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -65,7 +65,8 @@ export default {
 /** @type {import('@web/test-runner-core').Reporter} */
 function minimalReporter() {
   const base = dotReporter();
-  const log = (result) => process.stdout.write(result.passed ? '.' : '\x1b[31mx\x1b[0m');
+  const log = (result) =>
+    process.stdout.write(result.passed ? '.' : result.skipped ? '-' : '\x1b[31mx\x1b[0m');
   function logResults(results) {
     results?.tests?.forEach(log);
     results?.suites?.forEach(logResults);

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -66,7 +66,7 @@ export default {
 function minimalReporter() {
   const base = dotReporter();
   const log = (result) =>
-    process.stdout.write(result.passed ? '.' : result.skipped ? '-' : '\x1b[31mx\x1b[0m');
+    process.stdout.write(result.passed ? '.' : result.skipped ? '~' : '\x1b[31mx\x1b[0m');
   function logResults(results) {
     results?.tests?.forEach(log);
     results?.suites?.forEach(logResults);


### PR DESCRIPTION
Since we now have browser-specific snapshots,  the `test:snapshot` command has to run the update on each browser