### PR TITLE
fix(sbb-header): fix header shadow on keyboard navigation

### DIFF
--- a/src/components/header/header/header.scss
+++ b/src/components/header/header/header.scss
@@ -65,7 +65,7 @@
     timing-function: var(--sbb-header-transition-timing);
   }
 
-  :host(:is([data-shadow], [data-has-visible-focus-within])) & {
+  :host(:is([data-shadow], [data-has-visible-focus-within][data-fixed])) & {
     @include sbb.shadow-level-9-soft;
   }
 


### PR DESCRIPTION
Doesn't show the shadow if the header is not in `position: fixed`.