### PR TITLE
chore: remove 'vite-plugin-turbosnap' dependency

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,6 +1,5 @@
 import type { StorybookConfig } from '@storybook/web-components-vite';
 import { type BuildOptions, type UserConfig, mergeConfig } from 'vite';
-import turbosnap from 'vite-plugin-turbosnap';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.ts'],
@@ -30,14 +29,6 @@ const config: StorybookConfig = {
     return mergeConfig(config, <UserConfig>{
       assetsInclude: ['src/**/*.md'],
       build,
-      plugins: process.env.CHROMATIC
-        ? [
-            // Creates the webpack-stats.json file which is needed by chromatic
-            turbosnap({
-              rootDir: config.root ?? process.cwd(),
-            }),
-          ]
-        : [],
     });
   },
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "postinstall": "yarn playwright install",
     "build:components": "vite build --config src/components/vite.config.ts",
     "build:react": "vite build --config src/react/vite.config.ts",
-    "build:storybook": "storybook build --quiet --output-dir dist/storybook",
+    "build:storybook": "storybook build --quiet --output-dir dist/storybook --stats-json",
     "build": "npm-run-all --sequential build:components build:react build:storybook",
     "docs": "npm-run-all --sequential docs:manifest docs:to-md",
     "docs:manifest": "custom-elements-manifest analyze --config config/custom-elements-manifest.config.js",
@@ -119,8 +119,7 @@
     "tsx": "4.7.1",
     "typescript": "5.4.2",
     "vite": "5.1.6",
-    "vite-plugin-dts": "3.7.3",
-    "vite-plugin-turbosnap": "1.0.3"
+    "vite-plugin-dts": "3.7.3"
   },
   "resolutions": {
     "@types/node": "20.11.28",


### PR DESCRIPTION
With Storybook 8.0 they started supporting the generation of `preview-stats.json` (used by turbosnap) with Vite.
We don't need the external plugin anymore 😄 

Ps. Chromatic will fail until we merge this fix