### PR TITLE
refactor: implement and use hostAttributes decorator

### DIFF
--- a/src/components/autocomplete/autocomplete.ts
+++ b/src/components/autocomplete/autocomplete.ts
@@ -4,7 +4,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { ref } from 'lit/directives/ref.js';
 
 import { assignId, getNextElementIndex } from '../core/a11y';
-import { SbbNegativeMixin, SlotChildObserver } from '../core/common-behaviors';
+import { hostAttributes, SbbNegativeMixin, SlotChildObserver } from '../core/common-behaviors';
 import {
   setAttribute,
   getDocumentWritingMode,
@@ -38,6 +38,9 @@ let nextId = 0;
  * @event {CustomEvent<void>} willClose - Emits whenever the `sbb-autocomplete` begins the closing transition. Can be canceled.
  * @event {CustomEvent<void>} didClose - Emits whenever the `sbb-autocomplete` is closed.
  */
+@hostAttributes({
+  dir: getDocumentWritingMode(),
+})
 @customElement('sbb-autocomplete')
 export class SbbAutocompleteElement extends SlotChildObserver(SbbNegativeMixin(LitElement)) {
   public static override styles: CSSResultGroup = style;
@@ -549,7 +552,6 @@ export class SbbAutocompleteElement extends SlotChildObserver(SbbNegativeMixin(L
   protected override render(): TemplateResult {
     setAttribute(this, 'data-state', this._state);
     setAttribute(this, 'role', this._ariaRoleOnHost ? 'listbox' : null);
-    setAttribute(this, 'dir', getDocumentWritingMode());
     this._ariaRoleOnHost && assignId(() => this._overlayId)(this);
 
     return html`

--- a/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.ts
+++ b/src/components/breadcrumb/breadcrumb-group/breadcrumb-group.ts
@@ -9,7 +9,11 @@ import { html, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
 import { getNextElementIndex, isArrowKeyPressed, sbbInputModalityDetector } from '../../core/a11y';
-import { SbbNamedSlotListElementMixin, type WithListChildren } from '../../core/common-behaviors';
+import {
+  hostAttributes,
+  SbbNamedSlotListElementMixin,
+  type WithListChildren,
+} from '../../core/common-behaviors';
 import { LanguageController } from '../../core/common-behaviors';
 import { setAttribute } from '../../core/dom';
 import { ConnectedAbortController } from '../../core/eventing';
@@ -26,6 +30,9 @@ import '../../icon';
  *
  * @slot - Use the unnamed slot to add `sbb-breadcrumb` elements.
  */
+@hostAttributes({
+  role: 'navigation',
+})
 @customElement('sbb-breadcrumb-group')
 export class SbbBreadcrumbGroupElement extends SbbNamedSlotListElementMixin<
   SbbBreadcrumbElement,
@@ -197,7 +204,6 @@ export class SbbBreadcrumbGroupElement extends SbbNamedSlotListElementMixin<
   }
 
   protected override render(): TemplateResult {
-    setAttribute(this, 'role', 'navigation');
     setAttribute(this, 'data-state', this._state);
 
     return html`

--- a/src/components/card/card-badge/card-badge.ts
+++ b/src/components/card/card-badge/card-badge.ts
@@ -2,7 +2,8 @@ import type { CSSResultGroup, TemplateResult } from 'lit';
 import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { toggleDatasetEntry, getDocumentWritingMode, setAttribute } from '../../core/dom';
+import { hostAttributes } from '../../core/common-behaviors';
+import { toggleDatasetEntry, getDocumentWritingMode } from '../../core/dom';
 
 import style from './card-badge.scss?lit&inline';
 
@@ -12,6 +13,11 @@ import style from './card-badge.scss?lit&inline';
  * @slot - Use the unnamed slot to add content to the badge.
  *   Content parts should be wrapped in `<span>` tags to achieve correct spacings.
  */
+@hostAttributes({
+  slot: 'badge',
+  role: 'text',
+  dir: getDocumentWritingMode(),
+})
 @customElement('sbb-card-badge')
 export class SbbCardBadgeElement extends LitElement {
   public static override styles: CSSResultGroup = style;
@@ -38,10 +44,6 @@ export class SbbCardBadgeElement extends LitElement {
   }
 
   protected override render(): TemplateResult {
-    setAttribute(this, 'slot', 'badge');
-    setAttribute(this, 'dir', getDocumentWritingMode());
-    setAttribute(this, 'role', 'text');
-
     return html`
       <span class="sbb-card-badge-wrapper">
         <span class="sbb-card-badge">

--- a/src/components/card/common/card-action-common.ts
+++ b/src/components/card/common/card-action-common.ts
@@ -3,8 +3,12 @@ import { property } from 'lit/decorators.js';
 import { html } from 'lit/static-html.js';
 
 import { IS_FOCUSABLE_QUERY } from '../../core/a11y';
-import type { AbstractConstructor, SbbActionBaseElement } from '../../core/common-behaviors';
-import { setAttribute, toggleDatasetEntry } from '../../core/dom';
+import {
+  type AbstractConstructor,
+  hostAttributes,
+  type SbbActionBaseElement,
+} from '../../core/common-behaviors';
+import { toggleDatasetEntry } from '../../core/dom';
 import { AgnosticMutationObserver } from '../../core/observers';
 import type { SbbCardElement } from '../card';
 
@@ -20,6 +24,9 @@ export const SbbCardActionCommonElementMixin = <
 >(
   superClass: T,
 ): AbstractConstructor<SbbCardActionCommonElementMixinType> & T => {
+  @hostAttributes({
+    slot: 'action',
+  })
   abstract class SbbCardActionCommonElement
     extends superClass
     implements Partial<SbbCardActionCommonElementMixinType>
@@ -68,7 +75,6 @@ export const SbbCardActionCommonElementMixin = <
         toggleDatasetEntry(this._card, 'hasAction', true);
         toggleDatasetEntry(this._card, 'hasActiveAction', this.active);
         this._card.dataset.actionRole = this.getAttribute('role')!;
-        setAttribute(this, 'slot', 'action');
 
         this._checkForSlottedActions();
         this._cardMutationObserver.observe(this._card, {

--- a/src/components/container/sticky-bar/sticky-bar.ts
+++ b/src/components/container/sticky-bar/sticky-bar.ts
@@ -1,7 +1,8 @@
 import { type CSSResultGroup, html, LitElement, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { setAttribute, toggleDatasetEntry } from '../../core/dom';
+import { hostAttributes } from '../../core/common-behaviors';
+import { toggleDatasetEntry } from '../../core/dom';
 import { AgnosticIntersectionObserver } from '../../core/observers';
 
 import style from './sticky-bar.scss?lit&inline';
@@ -11,6 +12,9 @@ import style from './sticky-bar.scss?lit&inline';
  *
  * @slot - Use the unnamed slot to add content to the sticky bar.
  */
+@hostAttributes({
+  slot: 'sticky-bar',
+})
 @customElement('sbb-sticky-bar')
 export class SbbStickyBarElement extends LitElement {
   public static override styles: CSSResultGroup = style;
@@ -29,8 +33,6 @@ export class SbbStickyBarElement extends LitElement {
 
   public override connectedCallback(): void {
     super.connectedCallback();
-
-    setAttribute(this, 'slot', 'sticky-bar');
 
     const container = this.closest('sbb-container');
     if (container) {

--- a/src/components/core/common-behaviors/action-base-element.ts
+++ b/src/components/core/common-behaviors/action-base-element.ts
@@ -2,6 +2,8 @@ import { html, LitElement, type TemplateResult } from 'lit';
 
 import { getDocumentWritingMode, getLocalName } from '../dom';
 
+import { hostAttributes } from './host-attributes';
+
 /**
  * Whenever an element can be disabled it has disabled property
  * or formDisabled if it's a form element.
@@ -12,6 +14,9 @@ type MaybeDisabled = {
   formDisabled?: boolean;
 };
 
+@hostAttributes({
+  dir: getDocumentWritingMode(),
+})
 export abstract class SbbActionBaseElement extends LitElement {
   protected setupBaseEventHandlers(): void {
     this.addEventListener(
@@ -58,11 +63,6 @@ export abstract class SbbActionBaseElement extends LitElement {
   /** Override this method to render the component template. */
   protected renderTemplate(): TemplateResult {
     throw new Error('Implementation needed!');
-  }
-
-  protected override createRenderRoot(): HTMLElement | DocumentFragment {
-    this.setAttribute('dir', getDocumentWritingMode());
-    return super.createRenderRoot();
   }
 
   /** Default render method for button-like components. */

--- a/src/components/core/common-behaviors/button-base-element.ts
+++ b/src/components/core/common-behaviors/button-base-element.ts
@@ -4,11 +4,16 @@ import { property } from 'lit/decorators.js';
 import { isEventPrevented } from '../eventing';
 
 import { SbbActionBaseElement } from './action-base-element';
+import { hostAttributes } from './host-attributes';
 
 /** Enumeration for type attribute in <button> HTML tag. */
 export type SbbButtonType = 'button' | 'reset' | 'submit';
 
 /** Button base class. */
+@hostAttributes({
+  role: 'button',
+  tabindex: '0',
+})
 export abstract class SbbButtonBaseElement extends SbbActionBaseElement {
   /** The type attribute to use for the button. */
   @property() public type: SbbButtonType = 'button';
@@ -83,11 +88,5 @@ export abstract class SbbButtonBaseElement extends SbbActionBaseElement {
       this.addEventListener('keyup', this._dispatchClickEventOnSpaceKeyup, passiveOptions);
       this.addEventListener('blur', this._removeActiveMarker, passiveOptions);
     }
-  }
-
-  protected override createRenderRoot(): HTMLElement | DocumentFragment {
-    this.setAttribute('role', 'button');
-    this.setAttribute('tabindex', '0');
-    return super.createRenderRoot();
   }
 }

--- a/src/components/core/common-behaviors/host-attributes.ts
+++ b/src/components/core/common-behaviors/host-attributes.ts
@@ -1,5 +1,7 @@
 import { isServer, type ReactiveElement } from 'lit';
 
+import type { AbstractConstructor } from './constructor';
+
 function applyAttributes(instance: ReactiveElement, attributes: Record<string, string>): void {
   for (const [name, value] of Object.entries(attributes)) {
     if (value) {
@@ -11,7 +13,7 @@ function applyAttributes(instance: ReactiveElement, attributes: Record<string, s
 }
 
 /**
- * Applies the given attibutes to the related element.
+ * Applies the given attributes to the related element.
  * If an empty string is passed as a value, the attribute will be set
  * without value.
  *
@@ -28,15 +30,21 @@ function applyAttributes(instance: ReactiveElement, attributes: Record<string, s
  * @param attributes A record of attributes to apply to the element.
  */
 export const hostAttributes =
-  (attributes: Record<string, string>) => (target: typeof ReactiveElement) =>
-    target.addInitializer((instance: ReactiveElement) => {
+  (attributes: Record<string, string>) => (target: AbstractConstructor<ReactiveElement>) =>
+    (target as typeof ReactiveElement).addInitializer((instance: ReactiveElement) => {
       if (isServer) {
         applyAttributes(instance, attributes);
       } else {
         // It is not allowed to set attributes during constructor phase. Due to this we use a
         // controller to assign the attributes during lit initialization phase.
+        // HostConnected or hostUpdate can be called either order. Due to that we apply in the
+        // first occurrence and directly remove the controller, so it's only called once.
         instance.addController({
           hostConnected() {
+            applyAttributes(instance, attributes);
+            instance.removeController(this);
+          },
+          hostUpdate() {
             applyAttributes(instance, attributes);
             instance.removeController(this);
           },

--- a/src/components/core/common-behaviors/host-attributes.ts
+++ b/src/components/core/common-behaviors/host-attributes.ts
@@ -1,0 +1,45 @@
+import { isServer, type ReactiveElement } from 'lit';
+
+function applyAttributes(instance: ReactiveElement, attributes: Record<string, string>): void {
+  for (const [name, value] of Object.entries(attributes)) {
+    if (value) {
+      instance.setAttribute(name, value);
+    } else {
+      instance.toggleAttribute(name, true);
+    }
+  }
+}
+
+/**
+ * Applies the given attibutes to the related element.
+ * If an empty string is passed as a value, the attribute will be set
+ * without value.
+ *
+ * @example
+ *
+ * @hostAttributes({
+ *   role: 'region'
+ * })
+ * @customElement('my-element)
+ * export class MyElement extends LitElement {
+ *   ...
+ * }
+ *
+ * @param attributes A record of attributes to apply to the element.
+ */
+export const hostAttributes =
+  (attributes: Record<string, string>) => (target: typeof ReactiveElement) =>
+    target.addInitializer((instance: ReactiveElement) => {
+      if (isServer) {
+        applyAttributes(instance, attributes);
+      } else {
+        // It is not allowed to set attributes during constructor phase. Due to this we use a
+        // controller to assign the attributes during lit initialization phase.
+        instance.addController({
+          hostConnected() {
+            applyAttributes(instance, attributes);
+            instance.removeController(this);
+          },
+        });
+      }
+    });

--- a/src/components/core/common-behaviors/index.ts
+++ b/src/components/core/common-behaviors/index.ts
@@ -2,6 +2,7 @@ export * from './action-base-element';
 export * from './button-base-element';
 export * from './constructor';
 export * from './disabled-mixins';
+export * from './host-attributes';
 export * from './hydration-mixin';
 export * from './icon-name-mixin';
 export * from './language-controller';

--- a/src/components/core/common-behaviors/link-base-element.ts
+++ b/src/components/core/common-behaviors/link-base-element.ts
@@ -1,18 +1,23 @@
 import { html, isServer, nothing, type TemplateResult } from 'lit';
 import { property } from 'lit/decorators.js';
 
-import { getDocumentWritingMode } from '../dom';
 import { isEventPrevented } from '../eventing';
 import { i18nTargetOpensInNewWindow } from '../i18n';
 
 import { SbbActionBaseElement } from './action-base-element';
-import '../../screenreader-only';
+import { hostAttributes } from './host-attributes';
 import { LanguageController } from './language-controller';
+
+import '../../screenreader-only';
 
 /** Enumeration for 'target' attribute in <a> HTML tag. */
 export type LinkTargetType = '_blank' | '_self' | '_parent' | '_top';
 
 /** Link base class. */
+@hostAttributes({
+  role: 'link',
+  tabindex: '0',
+})
 export abstract class SbbLinkBaseElement extends SbbActionBaseElement {
   /** The href value you want to link to. */
   @property() public href?: string;
@@ -34,13 +39,6 @@ export abstract class SbbLinkBaseElement extends SbbActionBaseElement {
       this.setupBaseEventHandlers();
       this.addEventListener('click', this._triggerAnchorWhenNecessary);
     }
-  }
-
-  protected override createRenderRoot(): HTMLElement | DocumentFragment {
-    this.setAttribute('role', 'link');
-    this.setAttribute('dir', getDocumentWritingMode());
-    this.setAttribute('tabindex', '0');
-    return super.createRenderRoot();
   }
 
   /**

--- a/src/components/datepicker/datepicker-next-day/datepicker-next-day.ts
+++ b/src/components/datepicker/datepicker-next-day/datepicker-next-day.ts
@@ -6,6 +6,7 @@ import {
   LanguageController,
   SbbNegativeMixin,
   SbbButtonBaseElement,
+  hostAttributes,
 } from '../../core/common-behaviors';
 import { defaultDateAdapter, type DateAdapter } from '../../core/datetime';
 import { isValidAttribute, toggleDatasetEntry } from '../../core/dom';
@@ -24,6 +25,9 @@ import style from './datepicker-next-day.scss?lit&inline';
 /**
  * Combined with a `sbb-datepicker`, it can be used to move the date ahead.
  */
+@hostAttributes({
+  slot: 'suffix',
+})
 @customElement('sbb-datepicker-next-day')
 export class SbbDatepickerNextDayElement extends SbbNegativeMixin(SbbButtonBaseElement) {
   public static override styles: CSSResultGroup = style;
@@ -193,11 +197,6 @@ export class SbbDatepickerNextDayElement extends SbbNegativeMixin(SbbButtonBaseE
       this.removeAttribute('aria-disabled');
       this.setAttribute('tabindex', '0');
     }
-  }
-
-  protected override createRenderRoot(): HTMLElement | DocumentFragment {
-    this.setAttribute('slot', 'suffix');
-    return super.createRenderRoot();
   }
 
   protected override renderTemplate(): TemplateResult {

--- a/src/components/datepicker/datepicker-previous-day/datepicker-previous-day.ts
+++ b/src/components/datepicker/datepicker-previous-day/datepicker-previous-day.ts
@@ -6,6 +6,7 @@ import {
   LanguageController,
   SbbNegativeMixin,
   SbbButtonBaseElement,
+  hostAttributes,
 } from '../../core/common-behaviors';
 import { defaultDateAdapter, type DateAdapter } from '../../core/datetime';
 import { isValidAttribute, toggleDatasetEntry } from '../../core/dom';
@@ -24,6 +25,9 @@ import style from './datepicker-previous-day.scss?lit&inline';
 /**
  * Combined with a `sbb-datepicker`, it can be used to move the date back.
  */
+@hostAttributes({
+  slot: 'prefix',
+})
 @customElement('sbb-datepicker-previous-day')
 export class SbbDatepickerPreviousDayElement extends SbbNegativeMixin(SbbButtonBaseElement) {
   public static override styles: CSSResultGroup = style;
@@ -196,11 +200,6 @@ export class SbbDatepickerPreviousDayElement extends SbbNegativeMixin(SbbButtonB
       this.removeAttribute('aria-disabled');
       this.setAttribute('tabindex', '0');
     }
-  }
-
-  protected override createRenderRoot(): HTMLElement | DocumentFragment {
-    this.setAttribute('slot', 'prefix');
-    return super.createRenderRoot();
   }
 
   protected override renderTemplate(): TemplateResult {

--- a/src/components/datepicker/datepicker-toggle/datepicker-toggle.ts
+++ b/src/components/datepicker/datepicker-toggle/datepicker-toggle.ts
@@ -5,8 +5,8 @@ import { ref } from 'lit/directives/ref.js';
 
 import type { SbbCalendarElement } from '../../calendar';
 import { sbbInputModalityDetector } from '../../core/a11y';
-import { LanguageController, SbbNegativeMixin } from '../../core/common-behaviors';
-import { isValidAttribute, setAttribute } from '../../core/dom';
+import { hostAttributes, LanguageController, SbbNegativeMixin } from '../../core/common-behaviors';
+import { isValidAttribute } from '../../core/dom';
 import { i18nShowCalendar } from '../../core/i18n';
 import type { SbbPopoverElement, SbbPopoverTriggerElement } from '../../popover';
 import { datepickerControlRegisteredEventFactory, getDatePicker } from '../datepicker';
@@ -19,6 +19,9 @@ import style from './datepicker-toggle.scss?lit&inline';
 /**
  * Combined with a `sbb-datepicker`, it can be used to select a date from a `sbb-calendar`.
  */
+@hostAttributes({
+  slot: 'prefix',
+})
 @customElement('sbb-datepicker-toggle')
 export class SbbDatepickerToggleElement extends SbbNegativeMixin(LitElement) {
   public static override styles: CSSResultGroup = style;
@@ -173,7 +176,6 @@ export class SbbDatepickerToggleElement extends SbbNegativeMixin(LitElement) {
   }
 
   protected override render(): TemplateResult {
-    setAttribute(this, 'slot', 'prefix');
     return html`
       <sbb-popover-trigger
         icon-name="calendar-small"

--- a/src/components/divider/divider.ts
+++ b/src/components/divider/divider.ts
@@ -2,7 +2,7 @@ import type { CSSResultGroup, TemplateResult } from 'lit';
 import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { SbbNegativeMixin } from '../core/common-behaviors';
+import { hostAttributes, SbbNegativeMixin } from '../core/common-behaviors';
 import { setAttribute } from '../core/dom';
 import type { SbbOrientation } from '../core/interfaces';
 
@@ -11,6 +11,9 @@ import style from './divider.scss?lit&inline';
 /**
  * It displays a divider between sections.
  */
+@hostAttributes({
+  role: 'separator',
+})
 @customElement('sbb-divider')
 export class SbbDividerElement extends SbbNegativeMixin(LitElement) {
   public static override styles: CSSResultGroup = style;
@@ -19,7 +22,6 @@ export class SbbDividerElement extends SbbNegativeMixin(LitElement) {
   @property({ reflect: true }) public orientation?: SbbOrientation = 'horizontal';
 
   protected override render(): TemplateResult {
-    setAttribute(this, 'role', 'separator');
     setAttribute(this, 'aria-orientation', this.orientation);
 
     return html` <div class="sbb-divider"></div> `;

--- a/src/components/expansion-panel/expansion-panel-content/expansion-panel-content.ts
+++ b/src/components/expansion-panel/expansion-panel-content/expansion-panel-content.ts
@@ -2,6 +2,8 @@ import type { CSSResultGroup, TemplateResult } from 'lit';
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
+import { hostAttributes } from '../../core/common-behaviors';
+
 import style from './expansion-panel-content.scss?lit&inline';
 
 /**
@@ -9,15 +11,13 @@ import style from './expansion-panel-content.scss?lit&inline';
  *
  * @slot - Use the unnamed slot to add content to the `sbb-expansion-panel`.
  */
+@hostAttributes({
+  role: 'region',
+  slot: 'content',
+})
 @customElement('sbb-expansion-panel-content')
 export class SbbExpansionPanelContentElement extends LitElement {
   public static override styles: CSSResultGroup = style;
-
-  protected override createRenderRoot(): HTMLElement | DocumentFragment {
-    this.setAttribute('slot', 'content');
-    this.setAttribute('role', 'region');
-    return super.createRenderRoot();
-  }
 
   protected override render(): TemplateResult {
     return html`

--- a/src/components/expansion-panel/expansion-panel-header/expansion-panel-header.ts
+++ b/src/components/expansion-panel/expansion-panel-header/expansion-panel-header.ts
@@ -7,6 +7,7 @@ import {
   SbbButtonBaseElement,
   SbbDisabledTabIndexActionMixin,
   SbbIconNameMixin,
+  hostAttributes,
 } from '../../core/common-behaviors';
 import { EventEmitter, ConnectedAbortController } from '../../core/eventing';
 import { type SbbExpansionPanelElement } from '../expansion-panel';
@@ -21,6 +22,9 @@ import style from './expansion-panel-header.scss?lit&inline';
  * @slot icon - Slot used to render the `sbb-expansion-panel-header` icon.
  * @event {CustomEvent<void>} toggleExpanded - Notifies that the `sbb-expansion-panel` has to expand.
  */
+@hostAttributes({
+  slot: 'header',
+})
 @customElement('sbb-expansion-panel-header')
 export class SbbExpansionPanelHeaderElement extends SbbDisabledTabIndexActionMixin(
   SbbIconNameMixin(SbbButtonBaseElement),
@@ -47,11 +51,6 @@ export class SbbExpansionPanelHeaderElement extends SbbDisabledTabIndexActionMix
     this.addEventListener('click', () => this._emitExpandedEvent(), { signal });
     this.addEventListener('mouseenter', () => this._onMouseMovement(true), { signal });
     this.addEventListener('mouseleave', () => this._onMouseMovement(false), { signal });
-  }
-
-  protected override createRenderRoot(): HTMLElement | DocumentFragment {
-    this.setAttribute('slot', 'header');
-    return super.createRenderRoot();
   }
 
   private _emitExpandedEvent(): void {

--- a/src/components/form-field/form-field-clear/form-field-clear.ts
+++ b/src/components/form-field/form-field-clear/form-field-clear.ts
@@ -1,4 +1,4 @@
-import type { CSSResultGroup, TemplateResult } from 'lit';
+import type { CSSResultGroup, PropertyValues, TemplateResult } from 'lit';
 import { html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
@@ -6,6 +6,7 @@ import {
   LanguageController,
   SbbButtonBaseElement,
   SbbNegativeMixin,
+  hostAttributes,
 } from '../../core/common-behaviors';
 import { hostContext, isValidAttribute } from '../../core/dom';
 import { ConnectedAbortController } from '../../core/eventing';
@@ -18,6 +19,9 @@ import style from './form-field-clear.scss?lit&inline';
 /**
  * Combined with `sbb-form-field`, it displays a button which clears the input value.
  */
+@hostAttributes({
+  slot: 'suffix',
+})
 @customElement('sbb-form-field-clear')
 export class SbbFormFieldClearElement extends SbbNegativeMixin(SbbButtonBaseElement) {
   public static override styles: CSSResultGroup = style;
@@ -40,20 +44,19 @@ export class SbbFormFieldClearElement extends SbbNegativeMixin(SbbButtonBaseElem
   }
 
   private async _handleClick(): Promise<void> {
-    const input = await this._formField?.getInputElement();
+    const input = this._formField?.inputElement;
     if (!input || input.tagName !== 'INPUT') {
       return;
     }
-    await this._formField?.clear();
+    this._formField?.clear();
     input.focus();
     input.dispatchEvent(new InputEvent('input', { bubbles: true, composed: true }));
     input.dispatchEvent(new Event('change', { bubbles: true }));
   }
 
-  protected override createRenderRoot(): HTMLElement | DocumentFragment {
-    this.setAttribute('slot', 'suffix');
+  protected override willUpdate(changedProperties: PropertyValues<this>): void {
+    super.willUpdate(changedProperties);
     this.setAttribute('aria-label', i18nClearInput[this._language.current]);
-    return super.createRenderRoot();
   }
 
   protected override renderTemplate(): TemplateResult {

--- a/src/components/icon/icon-base.ts
+++ b/src/components/icon/icon-base.ts
@@ -6,9 +6,15 @@ import type { UnsafeHTMLDirective } from 'lit/directives/unsafe-html.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { until } from 'lit/directives/until.js';
 
+import { hostAttributes } from '../core/common-behaviors';
+
 import { getSvgContent } from './icon-request';
 import style from './icon.scss?lit&inline';
 
+@hostAttributes({
+  'data-namespace': SbbIconBase._defaultNamespace,
+  'data-empty': '',
+})
 export abstract class SbbIconBase extends LitElement {
   public static override styles: CSSResultGroup = style;
   private static readonly _defaultNamespace = 'default';
@@ -27,14 +33,6 @@ export abstract class SbbIconBase extends LitElement {
    * @default false
    */
   @property({ attribute: 'no-sanitize', type: Boolean }) public noSanitize = false;
-
-  protected override createRenderRoot(): HTMLElement | DocumentFragment {
-    this.setAttribute('data-namespace', this._svgNamespace);
-    if (!this._svgIcon) {
-      this.toggleAttribute('data-empty', true);
-    }
-    return super.createRenderRoot();
-  }
 
   protected async loadSvgIcon(iconName: string): Promise<void> {
     if (!iconName) {

--- a/src/components/loading-indicator/loading-indicator.ts
+++ b/src/components/loading-indicator/loading-indicator.ts
@@ -2,13 +2,17 @@ import type { CSSResultGroup, TemplateResult } from 'lit';
 import { html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { setAttribute } from '../core/dom';
+import { hostAttributes } from '../core/common-behaviors';
 
 import style from './loading-indicator.scss?lit&inline';
 
 /**
  * It displays a loading indicator.
  */
+@hostAttributes({
+  role: 'progressbar',
+  'aria-busy': 'true',
+})
 @customElement('sbb-loading-indicator')
 export class SbbLoadingIndicatorElement extends LitElement {
   public static override styles: CSSResultGroup = style;
@@ -27,9 +31,6 @@ export class SbbLoadingIndicatorElement extends LitElement {
   public disableAnimation = false;
 
   protected override render(): TemplateResult {
-    setAttribute(this, 'role', 'progressbar');
-    setAttribute(this, 'aria-busy', 'true');
-
     return html`
       <span class="sbb-loading-indicator">
         <span class="sbb-loading-indicator__animated-element">

--- a/src/components/navigation/navigation-section/navigation-section.ts
+++ b/src/components/navigation/navigation-section/navigation-section.ts
@@ -11,6 +11,7 @@ import {
   setModalityOnNextFocus,
 } from '../../core/a11y';
 import {
+  hostAttributes,
   LanguageController,
   NamedSlotStateController,
   UpdateScheduler,
@@ -41,6 +42,9 @@ let nextId = 0;
  *
  * @slot - Use the unnamed slot to add content into the `sbb-navigation-section`.
  */
+@hostAttributes({
+  slot: 'navigation-section',
+})
 @customElement('sbb-navigation-section')
 export class SbbNavigationSectionElement extends UpdateScheduler(LitElement) {
   public static override styles: CSSResultGroup = style;
@@ -356,7 +360,6 @@ export class SbbNavigationSectionElement extends UpdateScheduler(LitElement) {
       accessibilityAttributes = { 'aria-label': this.accessibilityLabel };
     }
 
-    setAttribute(this, 'slot', 'navigation-section');
     setAttribute(this, 'data-state', this._state);
     setAttribute(this, 'aria-hidden', this._state !== 'opened' ? 'true' : null);
     assignId(() => this._navigationSectionId)(this);

--- a/src/components/navigation/navigation/navigation.ts
+++ b/src/components/navigation/navigation/navigation.ts
@@ -4,7 +4,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { ref } from 'lit/directives/ref.js';
 
 import { FocusHandler, assignId, setModalityOnNextFocus } from '../../core/a11y';
-import { LanguageController, UpdateScheduler } from '../../core/common-behaviors';
+import { hostAttributes, LanguageController, UpdateScheduler } from '../../core/common-behaviors';
 import {
   ScrollHandler,
   isValidAttribute,
@@ -43,6 +43,9 @@ let nextId = 0;
  * @event {CustomEvent<void>} willClose - Emits whenever the `sbb-navigation` begins the closing transition. Can be canceled.
  * @event {CustomEvent<void>} didClose - Emits whenever the `sbb-navigation` is closed.
  */
+@hostAttributes({
+  role: 'navigation',
+})
 @customElement('sbb-navigation')
 export class SbbNavigationElement extends UpdateScheduler(LitElement) {
   public static override styles: CSSResultGroup = style;
@@ -344,7 +347,6 @@ export class SbbNavigationElement extends UpdateScheduler(LitElement) {
       ></sbb-button>
     `;
 
-    setAttribute(this, 'role', 'navigation');
     setAttribute(this, 'data-has-navigation-section', !!this._activeNavigationSection);
     setAttribute(this, 'data-state', this._state);
     assignId(() => this._navigationId)(this);

--- a/src/components/option/option/option.ts
+++ b/src/components/option/option/option.ts
@@ -4,6 +4,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 
 import { assignId } from '../../core/a11y';
 import {
+  hostAttributes,
   NamedSlotStateController,
   SbbDisabledMixin,
   SbbIconNameMixin,
@@ -39,6 +40,9 @@ export type SbbOptionVariant = 'autocomplete' | 'select';
  * @event {CustomEvent<void>} optionSelectionChange - Emits when the option selection status changes.
  * @event {CustomEvent<void>} optionSelected - Emits when an option was selected by user.
  */
+@hostAttributes({
+  role: 'option',
+})
 @customElement('sbb-option')
 export class SbbOptionElement extends SbbDisabledMixin(SbbIconNameMixin(LitElement)) {
   public static override styles: CSSResultGroup = style;
@@ -250,7 +254,6 @@ export class SbbOptionElement extends SbbDisabledMixin(SbbIconNameMixin(LitEleme
 
   protected override render(): TemplateResult {
     const isMultiple = this._isMultiple;
-    setAttribute(this, 'role', 'option');
     setAttribute(this, 'tabindex', isAndroid() && !this.disabled && 0);
     setAttribute(this, 'data-variant', this._variant);
     setAttribute(this, 'data-multiple', isMultiple);

--- a/src/components/radio-button/radio-button-group/radio-button-group.ts
+++ b/src/components/radio-button/radio-button-group/radio-button-group.ts
@@ -3,8 +3,12 @@ import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { isArrowKeyPressed, getNextElementIndex } from '../../core/a11y';
-import { NamedSlotStateController, SbbDisabledMixin } from '../../core/common-behaviors';
-import { toggleDatasetEntry, setAttribute } from '../../core/dom';
+import {
+  hostAttributes,
+  NamedSlotStateController,
+  SbbDisabledMixin,
+} from '../../core/common-behaviors';
+import { toggleDatasetEntry } from '../../core/dom';
 import { EventEmitter, ConnectedAbortController } from '../../core/eventing';
 import type { SbbHorizontalFrom, SbbOrientation, SbbStateChange } from '../../core/interfaces';
 import type { SbbSelectionPanelElement } from '../../selection-panel';
@@ -30,6 +34,9 @@ export type SbbRadioButtonGroupEventDetail = {
  * @event {CustomEvent<SbbRadioButtonGroupEventDetail>} change - Emits whenever the `sbb-radio-group` value changes.
  * @event {CustomEvent<SbbRadioButtonGroupEventDetail>} input - Emits whenever the `sbb-radio-group` value changes.
  */
+@hostAttributes({
+  role: 'radiogroup',
+})
 @customElement('sbb-radio-button-group')
 export class SbbRadioButtonGroupElement extends SbbDisabledMixin(LitElement) {
   public static override styles: CSSResultGroup = style;
@@ -269,8 +276,6 @@ export class SbbRadioButtonGroupElement extends SbbDisabledMixin(LitElement) {
   }
 
   protected override render(): TemplateResult {
-    setAttribute(this, 'role', 'radiogroup');
-
     return html`
       <div class="sbb-radio-group">
         <slot @slotchange=${() => this._updateRadios()}></slot>

--- a/src/components/radio-button/radio-button/radio-button.ts
+++ b/src/components/radio-button/radio-button/radio-button.ts
@@ -3,6 +3,7 @@ import { html, LitElement, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 import {
+  hostAttributes,
   LanguageController,
   NamedSlotStateController,
   UpdateScheduler,
@@ -39,6 +40,9 @@ export type SbbRadioButtonSize = 's' | 'm';
  * @slot subtext - Slot used to render a subtext under the label (only visible within a `sbb-selection-panel`).
  * @slot suffix - Slot used to render additional content after the label (only visible within a `sbb-selection-panel`).
  */
+@hostAttributes({
+  role: 'radio',
+})
 @customElement('sbb-radio-button')
 export class SbbRadioButtonElement extends UpdateScheduler(LitElement) {
   public static override styles: CSSResultGroup = style;
@@ -249,7 +253,6 @@ export class SbbRadioButtonElement extends UpdateScheduler(LitElement) {
 
   protected override render(): TemplateResult {
     const attributes = {
-      role: 'radio',
       'aria-checked': this.checked?.toString() ?? 'false',
       'aria-required': this.required.toString(),
       'aria-disabled': this.disabled.toString(),

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -4,7 +4,12 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { ref } from 'lit/directives/ref.js';
 
 import { getNextElementIndex, assignId } from '../core/a11y';
-import { SbbDisabledMixin, SbbNegativeMixin, UpdateScheduler } from '../core/common-behaviors';
+import {
+  hostAttributes,
+  SbbDisabledMixin,
+  SbbNegativeMixin,
+  UpdateScheduler,
+} from '../core/common-behaviors';
 import {
   isSafari,
   isValidAttribute,
@@ -39,6 +44,9 @@ export interface SelectChange {
  * @event {CustomEvent<void>} willClose - Emits whenever the `sbb-select` begins the closing transition. Can be canceled.
  * @event {CustomEvent<void>} didClose - Emits whenever the `sbb-select` is closed.
  */
+@hostAttributes({
+  dir: getDocumentWritingMode(),
+})
 @customElement('sbb-select')
 export class SbbSelectElement extends UpdateScheduler(
   SbbDisabledMixin(SbbNegativeMixin(LitElement)),
@@ -688,7 +696,6 @@ export class SbbSelectElement extends UpdateScheduler(
     setAttribute(this, 'data-state', this._state);
     setAttribute(this, 'data-multiple', this.multiple);
     setAttribute(this, 'role', this._ariaRoleOnHost ? 'listbox' : null);
-    setAttribute(this, 'dir', getDocumentWritingMode());
     this._ariaRoleOnHost && assignId(() => this._overlayId)(this);
 
     return html`

--- a/src/components/slider/slider.ts
+++ b/src/components/slider/slider.ts
@@ -5,7 +5,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { ref } from 'lit/directives/ref.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import { SbbDisabledMixin } from '../core/common-behaviors';
+import { hostAttributes, SbbDisabledMixin } from '../core/common-behaviors';
 import { setAttributes } from '../core/dom';
 import { forwardEventToHost, EventEmitter, ConnectedAbortController } from '../core/eventing';
 
@@ -19,6 +19,9 @@ import '../icon';
  * @slot suffix - Use this slot to render an icon on the right side of the input.
  * @event {CustomEvent<void>} didChange - Deprecated. used for React. Will probably be removed once React 19 is available.
  */
+@hostAttributes({
+  role: 'slider',
+})
 @customElement('sbb-slider')
 export class SbbSliderElement extends SbbDisabledMixin(LitElement) {
   public static override styles: CSSResultGroup = style;
@@ -168,7 +171,6 @@ export class SbbSliderElement extends SbbDisabledMixin(LitElement) {
 
   protected override render(): TemplateResult {
     const hostAttributes = {
-      role: 'slider',
       tabIndex: this.disabled ? null : '0',
       'aria-valuemin': this.min || null,
       'aria-valuemax': this.max || null,

--- a/src/components/timetable-row/timetable-row.ts
+++ b/src/components/timetable-row/timetable-row.ts
@@ -3,9 +3,8 @@ import type { CSSResultGroup, TemplateResult } from 'lit';
 import { html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { LanguageController } from '../core/common-behaviors';
+import { hostAttributes, LanguageController } from '../core/common-behaviors';
 import { removeTimezoneFromISOTimeString, durationToTime } from '../core/datetime';
-import { setAttribute } from '../core/dom';
 import {
   i18nArrival,
   i18nClass,
@@ -270,7 +269,10 @@ export const handleNotices = (notices: Notice[]): Notice[] => {
 
 /**
  * It displays information about the trip, acting as a container for all the `sbb-timetable-*` components.
- * */
+ */
+@hostAttributes({
+  role: 'rowgroup',
+})
 @customElement('sbb-timetable-row')
 export class SbbTimetableRowElement extends LitElement {
   public static override styles: CSSResultGroup = style;
@@ -544,7 +546,6 @@ export class SbbTimetableRowElement extends LitElement {
     const noticeAttributes = notices && handleNotices(notices);
 
     const durationObj = duration ? durationToTime(duration, this._language.current) : null;
-    setAttribute(this, 'role', 'rowgroup');
 
     return html`
       <sbb-card size="l" id=${id}>

--- a/src/components/timetable-row/timetable-row.ts
+++ b/src/components/timetable-row/timetable-row.ts
@@ -3,8 +3,9 @@ import type { CSSResultGroup, TemplateResult } from 'lit';
 import { html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { hostAttributes, LanguageController } from '../core/common-behaviors';
+import { LanguageController } from '../core/common-behaviors';
 import { removeTimezoneFromISOTimeString, durationToTime } from '../core/datetime';
+import { setAttribute } from '../core/dom';
 import {
   i18nArrival,
   i18nClass,
@@ -269,10 +270,7 @@ export const handleNotices = (notices: Notice[]): Notice[] => {
 
 /**
  * It displays information about the trip, acting as a container for all the `sbb-timetable-*` components.
- */
-@hostAttributes({
-  role: 'rowgroup',
-})
+ * */
 @customElement('sbb-timetable-row')
 export class SbbTimetableRowElement extends LitElement {
   public static override styles: CSSResultGroup = style;
@@ -546,6 +544,7 @@ export class SbbTimetableRowElement extends LitElement {
     const noticeAttributes = notices && handleNotices(notices);
 
     const durationObj = duration ? durationToTime(duration, this._language.current) : null;
+    setAttribute(this, 'role', 'rowgroup');
 
     return html`
       <sbb-card size="l" id=${id}>

--- a/src/components/title/title.ts
+++ b/src/components/title/title.ts
@@ -3,7 +3,7 @@ import { LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { html, unsafeStatic } from 'lit/static-html.js';
 
-import { SbbNegativeMixin } from '../core/common-behaviors';
+import { SbbNegativeMixin, hostAttributes } from '../core/common-behaviors';
 
 import style from './title.scss?lit&inline';
 
@@ -14,6 +14,9 @@ export type SbbTitleLevel = '1' | '2' | '3' | '4' | '5' | '6';
  *
  * @slot - Use the unnamed slot to display the title.
  */
+@hostAttributes({
+  role: 'heading',
+})
 @customElement('sbb-title')
 export class SbbTitleElement extends SbbNegativeMixin(LitElement) {
   public static override styles: CSSResultGroup = style;
@@ -39,11 +42,6 @@ export class SbbTitleElement extends SbbNegativeMixin(LitElement) {
     if (changedProperties.has('level')) {
       this.setAttribute('aria-level', this.level);
     }
-  }
-
-  protected override createRenderRoot(): HTMLElement | DocumentFragment {
-    this.setAttribute('role', 'heading');
-    return super.createRenderRoot();
   }
 
   protected override render(): TemplateResult {

--- a/src/components/toggle/toggle-option/toggle-option.ts
+++ b/src/components/toggle/toggle-option/toggle-option.ts
@@ -2,7 +2,11 @@ import type { CSSResultGroup, TemplateResult } from 'lit';
 import { LitElement, html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { NamedSlotStateController, SbbIconNameMixin } from '../../core/common-behaviors';
+import {
+  hostAttributes,
+  NamedSlotStateController,
+  SbbIconNameMixin,
+} from '../../core/common-behaviors';
 import { setAttribute } from '../../core/dom';
 import { ConnectedAbortController, EventEmitter } from '../../core/eventing';
 import type { SbbToggleElement, SbbToggleStateChange } from '../toggle';
@@ -16,6 +20,9 @@ import style from './toggle-option.scss?lit&inline';
  * @slot - Use the unnamed slot to add content to the label of the toggle option.
  * @slot icon - Slot used to render the `sbb-icon`.
  */
+@hostAttributes({
+  role: 'radio',
+})
 @customElement('sbb-toggle-option')
 export class SbbToggleOptionElement extends SbbIconNameMixin(LitElement) {
   public static override styles: CSSResultGroup = style;
@@ -141,7 +148,6 @@ export class SbbToggleOptionElement extends SbbIconNameMixin(LitElement) {
   protected override render(): TemplateResult {
     setAttribute(this, 'aria-checked', (!!this.checked).toString());
     setAttribute(this, 'aria-disabled', this.disabled);
-    setAttribute(this, 'role', 'radio');
 
     return html`
       <input

--- a/src/components/toggle/toggle/toggle.ts
+++ b/src/components/toggle/toggle/toggle.ts
@@ -4,7 +4,8 @@ import { customElement, property } from 'lit/decorators.js';
 import { ref } from 'lit/directives/ref.js';
 
 import { isArrowKeyPressed, getNextElementIndex, interactivityChecker } from '../../core/a11y';
-import { toggleDatasetEntry, setAttribute, isBrowser } from '../../core/dom';
+import { hostAttributes } from '../../core/common-behaviors';
+import { toggleDatasetEntry, isBrowser } from '../../core/dom';
 import { EventEmitter, ConnectedAbortController } from '../../core/eventing';
 import type {
   SbbCheckedStateChange,
@@ -28,6 +29,9 @@ export type SbbToggleStateChange = Extract<
  * @event {CustomEvent<void>} didChange - Deprecated. used for React. Will probably be removed once React 19 is available.
  * @event {CustomEvent<void>} change - Emits whenever the toggle value changes.
  */
+@hostAttributes({
+  role: 'radiogroup',
+})
 @customElement('sbb-toggle')
 export class SbbToggleElement extends LitElement {
   public static override styles: CSSResultGroup = style;
@@ -260,7 +264,6 @@ export class SbbToggleElement extends LitElement {
   }
 
   protected override render(): TemplateResult {
-    setAttribute(this, 'role', 'radiogroup');
     return html`
       <div class="sbb-toggle" ${ref((toggle) => (this._toggleElement = toggle as HTMLElement))}>
         <slot @slotchange=${() => this._updateToggle()}></slot>


### PR DESCRIPTION
This replaces the usage of `createRenderRoot` for setting host attributes and instead uses the initializer functionality from lit to set static attributes.