### PR TITLE
refactor(sbb-navigation): improve active handling and focus

### DIFF
--- a/src/components/navigation/common/navigation-action-common.ts
+++ b/src/components/navigation/common/navigation-action-common.ts
@@ -58,7 +58,7 @@ export const SbbNavigationActionCommonElementMixin = <
           if (
             !this.hasAttribute('data-action-active') &&
             this._navigationMarker &&
-            !this._navigationSection
+            !this.connectedSection
           ) {
             this.marker?.select(
               this as unknown as SbbNavigationButtonElement | SbbNavigationLinkElement,

--- a/src/components/navigation/common/navigation-action-common.ts
+++ b/src/components/navigation/common/navigation-action-common.ts
@@ -3,9 +3,12 @@ import { property } from 'lit/decorators.js';
 import { html } from 'lit/static-html.js';
 
 import type { AbstractConstructor, SbbActionBaseElement } from '../../core/common-behaviors';
-import { hostContext, toggleDatasetEntry } from '../../core/dom';
+import { hostContext } from '../../core/dom';
 import { ConnectedAbortController } from '../../core/eventing';
+import type { SbbNavigationButtonElement } from '../navigation-button';
+import type { SbbNavigationLinkElement } from '../navigation-link';
 import type { SbbNavigationMarkerElement } from '../navigation-marker';
+import type { SbbNavigationSectionElement } from '../navigation-section';
 
 import style from './navigation-action.scss?lit&inline';
 
@@ -14,6 +17,7 @@ export type SbbNavigationActionSize = 's' | 'm' | 'l';
 export declare class SbbNavigationActionCommonElementMixinType {
   public size?: SbbNavigationActionSize;
   public navigationMarker?: SbbNavigationMarkerElement | null;
+  public navigationSection?: SbbNavigationSectionElement | null;
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -33,9 +37,18 @@ export const SbbNavigationActionCommonElementMixin = <
 
     private _abort = new ConnectedAbortController(this);
     private _navigationMarker: SbbNavigationMarkerElement | null = null;
+    private _navigationSection: SbbNavigationSectionElement | null = null;
 
     public get navigationMarker(): SbbNavigationMarkerElement | null {
       return this._navigationMarker;
+    }
+
+    public set navigationSection(navSection: SbbNavigationSectionElement) {
+      this._navigationSection = navSection;
+    }
+
+    public get navigationSection(): SbbNavigationSectionElement | null {
+      return this._navigationSection;
     }
 
     public override connectedCallback(): void {
@@ -44,8 +57,14 @@ export const SbbNavigationActionCommonElementMixin = <
       this.addEventListener(
         'click',
         () => {
-          if (!this.hasAttribute('data-action-active') && this._navigationMarker) {
-            toggleDatasetEntry(this, 'actionActive', true);
+          if (
+            !this.hasAttribute('data-action-active') &&
+            this._navigationMarker &&
+            !this._navigationSection
+          ) {
+            this.navigationMarker?.select(
+              this as unknown as SbbNavigationButtonElement | SbbNavigationLinkElement,
+            );
           }
         },
         { signal },

--- a/src/components/navigation/common/navigation-action-common.ts
+++ b/src/components/navigation/common/navigation-action-common.ts
@@ -3,10 +3,8 @@ import { property } from 'lit/decorators.js';
 import { html } from 'lit/static-html.js';
 
 import type { AbstractConstructor, SbbActionBaseElement } from '../../core/common-behaviors';
-import { hostContext } from '../../core/dom';
+import { hostContext, toggleDatasetEntry } from '../../core/dom';
 import { ConnectedAbortController } from '../../core/eventing';
-import type { SbbNavigationButtonElement } from '../navigation-button';
-import type { SbbNavigationLinkElement } from '../navigation-link';
 import type { SbbNavigationMarkerElement } from '../navigation-marker';
 
 import style from './navigation-action.scss?lit&inline';
@@ -15,8 +13,7 @@ export type SbbNavigationActionSize = 's' | 'm' | 'l';
 
 export declare class SbbNavigationActionCommonElementMixinType {
   public size?: SbbNavigationActionSize;
-  public active: boolean;
-  public navigationMarker: SbbNavigationMarkerElement | null;
+  public navigationMarker?: SbbNavigationMarkerElement | null;
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -34,20 +31,6 @@ export const SbbNavigationActionCommonElementMixin = <
     /** Action size variant. */
     @property({ reflect: true }) public size?: SbbNavigationActionSize = 'l';
 
-    /** Whether the action is active. */
-    @property({ reflect: true, type: Boolean })
-    public set active(value: boolean) {
-      const oldValue = this.active;
-      if (value !== oldValue) {
-        this._active = value;
-        this._handleActiveChange(this.active, oldValue);
-      }
-    }
-    public get active(): boolean {
-      return this._active;
-    }
-    private _active = false;
-
     private _abort = new ConnectedAbortController(this);
     private _navigationMarker: SbbNavigationMarkerElement | null = null;
 
@@ -61,8 +44,8 @@ export const SbbNavigationActionCommonElementMixin = <
       this.addEventListener(
         'click',
         () => {
-          if (!this.active && this._navigationMarker) {
-            this.active = true;
+          if (!this.hasAttribute('data-action-active') && this._navigationMarker) {
+            toggleDatasetEntry(this, 'actionActive', true);
           }
         },
         { signal },
@@ -73,18 +56,6 @@ export const SbbNavigationActionCommonElementMixin = <
         'sbb-navigation-marker',
         this,
       ) as SbbNavigationMarkerElement;
-    }
-
-    // Check whether the `active` attribute has been added or removed from the DOM
-    // and call the `select()` or `reset()` method accordingly.
-    private _handleActiveChange(newValue: boolean, oldValue: boolean): void {
-      if (newValue && !oldValue) {
-        this._navigationMarker?.select(
-          this as unknown as SbbNavigationButtonElement | SbbNavigationLinkElement,
-        );
-      } else if (!newValue && oldValue) {
-        this._navigationMarker?.reset();
-      }
     }
 
     protected override renderTemplate(): TemplateResult {

--- a/src/components/navigation/common/navigation-action-common.ts
+++ b/src/components/navigation/common/navigation-action-common.ts
@@ -3,7 +3,6 @@ import { property } from 'lit/decorators.js';
 import { html } from 'lit/static-html.js';
 
 import type { AbstractConstructor, SbbActionBaseElement } from '../../core/common-behaviors';
-import { hostContext } from '../../core/dom';
 import { ConnectedAbortController } from '../../core/eventing';
 import type { SbbNavigationButtonElement } from '../navigation-button';
 import type { SbbNavigationLinkElement } from '../navigation-link';
@@ -16,8 +15,9 @@ export type SbbNavigationActionSize = 's' | 'm' | 'l';
 
 export declare class SbbNavigationActionCommonElementMixinType {
   public size?: SbbNavigationActionSize;
-  public navigationMarker?: SbbNavigationMarkerElement | null;
-  public navigationSection?: SbbNavigationSectionElement | null;
+  public get marker(): SbbNavigationMarkerElement | null;
+  public get section(): SbbNavigationSectionElement | null;
+  public connectedSection: SbbNavigationSectionElement | null;
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -35,21 +35,19 @@ export const SbbNavigationActionCommonElementMixin = <
     /** Action size variant. */
     @property({ reflect: true }) public size?: SbbNavigationActionSize = 'l';
 
-    private _abort = new ConnectedAbortController(this);
-    private _navigationMarker: SbbNavigationMarkerElement | null = null;
-    private _navigationSection: SbbNavigationSectionElement | null = null;
+    public connectedSection: SbbNavigationSectionElement | null = null;
 
-    public get navigationMarker(): SbbNavigationMarkerElement | null {
+    public get marker(): SbbNavigationMarkerElement | null {
       return this._navigationMarker;
     }
 
-    public set navigationSection(navSection: SbbNavigationSectionElement) {
-      this._navigationSection = navSection;
-    }
-
-    public get navigationSection(): SbbNavigationSectionElement | null {
+    public get section(): SbbNavigationSectionElement | null {
       return this._navigationSection;
     }
+
+    private _abort = new ConnectedAbortController(this);
+    private _navigationMarker: SbbNavigationMarkerElement | null = null;
+    private _navigationSection: SbbNavigationSectionElement | null = null;
 
     public override connectedCallback(): void {
       super.connectedCallback();
@@ -62,7 +60,7 @@ export const SbbNavigationActionCommonElementMixin = <
             this._navigationMarker &&
             !this._navigationSection
           ) {
-            this.navigationMarker?.select(
+            this.marker?.select(
               this as unknown as SbbNavigationButtonElement | SbbNavigationLinkElement,
             );
           }
@@ -71,10 +69,10 @@ export const SbbNavigationActionCommonElementMixin = <
       );
 
       // Check if the current element is nested inside a navigation marker.
-      this._navigationMarker = hostContext(
-        'sbb-navigation-marker',
-        this,
-      ) as SbbNavigationMarkerElement;
+      this._navigationMarker = this.closest('sbb-navigation-marker');
+
+      // Check if the current element is nested inside a navigation section.
+      this._navigationSection = this.closest('sbb-navigation-section');
     }
 
     protected override renderTemplate(): TemplateResult {

--- a/src/components/navigation/common/navigation-action-common.ts
+++ b/src/components/navigation/common/navigation-action-common.ts
@@ -16,6 +16,7 @@ export type SbbNavigationActionSize = 's' | 'm' | 'l';
 export declare class SbbNavigationActionCommonElementMixinType {
   public size?: SbbNavigationActionSize;
   public active: boolean;
+  public navigationMarker: SbbNavigationMarkerElement | null;
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -47,8 +48,12 @@ export const SbbNavigationActionCommonElementMixin = <
     }
     private _active = false;
 
-    private _navigationMarker: SbbNavigationMarkerElement | null = null;
     private _abort = new ConnectedAbortController(this);
+    private _navigationMarker: SbbNavigationMarkerElement | null = null;
+
+    public get navigationMarker(): SbbNavigationMarkerElement | null {
+      return this._navigationMarker;
+    }
 
     public override connectedCallback(): void {
       super.connectedCallback();

--- a/src/components/navigation/common/navigation-action-common.ts
+++ b/src/components/navigation/common/navigation-action-common.ts
@@ -35,12 +35,15 @@ export const SbbNavigationActionCommonElementMixin = <
     /** Action size variant. */
     @property({ reflect: true }) public size?: SbbNavigationActionSize = 'l';
 
+    /** The section that is beign controlled by the action, if any. */
     public connectedSection: SbbNavigationSectionElement | null = null;
 
+    /** The navigation marker in which the action is nested. */
     public get marker(): SbbNavigationMarkerElement | null {
       return this._navigationMarker;
     }
 
+    /** The section in which the action is nested. */
     public get section(): SbbNavigationSectionElement | null {
       return this._navigationSection;
     }

--- a/src/components/navigation/common/navigation-action.scss
+++ b/src/components/navigation/common/navigation-action.scss
@@ -12,7 +12,7 @@
   --sbb-navigation-action-color: var(--sbb-color-cloud);
 }
 
-:host([active]) {
+:host([data-action-active]) {
   --sbb-navigation-action-color: var(--sbb-color-storm);
 
   @include sbb.if-forced-colors {

--- a/src/components/navigation/common/navigation-action.scss
+++ b/src/components/navigation/common/navigation-action.scss
@@ -12,7 +12,7 @@
   --sbb-navigation-action-color: var(--sbb-color-cloud);
 }
 
-:host([data-action-active]) {
+:host(:is([data-action-active], .sbb-active)) {
   --sbb-navigation-action-color: var(--sbb-color-storm);
 
   @include sbb.if-forced-colors {

--- a/src/components/navigation/common/navigation-action.scss
+++ b/src/components/navigation/common/navigation-action.scss
@@ -12,7 +12,7 @@
   --sbb-navigation-action-color: var(--sbb-color-cloud);
 }
 
-:host(:is([data-action-active], .sbb-active)) {
+:host(:is([data-action-active])) {
   --sbb-navigation-action-color: var(--sbb-color-storm);
 
   @include sbb.if-forced-colors {

--- a/src/components/navigation/navigation-button/readme.md
+++ b/src/components/navigation/navigation-button/readme.md
@@ -13,7 +13,7 @@ accepting its associated properties (`type`, `name`, `value` and `form`).
 
 ## State
 
-The navigation button can have an initial active state the can be set by using the class `.sbb-active`.
+The navigation button can have an initial active state which can be set by using the class `.sbb-active`.
 
 ```html
 <sbb-navigation-button class="sbb-active" value="menu" name="menu">Button</sbb-navigation-button>

--- a/src/components/navigation/navigation-button/readme.md
+++ b/src/components/navigation/navigation-button/readme.md
@@ -23,15 +23,16 @@ The component has three different sizes, which can be changed using the `size` p
 
 ## Properties
 
-| Name                | Attribute | Privacy | Type                                   | Default    | Description                                      |
-| ------------------- | --------- | ------- | -------------------------------------- | ---------- | ------------------------------------------------ |
-| `size`              | `size`    | public  | `SbbNavigationActionSize \| undefined` | `'l'`      | Action size variant.                             |
-| `navigationMarker`  | -         | public  | `SbbNavigationMarkerElement \| null`   | `null`     |                                                  |
-| `navigationSection` | -         | public  | `SbbNavigationSectionElement \| null`  | `null`     |                                                  |
-| `type`              | `type`    | public  | `SbbButtonType`                        | `'button'` | The type attribute to use for the button.        |
-| `name`              | `name`    | public  | `string`                               |            | The name of the button element.                  |
-| `value`             | `value`   | public  | `string`                               |            | The value of the button element.                 |
-| `form`              | `form`    | public  | `string \| undefined`                  |            | The <form> element to associate the button with. |
+| Name               | Attribute | Privacy | Type                                   | Default    | Description                                      |
+| ------------------ | --------- | ------- | -------------------------------------- | ---------- | ------------------------------------------------ |
+| `size`             | `size`    | public  | `SbbNavigationActionSize \| undefined` | `'l'`      | Action size variant.                             |
+| `connectedSection` | -         | public  | `SbbNavigationSectionElement \| null`  | `null`     |                                                  |
+| `marker`           | -         | public  | `SbbNavigationMarkerElement \| null`   |            |                                                  |
+| `section`          | -         | public  | `SbbNavigationSectionElement \| null`  |            |                                                  |
+| `type`             | `type`    | public  | `SbbButtonType`                        | `'button'` | The type attribute to use for the button.        |
+| `name`             | `name`    | public  | `string`                               |            | The name of the button element.                  |
+| `value`            | `value`   | public  | `string`                               |            | The value of the button element.                 |
+| `form`             | `form`    | public  | `string \| undefined`                  |            | The <form> element to associate the button with. |
 
 ## Slots
 

--- a/src/components/navigation/navigation-button/readme.md
+++ b/src/components/navigation/navigation-button/readme.md
@@ -31,16 +31,16 @@ The component has three different sizes, which can be changed using the `size` p
 
 ## Properties
 
-| Name               | Attribute | Privacy | Type                                   | Default    | Description                                      |
-| ------------------ | --------- | ------- | -------------------------------------- | ---------- | ------------------------------------------------ |
-| `size`             | `size`    | public  | `SbbNavigationActionSize \| undefined` | `'l'`      | Action size variant.                             |
-| `connectedSection` | -         | public  | `SbbNavigationSectionElement \| null`  | `null`     |                                                  |
-| `marker`           | -         | public  | `SbbNavigationMarkerElement \| null`   |            |                                                  |
-| `section`          | -         | public  | `SbbNavigationSectionElement \| null`  |            |                                                  |
-| `type`             | `type`    | public  | `SbbButtonType`                        | `'button'` | The type attribute to use for the button.        |
-| `name`             | `name`    | public  | `string`                               |            | The name of the button element.                  |
-| `value`            | `value`   | public  | `string`                               |            | The value of the button element.                 |
-| `form`             | `form`    | public  | `string \| undefined`                  |            | The <form> element to associate the button with. |
+| Name               | Attribute | Privacy | Type                                   | Default    | Description                                                 |
+| ------------------ | --------- | ------- | -------------------------------------- | ---------- | ----------------------------------------------------------- |
+| `size`             | `size`    | public  | `SbbNavigationActionSize \| undefined` | `'l'`      | Action size variant.                                        |
+| `connectedSection` | -         | public  | `SbbNavigationSectionElement \| null`  | `null`     | The section that is beign controlled by the action, if any. |
+| `marker`           | -         | public  | `SbbNavigationMarkerElement \| null`   |            | The navigation marker in which the action is nested.        |
+| `section`          | -         | public  | `SbbNavigationSectionElement \| null`  |            | The section in which the action is nested.                  |
+| `type`             | `type`    | public  | `SbbButtonType`                        | `'button'` | The type attribute to use for the button.                   |
+| `name`             | `name`    | public  | `string`                               |            | The name of the button element.                             |
+| `value`            | `value`   | public  | `string`                               |            | The value of the button element.                            |
+| `form`             | `form`    | public  | `string \| undefined`                  |            | The <form> element to associate the button with.            |
 
 ## Slots
 

--- a/src/components/navigation/navigation-button/readme.md
+++ b/src/components/navigation/navigation-button/readme.md
@@ -23,14 +23,15 @@ The component has three different sizes, which can be changed using the `size` p
 
 ## Properties
 
-| Name               | Attribute | Privacy | Type                                   | Default    | Description                                      |
-| ------------------ | --------- | ------- | -------------------------------------- | ---------- | ------------------------------------------------ |
-| `size`             | `size`    | public  | `SbbNavigationActionSize \| undefined` | `'l'`      | Action size variant.                             |
-| `navigationMarker` | -         | public  | `SbbNavigationMarkerElement \| null`   | `null`     |                                                  |
-| `type`             | `type`    | public  | `SbbButtonType`                        | `'button'` | The type attribute to use for the button.        |
-| `name`             | `name`    | public  | `string`                               |            | The name of the button element.                  |
-| `value`            | `value`   | public  | `string`                               |            | The value of the button element.                 |
-| `form`             | `form`    | public  | `string \| undefined`                  |            | The <form> element to associate the button with. |
+| Name                | Attribute | Privacy | Type                                   | Default    | Description                                      |
+| ------------------- | --------- | ------- | -------------------------------------- | ---------- | ------------------------------------------------ |
+| `size`              | `size`    | public  | `SbbNavigationActionSize \| undefined` | `'l'`      | Action size variant.                             |
+| `navigationMarker`  | -         | public  | `SbbNavigationMarkerElement \| null`   | `null`     |                                                  |
+| `navigationSection` | -         | public  | `SbbNavigationSectionElement \| null`  | `null`     |                                                  |
+| `type`              | `type`    | public  | `SbbButtonType`                        | `'button'` | The type attribute to use for the button.        |
+| `name`              | `name`    | public  | `string`                               |            | The name of the button element.                  |
+| `value`             | `value`   | public  | `string`                               |            | The value of the button element.                 |
+| `form`              | `form`    | public  | `string \| undefined`                  |            | The <form> element to associate the button with. |
 
 ## Slots
 

--- a/src/components/navigation/navigation-button/readme.md
+++ b/src/components/navigation/navigation-button/readme.md
@@ -23,14 +23,15 @@ The component has three different sizes, which can be changed using the `size` p
 
 ## Properties
 
-| Name     | Attribute | Privacy | Type                                   | Default    | Description                                      |
-| -------- | --------- | ------- | -------------------------------------- | ---------- | ------------------------------------------------ |
-| `size`   | `size`    | public  | `SbbNavigationActionSize \| undefined` | `'l'`      | Action size variant.                             |
-| `active` | `active`  | public  | `boolean`                              | `false`    | Whether the action is active.                    |
-| `type`   | `type`    | public  | `SbbButtonType`                        | `'button'` | The type attribute to use for the button.        |
-| `name`   | `name`    | public  | `string`                               |            | The name of the button element.                  |
-| `value`  | `value`   | public  | `string`                               |            | The value of the button element.                 |
-| `form`   | `form`    | public  | `string \| undefined`                  |            | The <form> element to associate the button with. |
+| Name               | Attribute | Privacy | Type                                   | Default    | Description                                      |
+| ------------------ | --------- | ------- | -------------------------------------- | ---------- | ------------------------------------------------ |
+| `size`             | `size`    | public  | `SbbNavigationActionSize \| undefined` | `'l'`      | Action size variant.                             |
+| `active`           | `active`  | public  | `boolean`                              | `false`    | Whether the action is active.                    |
+| `navigationMarker` | -         | public  | `SbbNavigationMarkerElement \| null`   | `null`  |                                                  |
+| `type`             | `type`    | public  | `SbbButtonType`                        | `'button'` | The type attribute to use for the button.        |
+| `name`             | `name`    | public  | `string`                               |            | The name of the button element.                  |
+| `value`            | `value`   | public  | `string`                               |            | The value of the button element.                 |
+| `form`             | `form`    | public  | `string \| undefined`                  |            | The <form> element to associate the button with. |
 
 ## Slots
 

--- a/src/components/navigation/navigation-button/readme.md
+++ b/src/components/navigation/navigation-button/readme.md
@@ -26,8 +26,7 @@ The component has three different sizes, which can be changed using the `size` p
 | Name               | Attribute | Privacy | Type                                   | Default    | Description                                      |
 | ------------------ | --------- | ------- | -------------------------------------- | ---------- | ------------------------------------------------ |
 | `size`             | `size`    | public  | `SbbNavigationActionSize \| undefined` | `'l'`      | Action size variant.                             |
-| `active`           | `active`  | public  | `boolean`                              | `false`    | Whether the action is active.                    |
-| `navigationMarker` | -         | public  | `SbbNavigationMarkerElement \| null`   | `null`  |                                                  |
+| `navigationMarker` | -         | public  | `SbbNavigationMarkerElement \| null`   | `null`     |                                                  |
 | `type`             | `type`    | public  | `SbbButtonType`                        | `'button'` | The type attribute to use for the button.        |
 | `name`             | `name`    | public  | `string`                               |            | The name of the button element.                  |
 | `value`            | `value`   | public  | `string`                               |            | The value of the button element.                 |

--- a/src/components/navigation/navigation-button/readme.md
+++ b/src/components/navigation/navigation-button/readme.md
@@ -11,6 +11,14 @@ accepting its associated properties (`type`, `name`, `value` and `form`).
 <sbb-navigation-button value="menu" name="menu">Button</sbb-navigation-button>
 ```
 
+## State
+
+The navigation button can have an initial active state the can be set by using the class `.sbb-active`.
+
+```html
+<sbb-navigation-button class="sbb-active" value="menu" name="menu">Button</sbb-navigation-button>
+```
+
 ## Style
 
 The component has three different sizes, which can be changed using the `size` property (`l`, which is the default, `m` and `s`).

--- a/src/components/navigation/navigation-link/readme.md
+++ b/src/components/navigation/navigation-link/readme.md
@@ -23,14 +23,15 @@ The component has three different sizes, which can be changed using the `size` p
 
 ## Properties
 
-| Name       | Attribute  | Privacy | Type                                    | Default | Description                                                       |
-| ---------- | ---------- | ------- | --------------------------------------- | ------- | ----------------------------------------------------------------- |
-| `size`     | `size`     | public  | `SbbNavigationActionSize \| undefined`  | `'l'`   | Action size variant.                                              |
-| `active`   | `active`   | public  | `boolean`                               | `false` | Whether the action is active.                                     |
-| `href`     | `href`     | public  | `string \| undefined`                   |         | The href value you want to link to.                               |
-| `target`   | `target`   | public  | `LinkTargetType \| string \| undefined` |         | Where to display the linked URL.                                  |
-| `rel`      | `rel`      | public  | `string \| undefined`                   |         | The relationship of the linked URL as space-separated link types. |
-| `download` | `download` | public  | `boolean \| undefined`                  |         | Whether the browser will show the download dialog on click.       |
+| Name               | Attribute  | Privacy | Type                                    | Default | Description                                                       |
+| ------------------ | ---------- | ------- | --------------------------------------- | ------- | ----------------------------------------------------------------- |
+| `size`             | `size`     | public  | `SbbNavigationActionSize \| undefined`  | `'l'`   | Action size variant.                                              |
+| `active`           | `active`   | public  | `boolean`                               | `false` | Whether the action is active.                                     |
+| `navigationMarker` | -          | public  | `SbbNavigationMarkerElement \| null`    | `null`  |                                                                   |
+| `href`             | `href`     | public  | `string \| undefined`                   |         | The href value you want to link to.                               |
+| `target`           | `target`   | public  | `LinkTargetType \| string \| undefined` |         | Where to display the linked URL.                                  |
+| `rel`              | `rel`      | public  | `string \| undefined`                   |         | The relationship of the linked URL as space-separated link types. |
+| `download`         | `download` | public  | `boolean \| undefined`                  |         | Whether the browser will show the download dialog on click.       |
 
 ## Slots
 

--- a/src/components/navigation/navigation-link/readme.md
+++ b/src/components/navigation/navigation-link/readme.md
@@ -11,6 +11,14 @@ accepting its associated properties (`href`, `target`, `rel` and `download`).
 <sbb-navigation-link href="#info" target="_blank">Link</sbb-navigation-link>
 ```
 
+## State
+
+The navigation button can have an initial active state the can be set by using the class `.sbb-active`.
+
+```html
+<sbb-navigation-link class="sbb-active" href="#info" target="_blank">Link</sbb-navigation-link>
+```
+
 ## Style
 
 The component has three different sizes, which can be changed using the `size` property (`l`, which is the default, `m` and `s`).

--- a/src/components/navigation/navigation-link/readme.md
+++ b/src/components/navigation/navigation-link/readme.md
@@ -23,15 +23,16 @@ The component has three different sizes, which can be changed using the `size` p
 
 ## Properties
 
-| Name                | Attribute  | Privacy | Type                                    | Default | Description                                                       |
-| ------------------- | ---------- | ------- | --------------------------------------- | ------- | ----------------------------------------------------------------- |
-| `size`              | `size`     | public  | `SbbNavigationActionSize \| undefined`  | `'l'`   | Action size variant.                                              |
-| `navigationMarker`  | -          | public  | `SbbNavigationMarkerElement \| null`    | `null`  |                                                                   |
-| `navigationSection` | -          | public  | `SbbNavigationSectionElement \| null`   | `null`  |                                                                   |
-| `href`              | `href`     | public  | `string \| undefined`                   |         | The href value you want to link to.                               |
-| `target`            | `target`   | public  | `LinkTargetType \| string \| undefined` |         | Where to display the linked URL.                                  |
-| `rel`               | `rel`      | public  | `string \| undefined`                   |         | The relationship of the linked URL as space-separated link types. |
-| `download`          | `download` | public  | `boolean \| undefined`                  |         | Whether the browser will show the download dialog on click.       |
+| Name               | Attribute  | Privacy | Type                                    | Default | Description                                                       |
+| ------------------ | ---------- | ------- | --------------------------------------- | ------- | ----------------------------------------------------------------- |
+| `size`             | `size`     | public  | `SbbNavigationActionSize \| undefined`  | `'l'`   | Action size variant.                                              |
+| `connectedSection` | -          | public  | `SbbNavigationSectionElement \| null`   | `null`  |                                                                   |
+| `marker`           | -          | public  | `SbbNavigationMarkerElement \| null`    |         |                                                                   |
+| `section`          | -          | public  | `SbbNavigationSectionElement \| null`   |         |                                                                   |
+| `href`             | `href`     | public  | `string \| undefined`                   |         | The href value you want to link to.                               |
+| `target`           | `target`   | public  | `LinkTargetType \| string \| undefined` |         | Where to display the linked URL.                                  |
+| `rel`              | `rel`      | public  | `string \| undefined`                   |         | The relationship of the linked URL as space-separated link types. |
+| `download`         | `download` | public  | `boolean \| undefined`                  |         | Whether the browser will show the download dialog on click.       |
 
 ## Slots
 

--- a/src/components/navigation/navigation-link/readme.md
+++ b/src/components/navigation/navigation-link/readme.md
@@ -26,7 +26,6 @@ The component has three different sizes, which can be changed using the `size` p
 | Name               | Attribute  | Privacy | Type                                    | Default | Description                                                       |
 | ------------------ | ---------- | ------- | --------------------------------------- | ------- | ----------------------------------------------------------------- |
 | `size`             | `size`     | public  | `SbbNavigationActionSize \| undefined`  | `'l'`   | Action size variant.                                              |
-| `active`           | `active`   | public  | `boolean`                               | `false` | Whether the action is active.                                     |
 | `navigationMarker` | -          | public  | `SbbNavigationMarkerElement \| null`    | `null`  |                                                                   |
 | `href`             | `href`     | public  | `string \| undefined`                   |         | The href value you want to link to.                               |
 | `target`           | `target`   | public  | `LinkTargetType \| string \| undefined` |         | Where to display the linked URL.                                  |

--- a/src/components/navigation/navigation-link/readme.md
+++ b/src/components/navigation/navigation-link/readme.md
@@ -34,9 +34,9 @@ The component has three different sizes, which can be changed using the `size` p
 | Name               | Attribute  | Privacy | Type                                    | Default | Description                                                       |
 | ------------------ | ---------- | ------- | --------------------------------------- | ------- | ----------------------------------------------------------------- |
 | `size`             | `size`     | public  | `SbbNavigationActionSize \| undefined`  | `'l'`   | Action size variant.                                              |
-| `connectedSection` | -          | public  | `SbbNavigationSectionElement \| null`   | `null`  |                                                                   |
-| `marker`           | -          | public  | `SbbNavigationMarkerElement \| null`    |         |                                                                   |
-| `section`          | -          | public  | `SbbNavigationSectionElement \| null`   |         |                                                                   |
+| `connectedSection` | -          | public  | `SbbNavigationSectionElement \| null`   | `null`  | The section that is beign controlled by the action, if any.       |
+| `marker`           | -          | public  | `SbbNavigationMarkerElement \| null`    |         | The navigation marker in which the action is nested.              |
+| `section`          | -          | public  | `SbbNavigationSectionElement \| null`   |         | The section in which the action is nested.                        |
 | `href`             | `href`     | public  | `string \| undefined`                   |         | The href value you want to link to.                               |
 | `target`           | `target`   | public  | `LinkTargetType \| string \| undefined` |         | Where to display the linked URL.                                  |
 | `rel`              | `rel`      | public  | `string \| undefined`                   |         | The relationship of the linked URL as space-separated link types. |

--- a/src/components/navigation/navigation-link/readme.md
+++ b/src/components/navigation/navigation-link/readme.md
@@ -13,7 +13,7 @@ accepting its associated properties (`href`, `target`, `rel` and `download`).
 
 ## State
 
-The navigation button can have an initial active state the can be set by using the class `.sbb-active`.
+The navigation button can have an initial active state which can be set by using the class `.sbb-active`.
 
 ```html
 <sbb-navigation-link class="sbb-active" href="#info" target="_blank">Link</sbb-navigation-link>

--- a/src/components/navigation/navigation-link/readme.md
+++ b/src/components/navigation/navigation-link/readme.md
@@ -23,14 +23,15 @@ The component has three different sizes, which can be changed using the `size` p
 
 ## Properties
 
-| Name               | Attribute  | Privacy | Type                                    | Default | Description                                                       |
-| ------------------ | ---------- | ------- | --------------------------------------- | ------- | ----------------------------------------------------------------- |
-| `size`             | `size`     | public  | `SbbNavigationActionSize \| undefined`  | `'l'`   | Action size variant.                                              |
-| `navigationMarker` | -          | public  | `SbbNavigationMarkerElement \| null`    | `null`  |                                                                   |
-| `href`             | `href`     | public  | `string \| undefined`                   |         | The href value you want to link to.                               |
-| `target`           | `target`   | public  | `LinkTargetType \| string \| undefined` |         | Where to display the linked URL.                                  |
-| `rel`              | `rel`      | public  | `string \| undefined`                   |         | The relationship of the linked URL as space-separated link types. |
-| `download`         | `download` | public  | `boolean \| undefined`                  |         | Whether the browser will show the download dialog on click.       |
+| Name                | Attribute  | Privacy | Type                                    | Default | Description                                                       |
+| ------------------- | ---------- | ------- | --------------------------------------- | ------- | ----------------------------------------------------------------- |
+| `size`              | `size`     | public  | `SbbNavigationActionSize \| undefined`  | `'l'`   | Action size variant.                                              |
+| `navigationMarker`  | -          | public  | `SbbNavigationMarkerElement \| null`    | `null`  |                                                                   |
+| `navigationSection` | -          | public  | `SbbNavigationSectionElement \| null`   | `null`  |                                                                   |
+| `href`              | `href`     | public  | `string \| undefined`                   |         | The href value you want to link to.                               |
+| `target`            | `target`   | public  | `LinkTargetType \| string \| undefined` |         | Where to display the linked URL.                                  |
+| `rel`               | `rel`      | public  | `string \| undefined`                   |         | The relationship of the linked URL as space-separated link types. |
+| `download`          | `download` | public  | `boolean \| undefined`                  |         | Whether the browser will show the download dialog on click.       |
 
 ## Slots
 

--- a/src/components/navigation/navigation-marker/navigation-marker.e2e.ts
+++ b/src/components/navigation/navigation-marker/navigation-marker.e2e.ts
@@ -32,14 +32,14 @@ describe('sbb-navigation-marker', () => {
     secondAction.click();
     await waitForLitRender(element);
 
-    expect(secondAction).to.have.attribute('active');
-    expect(firstAction).not.to.have.attribute('active');
+    expect(secondAction).to.have.attribute('data-action-active');
+    expect(firstAction).not.to.have.attribute('data-action-active');
 
     firstAction.click();
     await waitForLitRender(element);
 
-    expect(firstAction).to.have.attribute('active');
-    expect(secondAction).not.to.have.attribute('active');
+    expect(firstAction).to.have.attribute('data-action-active');
+    expect(secondAction).not.to.have.attribute('data-action-active');
   });
 
   it('automatic list generation', () => {

--- a/src/components/navigation/navigation-marker/navigation-marker.stories.ts
+++ b/src/components/navigation/navigation-marker/navigation-marker.stories.ts
@@ -1,7 +1,7 @@
 import type { InputType } from '@storybook/types';
 import type { Meta, StoryObj, ArgTypes, Args } from '@storybook/web-components';
 import type { TemplateResult } from 'lit';
-import { html } from 'lit';
+import { html, nothing } from 'lit';
 import type { StyleInfo } from 'lit/directives/style-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
@@ -34,7 +34,7 @@ const style: Readonly<StyleInfo> = {
 
 const navigationActionsL = (active: boolean): TemplateResult => html`
   <sbb-navigation-button id="nav-1">Tickets & Offers</sbb-navigation-button>
-  <sbb-navigation-button id="nav-2" ?active=${active}>
+  <sbb-navigation-button id="nav-2" class=${active ? 'sbb-active' : nothing}>
     Vacations & Recreation
   </sbb-navigation-button>
   <sbb-navigation-button id="nav-3">Travel information</sbb-navigation-button>
@@ -44,7 +44,9 @@ const navigationActionsL = (active: boolean): TemplateResult => html`
 const navigationActionsS = (active: boolean): TemplateResult => html`
   <sbb-navigation-button id="nav-5">Deutsch</sbb-navigation-button>
   <sbb-navigation-button id="nav-6">Français</sbb-navigation-button>
-  <sbb-navigation-button id="nav-7" ?active=${active}> Italiano </sbb-navigation-button>
+  <sbb-navigation-button id="nav-7" class=${active ? 'sbb-active' : nothing}>
+    Italiano
+  </sbb-navigation-button>
   <sbb-navigation-button id="nav-8">English</sbb-navigation-button>
 `;
 

--- a/src/components/navigation/navigation-marker/navigation-marker.ts
+++ b/src/components/navigation/navigation-marker/navigation-marker.ts
@@ -2,6 +2,7 @@ import { type CSSResultGroup, LitElement, type PropertyValues, type TemplateResu
 import { customElement, property, state } from 'lit/decorators.js';
 
 import { SbbNamedSlotListElementMixin, type WithListChildren } from '../../core/common-behaviors';
+import { toggleDatasetEntry } from '../../core/dom';
 import { AgnosticResizeObserver } from '../../core/observers';
 import type { SbbNavigationButtonElement, SbbNavigationLinkElement } from '../index';
 
@@ -44,8 +45,8 @@ export class SbbNavigationMarkerElement extends SbbNamedSlotListElementMixin<
       action.size = this.size;
     }
 
-    this._currentActiveAction = this.listChildren.find(
-      (action) => action.active ?? action.getAttribute('active'),
+    this._currentActiveAction = this.listChildren.find((action) =>
+      action.hasAttribute('data-action-active'),
     );
     this._setMarkerPosition();
   }
@@ -62,7 +63,7 @@ export class SbbNavigationMarkerElement extends SbbNamedSlotListElementMixin<
 
   public select(action: SbbNavigationButtonElement | SbbNavigationLinkElement): void {
     this.reset();
-    action.active = true;
+    toggleDatasetEntry(action, 'actionActive', true);
     this._currentActiveAction = action;
     setTimeout(() => this._setMarkerPosition());
   }
@@ -74,7 +75,7 @@ export class SbbNavigationMarkerElement extends SbbNamedSlotListElementMixin<
 
   public reset(): void {
     if (this._currentActiveAction) {
-      this._currentActiveAction.active = false;
+      toggleDatasetEntry(this._currentActiveAction, 'actionActive', false);
       this._currentActiveAction = undefined;
     }
   }

--- a/src/components/navigation/navigation-marker/navigation-marker.ts
+++ b/src/components/navigation/navigation-marker/navigation-marker.ts
@@ -60,7 +60,9 @@ export class SbbNavigationMarkerElement extends SbbNamedSlotListElementMixin<
     const activeAction = this.querySelector(
       ':is(sbb-navigation-button, sbb-navigation-link).sbb-active',
     ) as SbbNavigationButtonElement | SbbNavigationLinkElement;
-    activeAction && this.select(activeAction);
+    if (activeAction) {
+      this.select(activeAction);
+    }
   }
 
   public override disconnectedCallback(): void {
@@ -86,6 +88,7 @@ export class SbbNavigationMarkerElement extends SbbNamedSlotListElementMixin<
   public reset(): void {
     if (this._currentActiveAction) {
       this._currentActiveAction.toggleAttribute('data-action-active', false);
+      this._currentActiveAction.connectedSection?.close();
       this._currentActiveAction = undefined;
     }
   }

--- a/src/components/navigation/navigation-marker/navigation-marker.ts
+++ b/src/components/navigation/navigation-marker/navigation-marker.ts
@@ -2,7 +2,6 @@ import { type CSSResultGroup, LitElement, type PropertyValues, type TemplateResu
 import { customElement, property, state } from 'lit/decorators.js';
 
 import { SbbNamedSlotListElementMixin, type WithListChildren } from '../../core/common-behaviors';
-import { toggleDatasetEntry } from '../../core/dom';
 import { AgnosticResizeObserver } from '../../core/observers';
 import type { SbbNavigationButtonElement, SbbNavigationLinkElement } from '../index';
 
@@ -54,6 +53,14 @@ export class SbbNavigationMarkerElement extends SbbNamedSlotListElementMixin<
   public override connectedCallback(): void {
     super.connectedCallback();
     this._navigationMarkerResizeObserver.observe(this);
+    this._checkActiveAction();
+  }
+
+  private _checkActiveAction(): void {
+    const activeAction = this.querySelector(
+      ':is(sbb-navigation-button, sbb-navigation-link).sbb-active',
+    ) as SbbNavigationButtonElement | SbbNavigationLinkElement;
+    activeAction && this.select(activeAction);
   }
 
   public override disconnectedCallback(): void {
@@ -62,8 +69,11 @@ export class SbbNavigationMarkerElement extends SbbNamedSlotListElementMixin<
   }
 
   public select(action: SbbNavigationButtonElement | SbbNavigationLinkElement): void {
+    if (!action) {
+      return;
+    }
     this.reset();
-    toggleDatasetEntry(action, 'actionActive', true);
+    action.toggleAttribute('data-action-active', true);
     this._currentActiveAction = action;
     setTimeout(() => this._setMarkerPosition());
   }
@@ -75,7 +85,7 @@ export class SbbNavigationMarkerElement extends SbbNamedSlotListElementMixin<
 
   public reset(): void {
     if (this._currentActiveAction) {
-      toggleDatasetEntry(this._currentActiveAction, 'actionActive', false);
+      this._currentActiveAction.toggleAttribute('data-action-active', false);
       this._currentActiveAction = undefined;
     }
   }

--- a/src/components/navigation/navigation-section/navigation-section.stories.ts
+++ b/src/components/navigation/navigation-section/navigation-section.stories.ts
@@ -8,7 +8,6 @@ import { html } from 'lit';
 
 import { waitForComponentsReady } from '../../../storybook/testing/wait-for-components-ready';
 import { sbbSpread } from '../../core/dom';
-import type { SbbNavigationMarkerElement, SbbNavigationElement } from '../index';
 
 import readme from './readme.md?raw';
 import '../../button/secondary-button';
@@ -100,12 +99,6 @@ const DefaultTemplate = (args: Args): TemplateResult => html`
     id="navigation"
     trigger="navigation-trigger-1"
     ?disable-animation=${args['disable-animation']}
-    @didClose=${(event: CustomEvent) =>
-      (
-        (event.currentTarget as SbbNavigationElement).querySelector(
-          '#nav-marker',
-        ) as SbbNavigationMarkerElement
-      ).reset()}
   >
     <sbb-navigation-marker id="nav-marker">${navigationActionsL()}</sbb-navigation-marker>
 

--- a/src/components/navigation/navigation-section/navigation-section.ts
+++ b/src/components/navigation/navigation-section/navigation-section.ts
@@ -239,7 +239,7 @@ export class SbbNavigationSectionElement extends UpdateScheduler(LitElement) {
       () => {
         this._renderBackButton = this._isZeroToLargeBreakpoint();
       },
-      { signal: this._windowEventsController.signal },
+      { passive: true, signal: this._windowEventsController.signal },
     );
   }
 

--- a/src/components/navigation/navigation-section/navigation-section.ts
+++ b/src/components/navigation/navigation-section/navigation-section.ts
@@ -30,7 +30,6 @@ import {
 } from '../../core/overlay';
 import type { SbbNavigationElement } from '../navigation';
 import type { SbbNavigationButtonElement } from '../navigation-button';
-import type { SbbNavigationMarkerElement } from '../navigation-marker';
 import '../../divider';
 import '../../button/transparent-button';
 
@@ -127,7 +126,7 @@ export class SbbNavigationSectionElement extends UpdateScheduler(LitElement) {
   }
 
   private _setActiveNavigationAction(): void {
-    this._triggerElement?.navigationMarker?.select(this._triggerElement);
+    this._triggerElement?.marker?.select(this._triggerElement);
   }
 
   private _closePreviousNavigationSection(): void {
@@ -142,7 +141,6 @@ export class SbbNavigationSectionElement extends UpdateScheduler(LitElement) {
       return;
     }
 
-    this._resetMarker();
     this._state = 'closing';
     this.startUpdate();
     this.inert = true;
@@ -183,7 +181,7 @@ export class SbbNavigationSectionElement extends UpdateScheduler(LitElement) {
     );
     this._navigationSectionController?.abort();
     this._navigationSectionController = new AbortController();
-    this._triggerElement.navigationSection = this;
+    this._triggerElement.connectedSection = this;
     this._triggerElement.addEventListener('click', () => this.open(), {
       signal: this._navigationSectionController.signal,
     });
@@ -268,12 +266,6 @@ export class SbbNavigationSectionElement extends UpdateScheduler(LitElement) {
     return isBreakpoint('zero', 'large');
   }
 
-  private _resetMarker(): void {
-    if (this._isZeroToLargeBreakpoint()) {
-      (this._triggerElement?.parentElement as SbbNavigationMarkerElement)?.reset();
-    }
-  }
-
   // Closes the navigation on "Esc" key pressed.
   private _onKeydownEvent(event: KeyboardEvent): void {
     if (this._state === 'opened' && event.key === 'Escape') {
@@ -283,10 +275,12 @@ export class SbbNavigationSectionElement extends UpdateScheduler(LitElement) {
 
   // Set focus on the first focusable element.
   private _setNavigationSectionFocus(): void {
+    const activeAction = this.querySelector(
+      ':is(sbb-navigation-button, sbb-navigation-link).sbb-active',
+    ) as HTMLElement;
+    activeAction?.toggleAttribute('data-action-active', true);
     const firstFocusableElement =
-      (this.querySelector(
-        ':is(sbb-navigation-button, sbb-navigation-link).sbb-active',
-      ) as HTMLElement) ||
+      activeAction ||
       getFirstFocusableElement(
         [this.shadowRoot!.querySelector('#sbb-navigation-section-back-button')]
           .concat(Array.from(this.children))

--- a/src/components/navigation/navigation-section/navigation-section.ts
+++ b/src/components/navigation/navigation-section/navigation-section.ts
@@ -29,6 +29,7 @@ import {
   setAriaOverlayTriggerAttributes,
 } from '../../core/overlay';
 import type { SbbNavigationElement } from '../navigation';
+import type { SbbNavigationButtonElement } from '../navigation-button';
 import type { SbbNavigationMarkerElement } from '../navigation-marker';
 import '../../divider';
 import '../../button/transparent-button';
@@ -97,7 +98,7 @@ export class SbbNavigationSectionElement extends UpdateScheduler(LitElement) {
   private _firstLevelNavigation?: SbbNavigationElement | null = null;
   private _navigationSection!: HTMLElement;
   private _navigationSectionContainerElement!: HTMLElement;
-  private _triggerElement: HTMLElement | null = null;
+  private _triggerElement: SbbNavigationButtonElement | null = null;
   private _navigationSectionController!: AbortController;
   private _windowEventsController!: AbortController;
   private _navigationSectionId = `sbb-navigation-section-${++nextId}`;
@@ -116,11 +117,21 @@ export class SbbNavigationSectionElement extends UpdateScheduler(LitElement) {
       return;
     }
 
+    this._setActiveNavigationAction();
+    this._closePreviousNavigationSection();
     this._state = 'opening';
     this.startUpdate();
     this.inert = true;
     this._renderBackButton = this._isZeroToLargeBreakpoint();
     this._triggerElement?.setAttribute('aria-expanded', 'true');
+  }
+
+  private _setActiveNavigationAction(): void {
+    this._triggerElement?.navigationMarker?.select(this._triggerElement);
+  }
+
+  private _closePreviousNavigationSection(): void {
+    (this._firstLevelNavigation?.activeNavigationSection as SbbNavigationSectionElement)?.close();
   }
 
   /**
@@ -244,15 +255,7 @@ export class SbbNavigationSectionElement extends UpdateScheduler(LitElement) {
   };
 
   private _isCloseElement(element: HTMLElement): boolean {
-    // Check if the element is a navigation action belonging to the same group as the trigger.
-    const isActionElement =
-      element !== this._triggerElement &&
-      (element.nodeName === 'SBB-NAVIGATION-BUTTON' ||
-        element.nodeName === 'SBB-NAVIGATION-LINK') &&
-      element.parentElement === this._triggerElement?.parentElement;
-
     return (
-      isActionElement ||
       element.nodeName === 'A' ||
       (!isValidAttribute(element, 'disabled') &&
         (element.hasAttribute('sbb-navigation-close') ||

--- a/src/components/navigation/navigation-section/navigation-section.ts
+++ b/src/components/navigation/navigation-section/navigation-section.ts
@@ -183,6 +183,7 @@ export class SbbNavigationSectionElement extends UpdateScheduler(LitElement) {
     );
     this._navigationSectionController?.abort();
     this._navigationSectionController = new AbortController();
+    this._triggerElement.navigationSection = this;
     this._triggerElement.addEventListener('click', () => this.open(), {
       signal: this._navigationSectionController.signal,
     });
@@ -282,11 +283,15 @@ export class SbbNavigationSectionElement extends UpdateScheduler(LitElement) {
 
   // Set focus on the first focusable element.
   private _setNavigationSectionFocus(): void {
-    const firstFocusableElement = getFirstFocusableElement(
-      [this.shadowRoot!.querySelector('#sbb-navigation-section-back-button')]
-        .concat(Array.from(this.children))
-        .filter((e): e is HTMLElement => e instanceof window.HTMLElement),
-    );
+    const firstFocusableElement =
+      (this.querySelector(
+        ':is(sbb-navigation-button, sbb-navigation-link).sbb-active',
+      ) as HTMLElement) ||
+      getFirstFocusableElement(
+        [this.shadowRoot!.querySelector('#sbb-navigation-section-back-button')]
+          .concat(Array.from(this.children))
+          .filter((e): e is HTMLElement => e instanceof window.HTMLElement),
+      );
     if (firstFocusableElement) {
       setModalityOnNextFocus(firstFocusableElement);
       firstFocusableElement.focus();

--- a/src/components/navigation/navigation/navigation.e2e.ts
+++ b/src/components/navigation/navigation/navigation.e2e.ts
@@ -54,6 +54,99 @@ describe('sbb-navigation', () => {
     expect(element).to.have.attribute('data-state', 'opened');
   });
 
+  it('sets the initial active actions and focuses on the first one', async () => {
+    element = await fixture(html`
+      <sbb-navigation id="navigation" disable-animation>
+        <sbb-navigation-marker>
+          <sbb-navigation-button>Tickets & Offers</sbb-navigation-button>
+          <sbb-navigation-button id="action-active-1" class="sbb-active"
+            >Vacations & Recreation</sbb-navigation-button
+          >
+        </sbb-navigation-marker>
+
+        <sbb-navigation-marker>
+          <sbb-navigation-button id="action-active-2" class="sbb-active"
+            >English</sbb-navigation-button
+          >
+          <sbb-navigation-button>German</sbb-navigation-button>
+        </sbb-navigation-marker>
+      </sbb-navigation>
+    `);
+
+    const didOpenEventSpy = new EventSpy(SbbNavigationElement.events.didOpen);
+    const action2: SbbNavigationButtonElement = document.querySelector<SbbNavigationButtonElement>(
+      'sbb-navigation > sbb-navigation-marker > sbb-navigation-button#action-active-1',
+    )!;
+    const action3: SbbNavigationButtonElement = document.querySelector<SbbNavigationButtonElement>(
+      'sbb-navigation > sbb-navigation-marker > sbb-navigation-button#action-active-2',
+    )!;
+
+    element.open();
+    await waitForLitRender(element);
+
+    await waitForCondition(() => didOpenEventSpy.events.length === 1);
+    expect(didOpenEventSpy.count).to.be.equal(1);
+    await waitForLitRender(element);
+
+    expect(element).to.have.attribute('data-state', 'opened');
+
+    await waitForLitRender(element);
+
+    expect(action2).to.have.attribute('data-action-active');
+    expect(action3).to.have.attribute('data-action-active');
+    expect(document.activeElement?.id).to.be.equal('action-active-1');
+  });
+
+  it('sets the initial active action, opens the connected section and focuses on the first active action in the section', async () => {
+    element = await fixture(html`
+      <sbb-navigation id="navigation" disable-animation>
+        <sbb-navigation-marker>
+          <sbb-navigation-button>Tickets & Offers</sbb-navigation-button>
+          <sbb-navigation-button id="action-active" class="sbb-active"
+            >Vacations & Recreation</sbb-navigation-button
+          >
+        </sbb-navigation-marker>
+
+        <sbb-navigation-section trigger="action-active" id="active-section" disable-animation>
+          <sbb-navigation-button>Label</sbb-navigation-button>
+          <sbb-navigation-button id="section-action-active" class="sbb-active"
+            >Label</sbb-navigation-button
+          >
+        </sbb-navigation-section>
+      </sbb-navigation>
+    `);
+
+    const didOpenEventSpy = new EventSpy(SbbNavigationElement.events.didOpen);
+    const actionActive: SbbNavigationButtonElement =
+      document.querySelector<SbbNavigationButtonElement>(
+        'sbb-navigation > sbb-navigation-marker > sbb-navigation-button#action-active',
+      )!;
+    const sectionActionActive: SbbNavigationButtonElement =
+      document.querySelector<SbbNavigationButtonElement>(
+        'sbb-navigation > sbb-navigation-section > sbb-navigation-button#section-action-active',
+      )!;
+    const activeSection: SbbNavigationButtonElement =
+      document.querySelector<SbbNavigationButtonElement>(
+        'sbb-navigation > sbb-navigation-section#active-section',
+      )!;
+
+    element.open();
+    await waitForLitRender(element);
+
+    await waitForCondition(() => didOpenEventSpy.events.length === 1);
+    expect(didOpenEventSpy.count).to.be.equal(1);
+    await waitForLitRender(element);
+
+    expect(element).to.have.attribute('data-state', 'opened');
+
+    await waitForLitRender(element);
+
+    expect(actionActive).to.have.attribute('data-action-active');
+    expect(sectionActionActive).to.have.attribute('data-action-active');
+    expect(activeSection).to.have.attribute('data-state', 'opened');
+    expect(document.activeElement?.id).to.be.equal('section-action-active');
+  });
+
   it('closes the navigation', async () => {
     const didOpenEventSpy = new EventSpy(SbbNavigationElement.events.didOpen);
     const didCloseEventSpy = new EventSpy(SbbNavigationElement.events.didClose);

--- a/src/components/navigation/navigation/navigation.stories.ts
+++ b/src/components/navigation/navigation/navigation.stories.ts
@@ -16,7 +16,6 @@ import { html, nothing } from 'lit';
 
 import { waitForComponentsReady } from '../../../storybook/testing/wait-for-components-ready';
 import { sbbSpread } from '../../core/dom';
-import type { SbbNavigationMarkerElement } from '../navigation-marker';
 
 import { SbbNavigationElement } from './navigation';
 import readme from './readme.md?raw';
@@ -151,21 +150,12 @@ const actionLabels = (num: number): TemplateResult[] => {
   return labels;
 };
 
-const onNavigationClose = (event: CustomEvent): void => {
-  (
-    (event.currentTarget as SbbNavigationElement).querySelector(
-      '#nav-marker',
-    ) as SbbNavigationMarkerElement
-  ).reset();
-};
-
 const DefaultTemplate = (args: Args): TemplateResult => html`
   ${triggerButton('navigation-trigger-1')}
   <sbb-navigation
     data-testid="navigation"
     id="navigation"
     trigger="navigation-trigger-1"
-    @didClose=${onNavigationClose}
     ${sbbSpread(args)}
   >
     <sbb-navigation-marker id="nav-marker">${navigationActionsL()}</sbb-navigation-marker>
@@ -192,7 +182,6 @@ const WithNavigationSectionTemplate = (args: Args): TemplateResult => html`
     data-testid="navigation"
     id="navigation"
     trigger="navigation-trigger-1"
-    @didClose=${onNavigationClose}
     ${sbbSpread(args)}
   >
     <sbb-navigation-marker id="nav-marker">${navigationActionsL()}</sbb-navigation-marker>

--- a/src/components/navigation/navigation/navigation.stories.ts
+++ b/src/components/navigation/navigation/navigation.stories.ts
@@ -12,7 +12,7 @@ import type {
 } from '@storybook/web-components';
 import isChromatic from 'chromatic';
 import type { TemplateResult } from 'lit';
-import { html } from 'lit';
+import { html, nothing } from 'lit';
 
 import { waitForComponentsReady } from '../../../storybook/testing/wait-for-components-ready';
 import { sbbSpread } from '../../core/dom';
@@ -113,7 +113,9 @@ const navigationActionsL = (): TemplateResult => html`
   <sbb-navigation-button id="nav-1" data-testid="navigation-section-trigger-1">
     Tickets & Offers
   </sbb-navigation-button>
-  <sbb-navigation-button id="nav-2">Vacations & Recreation</sbb-navigation-button>
+  <sbb-navigation-button id="nav-2" class="sbb-active"
+    >Vacations & Recreation</sbb-navigation-button
+  >
   <sbb-navigation-button id="nav-3">Travel information</sbb-navigation-button>
   <sbb-navigation-link id="nav-4" href="https://www.sbb.ch/en/">
     Help & Contact
@@ -123,15 +125,21 @@ const navigationActionsL = (): TemplateResult => html`
 const navigationActionsS = (): TemplateResult => html`
   <sbb-navigation-button id="nav-5">Deutsch</sbb-navigation-button>
   <sbb-navigation-button id="nav-6">Français</sbb-navigation-button>
-  <sbb-navigation-button id="nav-7" active> Italiano </sbb-navigation-button>
+  <sbb-navigation-button id="nav-7" class="sbb-active">Italiano</sbb-navigation-button>
   <sbb-navigation-button id="nav-8">English</sbb-navigation-button>
 `;
 
-const navigationList = (label: string): TemplateResult => html`
+const navigationList = (label: string, active?: boolean): TemplateResult => html`
   <sbb-navigation-list label=${label}>
     <sbb-navigation-button size="m">Label</sbb-navigation-button>
     <sbb-navigation-button size="m">Label</sbb-navigation-button>
-    <sbb-navigation-link size="m" href="https://www.sbb.ch/en/"> Label </sbb-navigation-link>
+    <sbb-navigation-link
+      size="m"
+      href="https://www.sbb.ch/en/"
+      class=${active ? 'sbb-active' : nothing}
+    >
+      Label
+    </sbb-navigation-link>
   </sbb-navigation-list>
 `;
 
@@ -206,7 +214,7 @@ const WithNavigationSectionTemplate = (args: Args): TemplateResult => html`
       title-content="Title two"
       ?disable-animation=${args['disable-animation']}
     >
-      ${navigationList('Label')} ${navigationList('Label')} ${navigationList('Label')}
+      ${navigationList('Label', true)} ${navigationList('Label')} ${navigationList('Label')}
       ${navigationList('Label')} ${navigationList('Label')} ${navigationList('Label')}
     </sbb-navigation-section>
 

--- a/src/components/navigation/navigation/navigation.ts
+++ b/src/components/navigation/navigation/navigation.ts
@@ -97,6 +97,10 @@ export class SbbNavigationElement extends UpdateScheduler(LitElement) {
    */
   @state() private _activeNavigationSection: HTMLElement | null = null;
 
+  public get activeNavigationSection(): HTMLElement | null {
+    return this._activeNavigationSection;
+  }
+
   /** Emits whenever the `sbb-navigation` begins the opening transition. */
   private _willOpen: EventEmitter<void> = new EventEmitter(
     this,

--- a/src/components/navigation/navigation/navigation.ts
+++ b/src/components/navigation/navigation/navigation.ts
@@ -10,7 +10,6 @@ import {
   isValidAttribute,
   findReferencedElement,
   setAttribute,
-  toggleDatasetEntry,
 } from '../../core/dom';
 import { EventEmitter, ConnectedAbortController } from '../../core/eventing';
 import { i18nCloseNavigation } from '../../core/i18n';
@@ -172,15 +171,9 @@ export class SbbNavigationElement extends UpdateScheduler(LitElement) {
     activeActions.forEach((action: SbbNavigationActionCommonElementMixinType) => {
       if (action.navigationSection) {
         action.navigationSection.open();
-      } else if (action.navigationMarker) {
-        action.navigationMarker.select(
-          action as SbbNavigationButtonElement | SbbNavigationLinkElement,
-        );
       } else {
-        toggleDatasetEntry(
+        action.navigationMarker?.select(
           action as SbbNavigationButtonElement | SbbNavigationLinkElement,
-          'actionActive',
-          true,
         );
       }
     });

--- a/src/components/navigation/navigation/navigation.ts
+++ b/src/components/navigation/navigation/navigation.ts
@@ -22,9 +22,7 @@ import {
   applyInertMechanism,
   removeInertMechanism,
 } from '../../core/overlay';
-import type { SbbNavigationActionCommonElementMixinType } from '../common';
 import type { SbbNavigationButtonElement } from '../navigation-button';
-import type { SbbNavigationLinkElement } from '../navigation-link';
 import '../../button/transparent-button';
 
 import style from './navigation.scss?lit&inline';
@@ -156,7 +154,7 @@ export class SbbNavigationElement extends UpdateScheduler(LitElement) {
       return;
     }
     this._state = 'opening';
-    this._setActiveAction();
+    this._checkActiveSection();
     this.startUpdate();
 
     // Disable scrolling for content below the navigation
@@ -164,20 +162,12 @@ export class SbbNavigationElement extends UpdateScheduler(LitElement) {
     this._triggerElement?.setAttribute('aria-expanded', 'true');
   }
 
-  private _setActiveAction(): void {
-    const activeActions = Array.from(
-      this.querySelectorAll(':is(sbb-navigation-button, sbb-navigation-link).sbb-active'),
-    ) as SbbNavigationActionCommonElementMixinType[];
-    activeActions.forEach((action: SbbNavigationActionCommonElementMixinType) => {
-      if (action.navigationSection) {
-        action.navigationSection.open();
-      } else {
-        action.navigationMarker?.select(
-          action as SbbNavigationButtonElement | SbbNavigationLinkElement,
-        );
-      }
-    });
-    this._elementToFocus = activeActions[0] as HTMLElement;
+  private _checkActiveSection(): void {
+    const activeAction = this.querySelector(
+      'sbb-navigation-button[data-action-active]',
+    ) as SbbNavigationButtonElement;
+    activeAction?.connectedSection?.open();
+    this._elementToFocus = activeAction as HTMLElement;
   }
 
   /**

--- a/src/components/navigation/navigation/readme.md
+++ b/src/components/navigation/navigation/readme.md
@@ -62,6 +62,7 @@ Similarly, if a navigation action is marked to indicate a selected option (e.g.,
 | `trigger`                 | `trigger`                   | public  | `string \| HTMLElement \| null` | `null`  | The element that will trigger the navigation. Accepts both a string (id of an element) or an HTML element. |
 | `accessibilityCloseLabel` | `accessibility-close-label` | public  | `\| string     \| undefined`    |         | This will be forwarded as aria-label to the close button element.                                          |
 | `disableAnimation`        | `disable-animation`         | public  | `boolean`                       | `false` | Whether the animation is enabled.                                                                          |
+| `activeNavigationSection` | -                           | public  | `HTMLElement \| null`           | `null`  |                                                                                                            |
 
 ## Methods
 

--- a/src/components/navigation/navigation/readme.md
+++ b/src/components/navigation/navigation/readme.md
@@ -5,7 +5,7 @@ Some of its features are:
 - uses a native dialog element;
 - creates a backdrop for disabling interaction below the navigation;
 - disables scrolling of the page content while open;
-- manages focus properly by setting it on the first focusable element;
+- manages focus properly by setting it on the first focusable element or the first action with the `.sbb-active` class;
 - can act as a host for components as [sbb-navigation-list](/docs/components-sbb-navigation-sbb-navigation-list--docs),
   [sbb-navigation-marker](/docs/components-sbb-navigation-sbb-navigation-marker--docs)
   and [sbb-navigation-section](/docs/components-sbb-navigation-sbb-navigation-section--docs);
@@ -50,6 +50,7 @@ or call the `open()` method on the `sbb-navigation` component.
 
 ## Accessibility
 
+On opening, the focus will be automatically set on the first focusable element or the first action with the `.sbb-active` class and, if the action with this class has a connected section, the section will be opened and the focus will be set on the first focusable element or the first action with the `.sbb-active` class in the section.
 When a navigation action is marked to indicate the user is currently on that page, `aria-current="page"` should be set on that action.
 Similarly, if a navigation action is marked to indicate a selected option (e.g., the selected language) `aria-pressed` should be set on that action.
 

--- a/src/storybook/pages/home/home.common.ts
+++ b/src/storybook/pages/home/home.common.ts
@@ -2,14 +2,8 @@ import type { Args, StoryContext } from '@storybook/web-components';
 import isChromatic from 'chromatic';
 import type { TemplateResult } from 'lit';
 import { html } from 'lit';
-import { ref } from 'lit/directives/ref.js';
 
 import { sbbSpread } from '../../../components/core/dom';
-import type {
-  SbbNavigationElement,
-  SbbNavigationMarkerElement,
-  SbbNavigationButtonElement,
-} from '../../../components/navigation';
 import '../../../components/button/button';
 import '../../../components/button/secondary-button';
 import '../../../components/button/secondary-button-static';
@@ -43,18 +37,8 @@ export const timetableInput = (): TemplateResult => html`
   </section>
 `;
 
-const onNavigationClose = (dialog: SbbNavigationElement): void => {
-  dialog?.addEventListener('did-close', () => {
-    (document.getElementById('nav-marker') as SbbNavigationMarkerElement).reset();
-    (document.getElementById('nav-1') as SbbNavigationButtonElement).setAttribute('active', '');
-  });
-};
-
 export const navigation = (): TemplateResult => html`
-  <sbb-navigation
-    trigger="hamburger-menu"
-    ${ref((dialog?: Element) => onNavigationClose(dialog as SbbNavigationElement))}
-  >
+  <sbb-navigation trigger="hamburger-menu">
     <sbb-navigation-marker id="nav-marker">
       <sbb-navigation-button aria-current="page" id="nav-1">
         Tickets & Offers

--- a/src/storybook/pages/home/home.common.ts
+++ b/src/storybook/pages/home/home.common.ts
@@ -56,7 +56,7 @@ export const navigation = (): TemplateResult => html`
     ${ref((dialog?: Element) => onNavigationClose(dialog as SbbNavigationElement))}
   >
     <sbb-navigation-marker id="nav-marker">
-      <sbb-navigation-button aria-current="page" id="nav-1" active>
+      <sbb-navigation-button aria-current="page" id="nav-1">
         Tickets & Offers
       </sbb-navigation-button>
       <sbb-navigation-button id="nav-2">Vacations & Recreation</sbb-navigation-button>
@@ -70,7 +70,9 @@ export const navigation = (): TemplateResult => html`
       <sbb-navigation-button aria-pressed="false" id="nav-5"> Deutsch </sbb-navigation-button>
       <sbb-navigation-button aria-pressed="false" id="nav-6"> Français </sbb-navigation-button>
       <sbb-navigation-button aria-pressed="false" id="nav-7"> Italiano </sbb-navigation-button>
-      <sbb-navigation-button aria-pressed="true" id="nav-8" active> English </sbb-navigation-button>
+      <sbb-navigation-button aria-pressed="true" id="nav-8" class="sbb-active">
+        English
+      </sbb-navigation-button>
     </sbb-navigation-marker>
 
     <sbb-navigation-section title-content="Title one" trigger="nav-1">

--- a/src/storybook/pages/home/home.common.ts
+++ b/src/storybook/pages/home/home.common.ts
@@ -40,7 +40,7 @@ export const timetableInput = (): TemplateResult => html`
 export const navigation = (): TemplateResult => html`
   <sbb-navigation trigger="hamburger-menu">
     <sbb-navigation-marker id="nav-marker">
-      <sbb-navigation-button aria-current="page" id="nav-1">
+      <sbb-navigation-button aria-current="page" id="nav-1" class="sbb-active">
         Tickets & Offers
       </sbb-navigation-button>
       <sbb-navigation-button id="nav-2">Vacations & Recreation</sbb-navigation-button>


### PR DESCRIPTION
Closes #2338 

BREAKING CHANGE: The `<sbb-navigation-button>`/`<sbb-navigation-link>` `active` property has been removed. Add the CSS class `sbb-active` to the corresponsive button/link, to mark it as active.