### PR TITLE
chore(github): update 'is-pr-open' action dep from v6 => v7

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -90,7 +90,7 @@ jobs:
       is-draft: ${{ fromJson(steps.get_issue_number.outputs.result).draft }}
       title: ${{ fromJson(steps.get_issue_number.outputs.result).title }}
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         id: get_issue_number
         with:
           script: |


### PR DESCRIPTION
This pr solves a deprecation warning on the new `is-pr-open` github action

![image](https://github.com/lyne-design-system/lyne-components/assets/12052575/3a7df651-e33f-4ac8-892f-bf955ac20b5f)
