### PR TITLE
refactor(breakpoint): convert breakpoint-dependent code to pure css

### DIFF
--- a/src/components/calendar/calendar.ts
+++ b/src/components/calendar/calendar.ts
@@ -1,5 +1,5 @@
 import type { CSSResultGroup, TemplateResult, PropertyValues } from 'lit';
-import { html, LitElement, nothing } from 'lit';
+import { html, isServer, LitElement, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 
@@ -133,7 +133,7 @@ export class SbbCalendarElement extends LitElement {
   private _weekdays!: Weekday[];
 
   /** Grid of calendar cells representing the dates of the month. */
-  private _weeks!: Day[][];
+  private _weeks: Day[][] = [];
 
   /** Grid of calendar cells representing months. */
   private _months!: Month[][];
@@ -166,11 +166,30 @@ export class SbbCalendarElement extends LitElement {
   /** Whether the focus should be reset on focusCell. */
   private _resetFocus = false;
 
+  private _initialized = false;
+
   private _abort = new ConnectedAbortController(this);
   private _language = new LanguageController(this).withHandler(() => {
     this._monthNames = this._dateAdapter.getMonthNames('long');
     this._createMonthRows();
   });
+
+  public constructor() {
+    super();
+    this._createMonthRows();
+    this._setWeekdays();
+
+    // Workaround to execute initialization immediately after hydration
+    // If no hydration is needed, will be executed before the first rendering
+    this.addController({
+      hostConnected: () => {
+        this._convertMinDate(this.min);
+        this._convertMaxDate(this.max);
+        this._setDates();
+        this._init();
+      },
+    });
+  }
 
   private _convertMinDate(newMin?: SbbDateLike): void {
     this._min = this._dateAdapter.deserializeDate(newMin);
@@ -216,15 +235,13 @@ export class SbbCalendarElement extends LitElement {
       passive: true,
       signal: this._abort.signal,
     });
-    this._convertMinDate(this.min);
-    this._convertMaxDate(this.max);
-    this._setDates();
-    this._createMonthRows();
-    this._setWeekdays();
-    this._init();
   }
 
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
+    if (!this._initialized) {
+      return;
+    }
+
     if (changedProperties.has('min')) {
       this._convertMinDate(this.min);
     }
@@ -253,6 +270,11 @@ export class SbbCalendarElement extends LitElement {
 
   /** Initializes the component. */
   private _init(activeDate?: Date): void {
+    //Due to its complexity, the caledar is inited only on client side
+    if (isServer) {
+      return;
+    }
+
     if (activeDate) {
       this._assignActiveDate(activeDate);
     }
@@ -272,6 +294,7 @@ export class SbbCalendarElement extends LitElement {
       );
       this._nextMonthYears = this._createYearRows(YEARS_PER_PAGE);
     }
+    this._initialized = true;
   }
 
   /** Focuses on a day cell prioritizing the selected day, the current day, and lastly, the first selectable day. */

--- a/src/components/calendar/calendar.ts
+++ b/src/components/calendar/calendar.ts
@@ -270,7 +270,7 @@ export class SbbCalendarElement extends LitElement {
 
   /** Initializes the component. */
   private _init(activeDate?: Date): void {
-    //Due to its complexity, the caledar is inited only on client side
+    //Due to its complexity, the caledar is only initialized on client side
     if (isServer) {
       return;
     }

--- a/src/components/header/common/header-action-common.ts
+++ b/src/components/header/common/header-action-common.ts
@@ -8,9 +8,7 @@ import {
   type SbbIconNameMixinType,
   SbbIconNameMixin,
 } from '../../core/common-behaviors';
-import { isBreakpoint } from '../../core/dom';
 import type { SbbHorizontalFrom } from '../../core/interfaces';
-import { AgnosticResizeObserver } from '../../core/observers';
 
 import '../../icon';
 import style from './header-action.scss?lit&inline';
@@ -40,31 +38,7 @@ export const SbbHeaderActionCommonElementMixin = <
      * and hidden for all the others.
      */
     @property({ attribute: 'expand-from', reflect: true })
-    public set expandFrom(value: SbbHorizontalFrom) {
-      this._expandFrom = value;
-      this._updateExpanded();
-    }
-    public get expandFrom(): SbbHorizontalFrom {
-      return this._expandFrom;
-    }
-    private _expandFrom: SbbHorizontalFrom = 'medium';
-
-    private _documentResizeObserver = new AgnosticResizeObserver(() => this._updateExpanded());
-
-    private _updateExpanded(): void {
-      this.toggleAttribute('data-expanded', !isBreakpoint('zero', this.expandFrom));
-    }
-
-    public override connectedCallback(): void {
-      super.connectedCallback();
-      this._documentResizeObserver.observe(document.documentElement);
-      this._updateExpanded();
-    }
-
-    public override disconnectedCallback(): void {
-      super.disconnectedCallback();
-      this._documentResizeObserver.disconnect();
-    }
+    public expandFrom: SbbHorizontalFrom = 'medium';
 
     protected override renderTemplate(): TemplateResult {
       return html`

--- a/src/components/header/common/header-action.scss
+++ b/src/components/header/common/header-action.scss
@@ -122,15 +122,7 @@
   @include sbb.text-xs--bold;
   @include sbb.ellipsis;
 
-  display: flex;
-
-  // This is a workaround to fix styling after orientation change on iOS.
-  // If the display value changes comparing to the base state (display: flex),
-  // it re-renders and displays everything correctly.
-  // Without this workaround, elements are overlapping each other.
-  :host([data-expanded]) & {
-    display: block;
-  }
+  display: block;
 }
 
 // TODO: reevaluate this once 'CSS container queries' is supported
@@ -149,6 +141,12 @@
 
       .sbb-header-action__text {
         @include sbb.screen-reader-only;
+
+        // This is a workaround to fix styling after orientation change on iOS.
+        // If the display value changes comparing to the base state (display: flex),
+        // it re-renders and displays everything correctly.
+        // Without this workaround, elements are overlapping each other.
+        display: flex;
       }
     }
   }

--- a/src/components/header/common/header-action.scss
+++ b/src/components/header/common/header-action.scss
@@ -4,11 +4,8 @@
 // travel the shadow boundary are defined through this mixin
 @include sbb.host-component-properties;
 
-// Displays the action item's text and corrects spacings.
-$breakpoints: 'zero', 'micro', 'small', 'medium', 'large', 'wide', 'ultra';
-
 :host {
-  --sbb-header-action-padding-inline: 0;
+  --sbb-header-action-padding-inline: var(--sbb-spacing-fixed-5x);
   --sbb-header-action-color: var(--sbb-color-black);
   --sbb-header-action-background-color: transparent;
   --sbb-header-action-min-height: var(--sbb-size-button-m-min-height);
@@ -25,27 +22,15 @@ $breakpoints: 'zero', 'micro', 'small', 'medium', 'large', 'wide', 'ultra';
     --sbb-header-action-color: LinkText;
   }
 
-  // The variable is assigned to the property in the sbb-header component if it is
-  // the first element in the header and needs left offset correction (see sbb-header.scss).
-  // To avoid duplicated css definitions, the value itself is assigned here in
-  // sbb-header-button/sbb-header-link instead of sbb-header.
-  //
-  // Move it left by 12px in collapsed width.
-  --sbb-header-first-item-margin-inline-start: #{sbb.px-to-rem-build(-12)};
+  // If expanded, move it left by left padding.
+  // As result, the icon should be aligned with the left side of the page wrapper.
+  --sbb-header-first-item-margin-inline-start: calc(-1 * var(--sbb-header-action-padding-inline));
 
   display: inline-block;
 
   // Use !important here to not interfere with Firefox focus ring definition
   // which appears in normalize css of several frameworks.
   outline: none !important;
-}
-
-:host([data-expanded]) {
-  --sbb-header-action-padding-inline: var(--sbb-spacing-fixed-5x);
-
-  // If expanded, move it left by left padding.
-  // As result, the icon should be aligned with the left side of the page wrapper.
-  --sbb-header-first-item-margin-inline-start: calc(-1 * var(--sbb-header-action-padding-inline));
 }
 
 @include sbb.hover-mq($hover: true) {
@@ -139,15 +124,32 @@ $breakpoints: 'zero', 'micro', 'small', 'medium', 'large', 'wide', 'ultra';
 
   display: flex;
 
-  :host(:not([data-expanded])) & {
-    @include sbb.screen-reader-only;
-  }
-
   // This is a workaround to fix styling after orientation change on iOS.
   // If the display value changes comparing to the base state (display: flex),
   // it re-renders and displays everything correctly.
   // Without this workaround, elements are overlapping each other.
   :host([data-expanded]) & {
     display: block;
+  }
+}
+
+// TODO: reevaluate this once 'CSS container queries' is supported
+// https://caniuse.com/css-container-queries-style
+@each $breakpoint, $value in sbb.$mq-breakpoints {
+  :host([expand-from='#{$breakpoint}']) {
+    @include sbb.mq($to: #{$breakpoint}) {
+      // The variable is assigned to the property in the sbb-header component if it is
+      // the first element in the header and needs left offset correction (see sbb-header.scss).
+      // To avoid duplicated css definitions, the value itself is assigned here in
+      // sbb-header-button/sbb-header-link instead of sbb-header.
+      //
+      // Move it left by 12px in collapsed width.
+      --sbb-header-first-item-margin-inline-start: #{sbb.px-to-rem-build(-12)};
+      --sbb-header-action-padding-inline: 0;
+
+      .sbb-header-action__text {
+        @include sbb.screen-reader-only;
+      }
+    }
   }
 }

--- a/src/components/header/header-button/__snapshots__/header-button.spec.snap.js
+++ b/src/components/header/header-button/__snapshots__/header-button.spec.snap.js
@@ -1,0 +1,92 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["sbb-header-button renders the component as a button with icon Light DOM"] = 
+`<sbb-header-button
+  data-action=""
+  data-button=""
+  dir="ltr"
+  expand-from="zero"
+  icon-name="pie-small"
+  name="test"
+  role="button"
+  tabindex="0"
+  type="reset"
+  value="value"
+>
+  Action
+</sbb-header-button>
+`;
+/* end snapshot sbb-header-button renders the component as a button with icon Light DOM */
+
+snapshots["sbb-header-button renders the component as a button with icon Shadow DOM"] = 
+`<span class="sbb-action-base sbb-header-button">
+  <span class="sbb-header-action__wrapper">
+    <span class="sbb-header-action__icon">
+      <slot name="icon">
+        <sbb-icon
+          aria-hidden="true"
+          data-namespace="default"
+          name="pie-small"
+          role="img"
+        >
+        </sbb-icon>
+      </slot>
+    </span>
+    <span class="sbb-header-action__text">
+      <slot>
+      </slot>
+    </span>
+  </span>
+</span>
+`;
+/* end snapshot sbb-header-button renders the component as a button with icon Shadow DOM */
+
+snapshots["sbb-header-button renders the component as a button with icon A11y tree Chrome"] = 
+`<p>
+  {
+  "role": "WebArea",
+  "name": "",
+  "children": [
+    {
+      "role": "button",
+      "name": "Action"
+    }
+  ]
+}
+</p>
+`;
+/* end snapshot sbb-header-button renders the component as a button with icon A11y tree Chrome */
+
+snapshots["sbb-header-button renders the component as a button with icon A11y tree Firefox"] = 
+`<p>
+  {
+  "role": "document",
+  "name": "",
+  "children": [
+    {
+      "role": "button",
+      "name": "Action"
+    }
+  ]
+}
+</p>
+`;
+/* end snapshot sbb-header-button renders the component as a button with icon A11y tree Firefox */
+
+snapshots["sbb-header-button renders the component as a button with icon A11y tree Safari"] = 
+`<p>
+  {
+  "role": "WebArea",
+  "name": "",
+  "children": [
+    {
+      "role": "button",
+      "name": "Action"
+    }
+  ]
+}
+</p>
+`;
+/* end snapshot sbb-header-button renders the component as a button with icon A11y tree Safari */
+

--- a/src/components/header/header-button/header-button.spec.ts
+++ b/src/components/header/header-button/header-button.spec.ts
@@ -2,52 +2,38 @@ import { expect, fixture } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
 
 import { waitForLitRender } from '../../core/testing';
+import { testA11yTreeSnapshot } from '../../core/testing/a11y-tree-snapshot';
 
+import type { SbbHeaderButtonElement } from './header-button';
 import './header-button';
 
 describe('sbb-header-button', () => {
-  it('renders the component as a button with icon', async () => {
-    const root = await fixture(html`
-      <sbb-header-button
-        icon-name="pie-small"
-        name="test"
-        type="reset"
-        value="value"
-        expand-from="zero"
-      >
-        Action
-      </sbb-header-button>
-    `);
+  describe('renders the component as a button with icon', () => {
+    let element: SbbHeaderButtonElement;
 
-    await waitForLitRender(root);
+    beforeEach(async () => {
+      element = await fixture(html`
+        <sbb-header-button
+          icon-name="pie-small"
+          name="test"
+          type="reset"
+          value="value"
+          expand-from="zero"
+        >
+          Action
+        </sbb-header-button>
+      `);
+      await waitForLitRender(element);
+    });
 
-    expect(root).dom.to.be.equal(
-      `
-      <sbb-header-button icon-name='pie-small' expand-from="zero" name="test" type="reset" value="value" role="button" tabindex="0" data-expanded dir="ltr" data-action data-button>
-        Action
-      </sbb-header-button>
-    `,
-    );
-    expect(root).shadowDom.to.be.equal(
-      `
-          <span class="sbb-action-base sbb-header-button">
-            <span class="sbb-header-action__wrapper">
-              <span class="sbb-header-action__icon">
-                <slot name="icon">
-                  <sbb-icon
-                    aria-hidden="true"
-                    data-namespace="default"
-                    name="pie-small"
-                    role="img"
-                  >
-                </slot>
-              </span>
-              <span class="sbb-header-action__text">
-                <slot></slot>
-              </span>
-            </span>
-          </span>
-        `,
-    );
+    it('Light DOM', async () => {
+      await expect(element).dom.to.be.equalSnapshot();
+    });
+
+    it('Shadow DOM', async () => {
+      await expect(element).shadowDom.to.be.equalSnapshot();
+    });
+
+    testA11yTreeSnapshot();
   });
 });

--- a/src/components/header/header-link/__snapshots__/header-link.spec.snap.js
+++ b/src/components/header/header-link/__snapshots__/header-link.spec.snap.js
@@ -1,0 +1,134 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["sbb-header-link renders the component as a button with icon Light DOM"] = 
+`<sbb-header-link
+  data-action=""
+  data-link=""
+  dir="ltr"
+  expand-from="small"
+  href="https://github.com/lyne-design-system/lyne-components"
+  icon-name="pie-small"
+  role="link"
+  tabindex="0"
+  target="_blank"
+>
+  Action
+</sbb-header-link>
+`;
+/* end snapshot sbb-header-link renders the component as a button with icon Light DOM */
+
+snapshots["sbb-header-link renders the component as a button with icon Shadow DOM"] = 
+`<a
+  class="sbb-action-base sbb-header-link"
+  href="https://github.com/lyne-design-system/lyne-components"
+  rel="external noopener nofollow"
+  role="presentation"
+  tabindex="-1"
+  target="_blank"
+>
+  <span class="sbb-header-action__wrapper">
+    <span class="sbb-header-action__icon">
+      <slot name="icon">
+        <sbb-icon
+          aria-hidden="true"
+          data-namespace="default"
+          name="pie-small"
+          role="img"
+        >
+        </sbb-icon>
+      </slot>
+    </span>
+    <span class="sbb-header-action__text">
+      <slot>
+      </slot>
+    </span>
+  </span>
+  <sbb-screenreader-only>
+    . Link target opens in a new window.
+  </sbb-screenreader-only>
+</a>
+`;
+/* end snapshot sbb-header-link renders the component as a button with icon Shadow DOM */
+
+snapshots["sbb-header-link renders the component as a button with icon A11y tree Chrome"] = 
+`<p>
+  {
+  "role": "WebArea",
+  "name": "",
+  "children": [
+    {
+      "role": "link",
+      "name": "Action . Link target opens in a new window.",
+      "children": [
+        {
+          "role": "link",
+          "name": "Action . Link target opens in a new window."
+        }
+      ]
+    }
+  ]
+}
+</p>
+`;
+/* end snapshot sbb-header-link renders the component as a button with icon A11y tree Chrome */
+
+snapshots["sbb-header-link renders the component as a button with icon A11y tree Firefox"] = 
+`<p>
+  {
+  "role": "document",
+  "name": "",
+  "children": [
+    {
+      "role": "link",
+      "name": "Action . Link target opens in a new window.",
+      "children": [
+        {
+          "role": "link",
+          "name": "Action . Link target opens in a new window.",
+          "value": "https://github.com/lyne-design-system/lyne-components"
+        }
+      ]
+    }
+  ]
+}
+</p>
+`;
+/* end snapshot sbb-header-link renders the component as a button with icon A11y tree Firefox */
+
+snapshots["sbb-header-link renders the component as a button with icon A11y tree Safari"] = 
+`<p>
+  {
+  "role": "WebArea",
+  "name": "",
+  "children": [
+    {
+      "role": "link",
+      "name": "",
+      "children": [
+        {
+          "role": "link",
+          "name": "Action . Link target opens in a new window.",
+          "children": [
+            {
+              "role": "text",
+              "name": "Action"
+            },
+            {
+              "role": "text",
+              "name": ". "
+            },
+            {
+              "role": "text",
+              "name": "Link target opens in a new window."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+</p>
+`;
+/* end snapshot sbb-header-link renders the component as a button with icon A11y tree Safari */
+

--- a/src/components/header/header-link/header-link.spec.ts
+++ b/src/components/header/header-link/header-link.spec.ts
@@ -2,60 +2,36 @@ import { expect, fixture } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
 
 import { waitForLitRender } from '../../core/testing';
+import { testA11yTreeSnapshot } from '../../core/testing/a11y-tree-snapshot';
 
+import type { SbbHeaderLinkElement } from './header-link';
 import './header-link';
 
 describe('sbb-header-link', () => {
-  it('renders the component as a link with icon', async () => {
-    const root = await fixture(
-      html`<sbb-header-link
-        expand-from="small"
-        href="https://github.com/lyne-design-system/lyne-components"
-        target="_blank"
-        icon-name="pie-small"
-        >Action</sbb-header-link
-      >`,
-    );
+  describe('renders the component as a button with icon', () => {
+    let element: SbbHeaderLinkElement;
 
-    await waitForLitRender(root);
+    beforeEach(async () => {
+      element = await fixture(
+        html`<sbb-header-link
+          expand-from="small"
+          href="https://github.com/lyne-design-system/lyne-components"
+          target="_blank"
+          icon-name="pie-small"
+          >Action</sbb-header-link
+        >`,
+      );
+      await waitForLitRender(element);
+    });
 
-    expect(root).dom.to.be.equal(`
-      <sbb-header-link
-       data-expanded
-       dir="ltr"
-       expand-from="small"
-       href="https://github.com/lyne-design-system/lyne-components"
-       icon-name='pie-small'
-       role="link"
-       tabindex="0"
-       target="_blank"
-       data-action
-       data-link
-       >
-        Action
-      </sbb-header-link>
-    `);
-    expect(root).shadowDom.to.be.equal(`
-      <a class="sbb-action-base sbb-header-link" href="https://github.com/lyne-design-system/lyne-components" rel="external noopener nofollow" role="presentation" tabindex="-1" target="_blank">
-        <span class="sbb-header-action__wrapper">
-          <span class="sbb-header-action__icon">
-            <slot name="icon">
-              <sbb-icon
-                aria-hidden="true"
-                data-namespace="default"
-                name="pie-small"
-                role="img"
-              >
-            </slot>
-          </span>
-          <span class="sbb-header-action__text">
-            <slot></slot>
-          </span>
-        </span>
-        <sbb-screenreader-only>
-          . Link target opens in a new window.
-        </sbb-screenreader-only>
-      </a>
-    `);
+    it('Light DOM', async () => {
+      await expect(element).dom.to.be.equalSnapshot();
+    });
+
+    it('Shadow DOM', async () => {
+      await expect(element).shadowDom.to.be.equalSnapshot();
+    });
+
+    testA11yTreeSnapshot();
   });
 });

--- a/src/components/navigation/navigation-section/navigation-section.scss
+++ b/src/components/navigation/navigation-section/navigation-section.scss
@@ -172,6 +172,10 @@
 .sbb-navigation-section__back {
   position: absolute;
   transform: translateX(calc((100% + var(--sbb-spacing-fixed-1x)) * -1));
+
+  @include sbb.mq($from: large) {
+    display: none;
+  }
 }
 
 .sbb-navigation-section__title {

--- a/src/components/navigation/navigation-section/navigation-section.ts
+++ b/src/components/navigation/navigation-section/navigation-section.ts
@@ -1,6 +1,6 @@
 import { spread } from '@open-wc/lit-helpers';
 import type { CSSResultGroup, TemplateResult } from 'lit';
-import { html, LitElement, nothing } from 'lit';
+import { html, LitElement } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { ref } from 'lit/directives/ref.js';
 
@@ -93,8 +93,6 @@ export class SbbNavigationSectionElement extends UpdateScheduler(LitElement) {
    */
   @state() private _state: SbbOverlayState = 'closed';
 
-  @state() private _renderBackButton = this._isZeroToLargeBreakpoint();
-
   private _firstLevelNavigation?: SbbNavigationElement | null = null;
   private _navigationSection!: HTMLElement;
   private _navigationSectionContainerElement!: HTMLElement;
@@ -122,7 +120,6 @@ export class SbbNavigationSectionElement extends UpdateScheduler(LitElement) {
     this._state = 'opening';
     this.startUpdate();
     this.inert = true;
-    this._renderBackButton = this._isZeroToLargeBreakpoint();
     this._triggerElement?.setAttribute('aria-expanded', 'true');
   }
 
@@ -243,14 +240,6 @@ export class SbbNavigationSectionElement extends UpdateScheduler(LitElement) {
     window.addEventListener('click', this._handleNavigationSectionClose, {
       signal: this._windowEventsController.signal,
     });
-
-    window.addEventListener(
-      'resize',
-      () => {
-        this._renderBackButton = this._isZeroToLargeBreakpoint();
-      },
-      { passive: true, signal: this._windowEventsController.signal },
-    );
   }
 
   // Check if the click was triggered on an element that should close the section.
@@ -354,19 +343,6 @@ export class SbbNavigationSectionElement extends UpdateScheduler(LitElement) {
   }
 
   protected override render(): TemplateResult {
-    const backButton = html`
-      <sbb-transparent-button
-        id="sbb-navigation-section-back-button"
-        class="sbb-navigation-section__back"
-        aria-label=${this.accessibilityBackLabel || i18nGoBack[this._language.current]}
-        negative
-        size="m"
-        type="button"
-        icon-name="chevron-small-left-small"
-        sbb-navigation-section-close
-      ></sbb-transparent-button>
-    `;
-
     // Accessibility label should win over aria-labelledby
     let accessibilityAttributes: Record<string, string> = { 'aria-labelledby': 'title' };
     if (this.accessibilityLabel) {
@@ -394,7 +370,18 @@ export class SbbNavigationSectionElement extends UpdateScheduler(LitElement) {
           <div class="sbb-navigation-section__wrapper">
             <div class="sbb-navigation-section__content">
               <div class="sbb-navigation-section__header">
-                ${this._renderBackButton ? backButton : nothing}
+                <!-- Back button -->
+                <sbb-transparent-button
+                  id="sbb-navigation-section-back-button"
+                  class="sbb-navigation-section__back"
+                  aria-label=${this.accessibilityBackLabel || i18nGoBack[this._language.current]}
+                  negative
+                  size="m"
+                  type="button"
+                  icon-name="chevron-small-left-small"
+                  sbb-navigation-section-close
+                ></sbb-transparent-button>
+
                 <span class="sbb-navigation-section__title" id="title">
                   <slot name="title">${this.titleContent}</slot>
                 </span>


### PR DESCRIPTION
This PR closes #2339 

Some components still use `isBreakpoint` in their code. Specifically:
- `sbb-calendar`: it's too complex to convert to a pure CSS approach (we delayed breakpoint-dependent code after hydration)
- `sbb-menu`: use `isBreakpoint` when opened (so no conflict with ssr)
- `navigation-section`: partially converted to CSS approach. The remaining part is not executed on init