### PR TITLE
fix(sbb-navigation-section): ensure `sbb-active` initializes correctly

### DIFF
--- a/src/components/navigation/common/navigation-action-common.ts
+++ b/src/components/navigation/common/navigation-action-common.ts
@@ -38,7 +38,7 @@ export const SbbNavigationActionCommonElementMixin = <
     @property({ reflect: true }) public size?: SbbNavigationActionSize = 'l';
 
     /** The section that is beign controlled by the action, if any. */
-    public connectedSection: SbbNavigationSectionElement | null = null;
+    public connectedSection?: SbbNavigationSectionElement;
 
     /** The navigation marker in which the action is nested. */
     public get marker(): SbbNavigationMarkerElement | null {

--- a/src/components/navigation/navigation-button/readme.md
+++ b/src/components/navigation/navigation-button/readme.md
@@ -31,16 +31,16 @@ The component has three different sizes, which can be changed using the `size` p
 
 ## Properties
 
-| Name               | Attribute | Privacy | Type                                   | Default    | Description                                                 |
-| ------------------ | --------- | ------- | -------------------------------------- | ---------- | ----------------------------------------------------------- |
-| `size`             | `size`    | public  | `SbbNavigationActionSize \| undefined` | `'l'`      | Action size variant.                                        |
-| `connectedSection` | -         | public  | `SbbNavigationSectionElement \| null`  | `null`     | The section that is beign controlled by the action, if any. |
-| `marker`           | -         | public  | `SbbNavigationMarkerElement \| null`   |            | The navigation marker in which the action is nested.        |
-| `section`          | -         | public  | `SbbNavigationSectionElement \| null`  |            | The section in which the action is nested.                  |
-| `type`             | `type`    | public  | `SbbButtonType`                        | `'button'` | The type attribute to use for the button.                   |
-| `name`             | `name`    | public  | `string`                               |            | The name of the button element.                             |
-| `value`            | `value`   | public  | `string`                               |            | The value of the button element.                            |
-| `form`             | `form`    | public  | `string \| undefined`                  |            | The <form> element to associate the button with.            |
+| Name               | Attribute | Privacy | Type                                       | Default    | Description                                                 |
+| ------------------ | --------- | ------- | ------------------------------------------ | ---------- | ----------------------------------------------------------- |
+| `size`             | `size`    | public  | `SbbNavigationActionSize \| undefined`     | `'l'`      | Action size variant.                                        |
+| `connectedSection` | -         | public  | `SbbNavigationSectionElement \| undefined` |            | The section that is beign controlled by the action, if any. |
+| `marker`           | -         | public  | `SbbNavigationMarkerElement \| null`       |            | The navigation marker in which the action is nested.        |
+| `section`          | -         | public  | `SbbNavigationSectionElement \| null`      |            | The section in which the action is nested.                  |
+| `type`             | `type`    | public  | `SbbButtonType`                            | `'button'` | The type attribute to use for the button.                   |
+| `name`             | `name`    | public  | `string`                                   |            | The name of the button element.                             |
+| `value`            | `value`   | public  | `string`                                   |            | The value of the button element.                            |
+| `form`             | `form`    | public  | `string \| undefined`                      |            | The <form> element to associate the button with.            |
 
 ## Slots
 

--- a/src/components/navigation/navigation-link/readme.md
+++ b/src/components/navigation/navigation-link/readme.md
@@ -31,16 +31,16 @@ The component has three different sizes, which can be changed using the `size` p
 
 ## Properties
 
-| Name               | Attribute  | Privacy | Type                                    | Default | Description                                                       |
-| ------------------ | ---------- | ------- | --------------------------------------- | ------- | ----------------------------------------------------------------- |
-| `size`             | `size`     | public  | `SbbNavigationActionSize \| undefined`  | `'l'`   | Action size variant.                                              |
-| `connectedSection` | -          | public  | `SbbNavigationSectionElement \| null`   | `null`  | The section that is beign controlled by the action, if any.       |
-| `marker`           | -          | public  | `SbbNavigationMarkerElement \| null`    |         | The navigation marker in which the action is nested.              |
-| `section`          | -          | public  | `SbbNavigationSectionElement \| null`   |         | The section in which the action is nested.                        |
-| `href`             | `href`     | public  | `string \| undefined`                   |         | The href value you want to link to.                               |
-| `target`           | `target`   | public  | `LinkTargetType \| string \| undefined` |         | Where to display the linked URL.                                  |
-| `rel`              | `rel`      | public  | `string \| undefined`                   |         | The relationship of the linked URL as space-separated link types. |
-| `download`         | `download` | public  | `boolean \| undefined`                  |         | Whether the browser will show the download dialog on click.       |
+| Name               | Attribute  | Privacy | Type                                       | Default | Description                                                       |
+| ------------------ | ---------- | ------- | ------------------------------------------ | ------- | ----------------------------------------------------------------- |
+| `size`             | `size`     | public  | `SbbNavigationActionSize \| undefined`     | `'l'`   | Action size variant.                                              |
+| `connectedSection` | -          | public  | `SbbNavigationSectionElement \| undefined` |         | The section that is beign controlled by the action, if any.       |
+| `marker`           | -          | public  | `SbbNavigationMarkerElement \| null`       |         | The navigation marker in which the action is nested.              |
+| `section`          | -          | public  | `SbbNavigationSectionElement \| null`      |         | The section in which the action is nested.                        |
+| `href`             | `href`     | public  | `string \| undefined`                      |         | The href value you want to link to.                               |
+| `target`           | `target`   | public  | `LinkTargetType \| string \| undefined`    |         | Where to display the linked URL.                                  |
+| `rel`              | `rel`      | public  | `string \| undefined`                      |         | The relationship of the linked URL as space-separated link types. |
+| `download`         | `download` | public  | `boolean \| undefined`                     |         | Whether the browser will show the download dialog on click.       |
 
 ## Slots
 


### PR DESCRIPTION
Currently the reference set via connectedSection is reset to null, on upgrade/call of the constructor of the action web components (HTMLElement => SbbNavigationButtonElement/SbbNavigationLinkElement).
This is an unfortunate side effect of web components initialization.