### PR TITLE
refactor(sbb-calendar): implement initial support for other date libraries

### DIFF
--- a/src/components/calendar/calendar.e2e.ts
+++ b/src/components/calendar/calendar.e2e.ts
@@ -6,8 +6,9 @@ import { waitForCondition, waitForLitRender, EventSpy } from '../core/testing';
 
 import { SbbCalendarElement } from './calendar';
 
-describe('sbb-calendar', () => {
-  const selected = new Date(2023, 0, 15).getTime() / 1000;
+import '../button';
+
+describe(`sbb-calendar with ${fixture.name}`, () => {
   let element: SbbCalendarElement;
   const waitForTransition = async (): Promise<void> => {
     await waitForLitRender(element);
@@ -16,7 +17,7 @@ describe('sbb-calendar', () => {
 
   beforeEach(async () => {
     element = await fixture(
-      html`<sbb-calendar data-now="1673348400000" selected-date="${selected}"></sbb-calendar>`,
+      html`<sbb-calendar data-now="1673348400000" selected="1673737200"></sbb-calendar>`,
     );
   });
 
@@ -185,7 +186,13 @@ describe('sbb-calendar', () => {
     expect(monthCells.length).to.be.equal(12);
     expect(monthCells[0]).dom.to.be.equal(`
       <td class="sbb-calendar__table-data sbb-calendar__table-month">
-        <button aria-disabled="false" aria-label="January 2023" aria-pressed="true" class="sbb-calendar__cell sbb-calendar__pill sbb-calendar__selected sbb-calendar__cell-current" tabindex="0">
+        <button
+          aria-disabled="false"
+          aria-label="January 2023"
+          aria-pressed="true"
+          class="sbb-calendar__cell sbb-calendar__pill sbb-calendar__selected sbb-calendar__cell-current"
+          data-month="1"
+          tabindex="0">
           Jan
         </button>
       </td>
@@ -317,7 +324,7 @@ describe('sbb-calendar', () => {
   describe('navigation for year view', () => {
     beforeEach(async () => {
       element = await fixture(
-        html`<sbb-calendar data-now="1673348400000" selected-date="${selected}"></sbb-calendar>`,
+        html`<sbb-calendar data-now="1673348400000" selected="1673737200"></sbb-calendar>`,
       );
 
       const yearSelectionButton: HTMLElement = element.shadowRoot!.querySelector(

--- a/src/components/calendar/calendar.e2e.ts
+++ b/src/components/calendar/calendar.e2e.ts
@@ -8,7 +8,7 @@ import { SbbCalendarElement } from './calendar';
 
 import '../button';
 
-describe(`sbb-calendar with ${fixture.name}`, () => {
+describe(`sbb-calendar`, () => {
   let element: SbbCalendarElement;
   const waitForTransition = async (): Promise<void> => {
     await waitForLitRender(element);
@@ -17,7 +17,7 @@ describe(`sbb-calendar with ${fixture.name}`, () => {
 
   beforeEach(async () => {
     element = await fixture(
-      html`<sbb-calendar data-now="1673348400000" selected="1673737200"></sbb-calendar>`,
+      html`<sbb-calendar data-now="1673348400000" selected="1673744400"></sbb-calendar>`,
     );
   });
 

--- a/src/components/calendar/calendar.spec.ts
+++ b/src/components/calendar/calendar.spec.ts
@@ -9,15 +9,12 @@ import './calendar';
 describe('sbb-calendar', () => {
   it('renders', async () => {
     const root = await fixture(
-      html`<sbb-calendar
-        selected-date="2023-01-20T00:00:00"
-        data-now="1672790400000"
-      ></sbb-calendar>`,
+      html`<sbb-calendar selected="2023-01-20T00:00:00" data-now="1672790400000"></sbb-calendar>`,
     );
     await waitForLitRender(root);
 
     expect(root).dom.to.be.equal(
-      `<sbb-calendar data-now="1672790400000" selected-date="2023-01-20T00:00:00"></sbb-calendar>`,
+      `<sbb-calendar data-now="1672790400000" selected="2023-01-20T00:00:00"></sbb-calendar>`,
     );
     await expect(root).shadowDom.to.be.equalSnapshot();
   });
@@ -25,7 +22,7 @@ describe('sbb-calendar', () => {
   it('renders with min and max', async () => {
     const page: HTMLElement = await fixture(
       html`<sbb-calendar
-        selected-date="2023-01-20T00:00:00"
+        selected="2023-01-20T00:00:00"
         min="2023-01-09T00:00:00"
         max="2023-01-29T00:00:00"
       ></sbb-calendar>`,
@@ -59,10 +56,7 @@ describe('sbb-calendar', () => {
   });
 
   testA11yTreeSnapshot(
-    html`<sbb-calendar
-      selected-date="2023-01-20T00:00:00"
-      data-now="1672790400000"
-    ></sbb-calendar>`,
+    html`<sbb-calendar selected="2023-01-20T00:00:00" data-now="1672790400000"></sbb-calendar>`,
     undefined,
     { safari: true }, // We skip safari because it has an inconsistent behavior on ci environment
   );

--- a/src/components/calendar/calendar.stories.ts
+++ b/src/components/calendar/calendar.stories.ts
@@ -22,9 +22,9 @@ const getCalendarAttr = (min: Date | string, max: Date | string): Record<string,
   return attr;
 };
 
-const Template = ({ min, max, selectedDate, dateFilter, ...args }: Args): TemplateResult => html`
+const Template = ({ min, max, selected, dateFilter, ...args }: Args): TemplateResult => html`
   <sbb-calendar
-    .selectedDate=${new Date(selectedDate)}
+    .selected=${new Date(selected)}
     .dateFilter=${dateFilter}
     ${sbbSpread(getCalendarAttr(min, max))}
     ${sbbSpread(args)}
@@ -34,13 +34,13 @@ const Template = ({ min, max, selectedDate, dateFilter, ...args }: Args): Templa
 const TemplateDynamicWidth = ({
   min,
   max,
-  selectedDate,
+  selected,
   dateFilter,
   ...args
 }: Args): TemplateResult => html`
   <sbb-calendar
     style=${styleMap({ width: '900px' })}
-    .selectedDate=${new Date(selectedDate)}
+    .selected=${new Date(selected)}
     .dateFilter=${dateFilter}
     ${sbbSpread(getCalendarAttr(min, max))}
     ${sbbSpread(args)}
@@ -56,7 +56,7 @@ const wide: InputType = {
   },
 };
 
-const selectedDate: InputType = {
+const selected: InputType = {
   control: {
     type: 'date',
   },
@@ -119,7 +119,7 @@ const dateFilter: InputType = {
 
 const defaultArgTypes: ArgTypes = {
   wide,
-  selectedDate,
+  selected,
   min,
   max,
   dateFilter,
@@ -131,7 +131,7 @@ today.setDate(today.getDate() >= 15 ? 8 : 18);
 
 const defaultArgs: Args = {
   wide: false,
-  selectedDate: isChromatic() ? new Date(2023, 0, 20) : today,
+  selected: isChromatic() ? new Date(2023, 0, 20) : today,
   dataNow: isChromatic() ? new Date(2023, 0, 12, 0, 0, 0).valueOf() : undefined,
 };
 

--- a/src/components/calendar/calendar.stories.ts
+++ b/src/components/calendar/calendar.stories.ts
@@ -6,18 +6,19 @@ import type { TemplateResult } from 'lit';
 import { html } from 'lit';
 import { styleMap } from 'lit/directives/style-map.js';
 
+import { defaultDateAdapter } from '../core/datetime';
 import { sbbSpread } from '../core/dom';
 
 import { SbbCalendarElement } from './calendar';
 import readme from './readme.md?raw';
 
-const getCalendarAttr = (min: Date | string, max: Date | string): Record<string, Date> => {
-  const attr: Record<string, Date> = {};
+const getCalendarAttr = (min: Date | string, max: Date | string): Record<string, string> => {
+  const attr: Record<string, string> = {};
   if (min) {
-    attr.min = new Date(min);
+    attr.min = defaultDateAdapter.toIso8601(new Date(min));
   }
   if (max) {
-    attr.max = new Date(max);
+    attr.max = defaultDateAdapter.toIso8601(new Date(max));
   }
   return attr;
 };

--- a/src/components/calendar/calendar.ts
+++ b/src/components/calendar/calendar.ts
@@ -453,7 +453,7 @@ export class SbbCalendarElement<T = Date> extends LitElement {
       return true;
     }
 
-    const firstOfYear = this._dateAdapter.createDate(year, 0, 1)!;
+    const firstOfYear = this._dateAdapter.createDate(year, 1, 1)!;
     for (
       let date: T = firstOfYear;
       this._dateAdapter.getYear(date) == year;

--- a/src/components/calendar/calendar.ts
+++ b/src/components/calendar/calendar.ts
@@ -26,10 +26,12 @@ import {
   i18nYearMonthSelection,
 } from '../core/i18n';
 import type { SbbDateLike } from '../core/interfaces';
-import '../button/secondary-button';
-import '../icon';
 
 import style from './calendar.scss?lit&inline';
+
+import '../button/secondary-button';
+import '../icon';
+import '../screenreader-only';
 
 /**
  * In keyboard navigation, the cell's index and the element's index in its month / year batch must be distinguished;
@@ -817,9 +819,9 @@ export class SbbCalendarElement<T = Date> extends LitElement {
         <div class="sbb-calendar__controls-month">
           ${this._createLabelForDayView(this._activeDate)}
           ${this._wide ? this._createLabelForDayView(nextMonthActiveDate!) : nothing}
-          <span role="status" class="sbb-calendar__visually-hidden">
+          <sbb-screenreader-only role="status">
             ${this._createAriaLabelForDayView(this._activeDate, nextMonthActiveDate!)}
-          </span>
+          </sbb-screenreader-only>
         </div>
         ${this._getArrow(
           'right',
@@ -897,7 +899,7 @@ export class SbbCalendarElement<T = Date> extends LitElement {
     return this._weekdays.map(
       (day: Weekday) => html`
         <th class="sbb-calendar__table-header">
-          <span class="sbb-calendar__visually-hidden">${day.long}</span>
+          <sbb-screenreader-only>${day.long}</sbb-screenreader-only>
           <span aria-hidden="true">${day.narrow}</span>
         </th>
       `,
@@ -1007,7 +1009,7 @@ export class SbbCalendarElement<T = Date> extends LitElement {
         ${this._chosenYear} ${this._wide ? ` - ${this._chosenYear! + 1}` : nothing}
         <sbb-icon name="chevron-small-up-small"></sbb-icon>
       </button>
-      <span role="status" class="sbb-calendar__visually-hidden"> ${this._chosenYear} </span>`;
+      <sbb-screenreader-only role="status"> ${this._chosenYear} </sbb-screenreader-only>`;
   }
 
   /** Creates the table for the month selection view. */
@@ -1154,7 +1156,7 @@ export class SbbCalendarElement<T = Date> extends LitElement {
         ${yearLabel}
         <sbb-icon name="chevron-small-up-small"></sbb-icon>
       </button>
-      <span role="status" class="sbb-calendar__visually-hidden"> ${yearLabel} </span>
+      <sbb-screenreader-only role="status"> ${yearLabel} </sbb-screenreader-only>
     `;
   }
 

--- a/src/components/calendar/calendar.ts
+++ b/src/components/calendar/calendar.ts
@@ -26,12 +26,10 @@ import {
   i18nYearMonthSelection,
 } from '../core/i18n';
 import type { SbbDateLike } from '../core/interfaces';
-
-import style from './calendar.scss?lit&inline';
-
 import '../button/secondary-button';
 import '../icon';
-import '../screenreader-only';
+
+import style from './calendar.scss?lit&inline';
 
 /**
  * In keyboard navigation, the cell's index and the element's index in its month / year batch must be distinguished;
@@ -80,10 +78,10 @@ export type CalendarView = 'day' | 'month' | 'year';
 /**
  * It displays a calendar which allows to choose a date.
  *
- * @event {CustomEvent<Date>} dateSelected - Event emitted on date selection.
+ * @event {CustomEvent<T>} dateSelected - Event emitted on date selection.
  */
 @customElement('sbb-calendar')
-export class SbbCalendarElement extends LitElement {
+export class SbbCalendarElement<T = Date> extends LitElement {
   public static override styles: CSSResultGroup = style;
   public static readonly events = {
     dateSelected: 'dateSelected',
@@ -92,26 +90,58 @@ export class SbbCalendarElement extends LitElement {
   /** If set to true, two months are displayed */
   @property({ type: Boolean }) public wide = false;
 
-  /** The minimum valid date. Takes Date Object, ISOString, and Unix Timestamp (number of seconds since Jan 1, 1970). */
-  @property() public min?: SbbDateLike;
+  /** The minimum valid date. Takes T Object, ISOString, and Unix Timestamp (number of seconds since Jan 1, 1970). */
+  @property()
+  public set min(value: SbbDateLike<T> | null) {
+    this._min = this._dateAdapter.getValidDateOrNull(this._dateAdapter.deserialize(value));
+  }
+  public get min(): T | null {
+    return this._min ?? null;
+  }
+  private _min?: T | null;
 
-  /** The maximum valid date. Takes Date Object, ISOString, and Unix Timestamp (number of seconds since Jan 1, 1970). */
-  @property() public max?: SbbDateLike;
+  /** The maximum valid date. Takes T Object, ISOString, and Unix Timestamp (number of seconds since Jan 1, 1970). */
+  @property()
+  public set max(value: SbbDateLike<T> | undefined) {
+    this._max = this._dateAdapter.getValidDateOrNull(this._dateAdapter.deserialize(value));
+  }
+  public get max(): T | null {
+    return this._max ?? null;
+  }
+  private _max?: T | null;
+
+  /** The selected date. Takes T Object, ISOString, and Unix Timestamp (number of seconds since Jan 1, 1970). */
+  @property()
+  public set selected(value: SbbDateLike<T> | undefined) {
+    this._selectedDate = this._dateAdapter.getValidDateOrNull(this._dateAdapter.deserialize(value));
+    if (
+      !!this._selectedDate &&
+      (!this._isDayInRange(this._dateAdapter.toIso8601(this._selectedDate)) ||
+        this._dateFilter(this._selectedDate))
+    ) {
+      this._selected = this._dateAdapter.toIso8601(this._selectedDate);
+    } else {
+      this._selected = undefined;
+    }
+  }
+  public get selected(): T | null {
+    return this._selectedDate ?? null;
+  }
+  private _selectedDate?: T | null;
 
   /** A function used to filter out dates. */
-  @property({ attribute: 'date-filter' }) public dateFilter?: (date: Date | null) => boolean;
+  @property({ attribute: 'date-filter' }) public dateFilter?: (date: T | null) => boolean;
 
-  /** The selected date. Takes Date Object, ISOString, and Unix Timestamp (number of seconds since Jan 1, 1970). */
-  @property({ attribute: 'selected-date' }) public selectedDate?: SbbDateLike;
+  private _dateAdapter: DateAdapter<T> = defaultDateAdapter as unknown as DateAdapter<T>;
 
   /** Event emitted on date selection. */
-  private _dateSelected: EventEmitter<Date> = new EventEmitter(
+  private _dateSelected: EventEmitter<T> = new EventEmitter(
     this,
     SbbCalendarElement.events.dateSelected,
   );
 
   /** The currently active date. */
-  @state() private _activeDate!: Date;
+  @state() private _activeDate: T = this._now();
 
   /** The selected date as ISOString. */
   @state() private _selected?: string;
@@ -119,17 +149,9 @@ export class SbbCalendarElement extends LitElement {
   /** The current wide property considering property value and breakpoints. From zero to small `wide` has always to be false. */
   @state() private _wide: boolean = false;
 
-  /** Minimum value converted to date */
-  @state() private _min?: Date | null;
-
-  /** Maximum value converted to date */
-  @state() private _max?: Date | null;
-
   @state() private _calendarView: CalendarView = 'day';
 
   private _nextCalendarView: CalendarView = 'day';
-
-  private _dateAdapter: DateAdapter<Date> = defaultDateAdapter;
 
   /** A list of days, in two formats (long and single char). */
   private _weekdays!: Weekday[];
@@ -184,37 +206,11 @@ export class SbbCalendarElement extends LitElement {
     // Workaround to execute initialization immediately after hydration
     // If no hydration is needed, will be executed before the first rendering
     this.addController({
-      hostConnected: () => {
-        this._convertMinDate(this.min);
-        this._convertMaxDate(this.max);
-        this._setDates();
-        this._init();
-      },
+      hostConnected: () => this.resetPosition(),
     });
   }
 
-  private _convertMinDate(newMin?: SbbDateLike): void {
-    this._min = this._dateAdapter.deserializeDate(newMin);
-  }
-
-  private _convertMaxDate(newMax?: SbbDateLike): void {
-    this._max = this._dateAdapter.deserializeDate(newMax);
-  }
-
-  /** Sets the selected date. */
-  private _setSelectedDate(selectedDate: SbbDateLike | null): void {
-    const value = this._dateAdapter.deserializeDate(selectedDate);
-    if (
-      !!value &&
-      (!this._isDayInRange(this._dateAdapter.getISOString(value)) || this._dateFilter(value))
-    ) {
-      this._selected = this._dateAdapter.getISOString(value);
-    } else {
-      this._selected = undefined;
-    }
-  }
-
-  private get _dateFilter(): (date: Date) => boolean {
+  private get _dateFilter(): (date: T) => boolean {
     return this.dateFilter ?? (() => true);
   }
 
@@ -223,7 +219,7 @@ export class SbbCalendarElement extends LitElement {
     if (this._calendarView !== 'day') {
       this._resetToDayView();
     }
-    this._setDates();
+    this._activeDate = this.selected ?? this._now();
     this._init();
   }
 
@@ -244,21 +240,13 @@ export class SbbCalendarElement extends LitElement {
       return;
     }
 
-    if (changedProperties.has('min')) {
-      this._convertMinDate(this.min);
-    }
-    if (changedProperties.has('max')) {
-      this._convertMaxDate(this.max);
-    }
-    if (changedProperties.has('selectedDate')) {
-      this._setSelectedDate(this.selectedDate as Date);
-    }
     if (changedProperties.has('wide')) {
       this.resetPosition();
     }
   }
 
-  protected override updated(): void {
+  protected override updated(changedProperties: PropertyValues<this>): void {
+    super.updated(changedProperties);
     // The calendar needs to calculate tab-indexes on first render,
     // and every time a date is selected or the month view changes.
     this._setTabIndex();
@@ -271,7 +259,7 @@ export class SbbCalendarElement extends LitElement {
   }
 
   /** Initializes the component. */
-  private _init(activeDate?: Date): void {
+  private _init(activeDate?: T): void {
     //Due to its complexity, the caledar is only initialized on client side
     if (isServer) {
       return;
@@ -281,19 +269,13 @@ export class SbbCalendarElement extends LitElement {
       this._assignActiveDate(activeDate);
     }
     this._wide = isBreakpoint('medium') && this.wide;
-    this._weeks = this._createWeekRows(
-      this._dateAdapter.getMonth(this._activeDate),
-      this._dateAdapter.getYear(this._activeDate),
-    );
+    this._weeks = this._createWeekRows(this._activeDate);
+    this._years = this._createYearRows();
     this._nextMonthWeeks = [[]];
     this._nextMonthYears = [[]];
-    this._years = this._createYearRows();
     if (this._wide) {
       const nextMonthDate = this._dateAdapter.addCalendarMonths(this._activeDate, 1);
-      this._nextMonthWeeks = this._createWeekRows(
-        this._dateAdapter.getMonth(nextMonthDate),
-        this._dateAdapter.getYear(nextMonthDate),
-      );
+      this._nextMonthWeeks = this._createWeekRows(nextMonthDate);
       this._nextMonthYears = this._createYearRows(YEARS_PER_PAGE);
     }
     this._initialized = true;
@@ -305,13 +287,6 @@ export class SbbCalendarElement extends LitElement {
       this._getFirstFocusable()?.focus();
       this._resetFocus = false;
     }
-  }
-
-  /** Sets the date variables. */
-  private _setDates(): void {
-    const selectedDate = this._dateAdapter.deserializeDate(this.selectedDate);
-    this._activeDate = selectedDate ?? this._now();
-    this._setSelectedDate(selectedDate);
   }
 
   /** Creates the array of weekdays. */
@@ -329,22 +304,26 @@ export class SbbCalendarElement extends LitElement {
   }
 
   /** Creates the rows for each week. */
-  private _createWeekRows(month: number, year: number): Day[][] {
-    const daysInMonth: number = this._dateAdapter.getNumDaysInMonth(year, month);
+  private _createWeekRows(value: T): Day[][] {
+    const daysInMonth: number = this._dateAdapter.getNumDaysInMonth(value);
     const dateNames: string[] = this._dateAdapter.getDateNames();
     const weeks: Day[][] = [[]];
-    const weekOffset = this._dateAdapter.getFirstWeekOffset(year, month);
+    const weekOffset = this._dateAdapter.getFirstWeekOffset(value);
     for (let i = 0, cell = weekOffset; i < daysInMonth; i++, cell++) {
       if (cell === DAYS_PER_ROW) {
         weeks.push([]);
         cell = 0;
       }
-      const date = this._dateAdapter.createDate(year, month, i + 1)!;
+      const date = this._dateAdapter.createDate(
+        this._dateAdapter.getYear(value),
+        this._dateAdapter.getMonth(value),
+        i + 1,
+      )!;
       weeks[weeks.length - 1].push({
-        value: this._dateAdapter.getISOString(date),
+        value: this._dateAdapter.toIso8601(date),
         dayValue: dateNames[i],
-        monthValue: String(month + 1),
-        yearValue: String(year),
+        monthValue: String(this._dateAdapter.getMonth(date)),
+        yearValue: String(this._dateAdapter.getYear(date)),
       });
     }
     return weeks;
@@ -357,7 +336,7 @@ export class SbbCalendarElement extends LitElement {
       (_, i: number): Month => ({
         value: shortNames[i],
         longValue: this._monthNames[i],
-        monthValue: i,
+        monthValue: i + 1,
       }),
     );
     const rows: number = 12 / MONTHS_PER_ROW;
@@ -370,11 +349,7 @@ export class SbbCalendarElement extends LitElement {
 
   /** Creates the rows for the year selection view. */
   private _createYearRows(offset: number = 0): number[][] {
-    const startValueYearView: number = this._dateAdapter.getStartValueYearView(
-      this._activeDate,
-      this._min,
-      this._max,
-    );
+    const startValueYearView: number = this._getStartValueYearView();
     const allYears: number[] = new Array(YEARS_PER_PAGE)
       .fill(0)
       .map((_, i: number) => startValueYearView + offset + i);
@@ -386,6 +361,30 @@ export class SbbCalendarElement extends LitElement {
     return yearArray;
   }
 
+  /**
+   * Calculates the first year that will be shown in the year selection panel.
+   * If `minDate` and `maxDate` are both null, the starting year is calculated as
+   * the multiple of YEARS_PER_PAGE closest to and less than activeDate,
+   * e.g., with `YEARS_PER_PAGE` = 24 and `activeDate` = 2020, the function will return 2016 (24 * 83),
+   * while with `activeDate` = 2000, the function will return 1992 (24 * 82).
+   * If `minDate` is not null, it returns the corresponding year; if `maxDate` is not null,
+   * it returns the corresponding year minus `YEARS_PER_PAGE`, so that the `maxDate` is the last rendered year.
+   * If both are not null, `maxDate` has priority over `minDate`.
+   */
+  private _getStartValueYearView(): number {
+    let startingYear = 0;
+    if (this.max) {
+      startingYear = this._dateAdapter.getYear(this.max) - YEARS_PER_PAGE + 1;
+    } else if (this.min) {
+      startingYear = this._dateAdapter.getYear(this.min);
+    }
+    const activeYear = this._dateAdapter.getYear(this._activeDate);
+    return (
+      activeYear -
+      ((((activeYear - startingYear) % YEARS_PER_PAGE) + YEARS_PER_PAGE) % YEARS_PER_PAGE)
+    );
+  }
+
   /** Checks if date is within the min-max range. */
   private _isDayInRange(date: string): boolean {
     if (!this._min && !this._max) {
@@ -393,12 +392,10 @@ export class SbbCalendarElement extends LitElement {
     }
     const isBeforeMin: boolean =
       this._dateAdapter.isValid(this._min) &&
-      this._dateAdapter.compareDate(this._min!, this._dateAdapter.createDateFromISOString(date)!) >
-        0;
+      this._dateAdapter.compareDate(this._min!, this._dateAdapter.deserialize(date)!) > 0;
     const isAfterMax: boolean =
       this._dateAdapter.isValid(this._max) &&
-      this._dateAdapter.compareDate(this._max!, this._dateAdapter.createDateFromISOString(date)!) <
-        0;
+      this._dateAdapter.compareDate(this._max!, this._dateAdapter.deserialize(date)!) < 0;
     return !(isBeforeMin || isAfterMax);
   }
 
@@ -436,7 +433,7 @@ export class SbbCalendarElement extends LitElement {
 
     const firstOfMonth = this._dateAdapter.createDate(this._chosenYear!, month, 1)!;
     for (
-      let date: Date = firstOfMonth;
+      let date: T = firstOfMonth;
       this._dateAdapter.getMonth(date) == month;
       date = this._dateAdapter.addCalendarDays(date, 1)
     ) {
@@ -456,7 +453,7 @@ export class SbbCalendarElement extends LitElement {
 
     const firstOfYear = this._dateAdapter.createDate(year, 0, 1)!;
     for (
-      let date: Date = firstOfYear;
+      let date: T = firstOfYear;
       this._dateAdapter.getYear(date) == year;
       date = this._dateAdapter.addCalendarDays(date, 1)
     ) {
@@ -474,11 +471,11 @@ export class SbbCalendarElement extends LitElement {
     this._chosenYear = undefined;
     if (this._selected !== day) {
       this._selected = day;
-      this._dateSelected.emit(this._dateAdapter.createDateFromISOString(day)!);
+      this._dateSelected.emit(this._dateAdapter.deserialize(day)!);
     }
   }
 
-  private _assignActiveDate(date: Date): void {
+  private _assignActiveDate(date: T): void {
     if (this._min && this._dateAdapter.compareDate(this._min, date) > 0) {
       this._activeDate = this._min;
       return;
@@ -498,7 +495,7 @@ export class SbbCalendarElement extends LitElement {
   private _goToDifferentYear(years: number): void {
     this._chosenYear! += years;
     // Can't use `_assignActiveDate(...)` here, because it will set it to min/max value if argument is out of range
-    this._activeDate = new Date(
+    this._activeDate = this._dateAdapter.createDate(
       this._chosenYear!,
       this._dateAdapter.getMonth(this._activeDate),
       this._dateAdapter.getDate(this._activeDate),
@@ -510,14 +507,14 @@ export class SbbCalendarElement extends LitElement {
     this._init(this._dateAdapter.addCalendarYears(this._activeDate, years));
   }
 
-  private _prevDisabled(prevDate: Date): boolean {
+  private _prevDisabled(prevDate: T): boolean {
     if (!this._min) {
       return false;
     }
     return this._dateAdapter.compareDate(prevDate, this._min) < 0;
   }
 
-  private _nextDisabled(nextDate: Date): boolean {
+  private _nextDisabled(nextDate: T): boolean {
     if (!this._max) {
       return false;
     }
@@ -526,46 +523,52 @@ export class SbbCalendarElement extends LitElement {
 
   /** Checks if the "previous month" button should be disabled. */
   private _previousMonthDisabled(): boolean {
-    const prevMonth: Date = this._dateAdapter.clone(this._activeDate);
-    prevMonth.setDate(0);
+    const prevMonth = this._dateAdapter.addCalendarDays(
+      this._activeDate,
+      this._dateAdapter.getDate(this._activeDate) * -1,
+    );
     return this._prevDisabled(prevMonth);
   }
 
   /** Checks if the "next month" button should be disabled. */
   private _nextMonthDisabled(): boolean {
-    const nextMonth: Date = this._dateAdapter.addCalendarMonths(
-      this._activeDate,
-      this._wide ? 2 : 1,
+    let nextMonth = this._dateAdapter.addCalendarMonths(this._activeDate, this._wide ? 2 : 1);
+    nextMonth = this._dateAdapter.createDate(
+      this._dateAdapter.getYear(nextMonth),
+      this._dateAdapter.getMonth(nextMonth),
+      1,
     );
-    nextMonth.setDate(1);
     return this._nextDisabled(nextMonth);
   }
 
   private _previousYearDisabled(): boolean {
-    const prevYear: Date = this._dateAdapter.clone(this._activeDate);
-    prevYear.setFullYear(this._dateAdapter.getYear(this._activeDate) - 1, 11, 31);
+    const prevYear = this._dateAdapter.createDate(
+      this._dateAdapter.getYear(this._activeDate) - 1,
+      12,
+      31,
+    );
     return this._prevDisabled(prevYear);
   }
 
   private _nextYearDisabled(): boolean {
-    const nextYear: Date = this._dateAdapter.clone(this._activeDate);
-    nextYear.setFullYear(this._dateAdapter.getYear(this._activeDate) + 1, 0, 1);
+    const nextYear = this._dateAdapter.createDate(
+      this._dateAdapter.getYear(this._activeDate) + 1,
+      1,
+      1,
+    );
     return this._nextDisabled(nextYear);
   }
 
   private _previousYearRangeDisabled(): boolean {
-    const prevYear: Date = this._dateAdapter.clone(this._activeDate);
-    prevYear.setFullYear(this._years.flat()[0] - 1, 11, 31);
+    const prevYear = this._dateAdapter.createDate(this._years[0][0] - 1, 12, 31);
     return this._prevDisabled(prevYear);
   }
 
   private _nextYearRangeDisabled(): boolean {
-    const lastYearArray: number[] = (
-      isBreakpoint('medium') && this.wide ? this._nextMonthYears : this._years
-    ).flat();
-    const lastYear: number = lastYearArray[lastYearArray.length - 1];
-    const nextYear: Date = this._dateAdapter.clone(this._activeDate);
-    nextYear.setFullYear(lastYear + 1, 0, 1);
+    const lastYear = (isBreakpoint('medium') && this.wide ? this._nextMonthYears : this._years)
+      .at(-1)!
+      .at(-1)!;
+    const nextYear = this._dateAdapter.createDate(lastYear + 1, 1, 1);
     return this._nextDisabled(nextYear);
   }
 
@@ -586,16 +589,16 @@ export class SbbCalendarElement extends LitElement {
   }
 
   private _getFirstFocusable(): HTMLButtonElement {
-    const active = this._selected ? new Date(this._selected) : this._now();
+    const active = this._selected ? this._dateAdapter.deserialize(this._selected)! : this._now();
     let firstFocusable =
       this.shadowRoot!.querySelector('.sbb-calendar__selected') ??
       this.shadowRoot!.querySelector(
-        `[data-day="${active.getDate()} ${
-          this._activeDate.getMonth() + 1
-        } ${this._activeDate.getFullYear()}"]`,
+        `[data-day="${this._dateAdapter.getDate(active)} ${this._dateAdapter.getMonth(
+          active,
+        )} ${this._dateAdapter.getYear(active)}"]`,
       ) ??
-      this.shadowRoot!.querySelector(`[data-month="${this._activeDate.getMonth()}"]`) ??
-      this.shadowRoot!.querySelector(`[data-year="${this._activeDate.getFullYear()}"]`);
+      this.shadowRoot!.querySelector(`[data-month="${this._dateAdapter.getMonth(active)}"]`) ??
+      this.shadowRoot!.querySelector(`[data-year="${this._dateAdapter.getYear(active)}"]`);
     if (!firstFocusable || (firstFocusable as HTMLButtonElement)?.disabled) {
       firstFocusable = this.shadowRoot!.querySelector('.sbb-calendar__cell:not([disabled])');
     }
@@ -692,7 +695,12 @@ export class SbbCalendarElement extends LitElement {
           offsetForWideMode: index - indexInView,
           lastElementIndexForWideMode:
             index === indexInView
-              ? this._dateAdapter.getNumDaysInMonth(+day!.yearValue, +day!.monthValue - 1)
+              ? this._dateAdapter.getNumDaysInMonth(
+                  this._dateAdapter.addCalendarMonths(
+                    this._dateAdapter.deserialize(day!.value)!,
+                    -1,
+                  ),
+                )
               : cells.length,
         };
       }
@@ -770,23 +778,23 @@ export class SbbCalendarElement extends LitElement {
       : this._findNext(days, nextIndex, -verticalOffset);
   }
 
-  private _now(): Date {
-    if (this._hasDataNow()) {
-      const today: Date = new Date(+(this.dataset.now as string));
-      today.setHours(0, 0, 0, 0);
-      return today;
+  private _now(): T {
+    if (this.hasAttribute('data-now')) {
+      const today = new Date(+this.getAttribute('data-now')!);
+      if (defaultDateAdapter.isValid(today)) {
+        return this._dateAdapter.createDate(
+          today.getFullYear(),
+          today.getMonth() + 1,
+          today.getDate(),
+        );
+      }
     }
     return this._dateAdapter.today();
   }
 
-  private _hasDataNow(): boolean {
-    const dataNow = +(this.dataset?.now as string);
-    return !!dataNow;
-  }
-
   private _resetToDayView(): void {
     this._resetFocus = true;
-    this._activeDate = this._dateAdapter.deserializeDate(this.selectedDate) ?? this._now();
+    this._activeDate = this.selected ?? this._now();
     this._chosenYear = undefined;
     this._chosenMonth = undefined;
     this._nextCalendarView = 'day';
@@ -809,9 +817,9 @@ export class SbbCalendarElement extends LitElement {
         <div class="sbb-calendar__controls-month">
           ${this._createLabelForDayView(this._activeDate)}
           ${this._wide ? this._createLabelForDayView(nextMonthActiveDate!) : nothing}
-          <sbb-screenreader-only role="status">
+          <span role="status" class="sbb-calendar__visually-hidden">
             ${this._createAriaLabelForDayView(this._activeDate, nextMonthActiveDate!)}
-          </sbb-screenreader-only>
+          </span>
         </div>
         ${this._getArrow(
           'right',
@@ -828,9 +836,9 @@ export class SbbCalendarElement extends LitElement {
   }
 
   /** Creates the label with the month for the daily view. */
-  private _createLabelForDayView(d: Date): TemplateResult {
+  private _createLabelForDayView(d: T): TemplateResult {
     const monthLabel = `${
-      this._monthNames[this._dateAdapter.getMonth(d)]
+      this._monthNames[this._dateAdapter.getMonth(d) - 1]
     } ${this._dateAdapter.getYear(d)}`;
     return html`
       <button
@@ -851,12 +859,12 @@ export class SbbCalendarElement extends LitElement {
   }
 
   /** Creates the aria-label for the daily view. */
-  private _createAriaLabelForDayView(...dates: Date[]): string {
+  private _createAriaLabelForDayView(...dates: T[]): string {
     let monthLabel = '';
     for (const d of dates) {
       if (d) {
         monthLabel += `${
-          this._monthNames[this._dateAdapter.getMonth(d)]
+          this._monthNames[this._dateAdapter.getMonth(d) - 1]
         } ${this._dateAdapter.getYear(d)} `;
       }
     }
@@ -889,7 +897,7 @@ export class SbbCalendarElement extends LitElement {
     return this._weekdays.map(
       (day: Weekday) => html`
         <th class="sbb-calendar__table-header">
-          <sbb-screenreader-only>${day.long}</sbb-screenreader-only>
+          <span class="sbb-calendar__visually-hidden">${day.long}</span>
           <span aria-hidden="true">${day.narrow}</span>
         </th>
       `,
@@ -898,7 +906,7 @@ export class SbbCalendarElement extends LitElement {
 
   /** Creates the table body with the day cells. For the first row, it also considers the possible day's offset. */
   private _createDayTableBody(weeks: Day[][]): TemplateResult[] {
-    const today: string = this._dateAdapter.getISOString(this._now());
+    const today: string = this._dateAdapter.toIso8601(this._now());
     return weeks.map((week: Day[], rowIndex: number) => {
       const firstRowOffset: number = DAYS_PER_ROW - week.length;
       if (rowIndex === 0 && firstRowOffset) {
@@ -925,9 +933,7 @@ export class SbbCalendarElement extends LitElement {
   private _createDayCells(week: Day[], today: string): TemplateResult[] {
     return week.map((day: Day) => {
       const isOutOfRange = !this._isDayInRange(day.value);
-      const isFilteredOut = !this._dateFilter(
-        this._dateAdapter.createDateFromISOString(day.value)!,
-      );
+      const isFilteredOut = !this._dateFilter(this._dateAdapter.deserialize(day.value)!);
       const selected: boolean = !!this._selected && day.value === this._selected;
       const dayValue = `${day.dayValue} ${day.monthValue} ${day.yearValue}`;
       const isToday = day.value === today;
@@ -1001,7 +1007,7 @@ export class SbbCalendarElement extends LitElement {
         ${this._chosenYear} ${this._wide ? ` - ${this._chosenYear! + 1}` : nothing}
         <sbb-icon name="chevron-small-up-small"></sbb-icon>
       </button>
-      <sbb-screenreader-only role="status"> ${this._chosenYear} </sbb-screenreader-only>`;
+      <span role="status" class="sbb-calendar__visually-hidden"> ${this._chosenYear} </span>`;
   }
 
   /** Creates the table for the month selection view. */
@@ -1026,10 +1032,10 @@ export class SbbCalendarElement extends LitElement {
                   const isOutOfRange = !this._isMonthInRange(month.monthValue);
                   const isFilteredOut = !this._isMonthFilteredOut(month.monthValue);
                   const selectedMonth = this._selected
-                    ? this._dateAdapter.getMonth(new Date(this._selected))
+                    ? this._dateAdapter.getMonth(this._dateAdapter.deserialize(this._selected)!)
                     : undefined;
                   const selectedYear = this._selected
-                    ? this._dateAdapter.getYear(new Date(this._selected))
+                    ? this._dateAdapter.getYear(this._dateAdapter.deserialize(this._selected)!)
                     : undefined;
                   const selected: boolean =
                     !!this._selected && year === selectedYear && month.monthValue === selectedMonth;
@@ -1075,9 +1081,15 @@ export class SbbCalendarElement extends LitElement {
 
   /** Select the month and change the view to day selection. */
   private _onMonthSelection(month: number, year: number, shiftRight: boolean): void {
-    this._chosenMonth = shiftRight ? month - 1 : month;
+    this._chosenMonth = shiftRight ? month + 1 : month;
     this._nextCalendarView = 'day';
-    this._init(new Date(year, this._chosenMonth, this._activeDate.getDate()));
+    this._init(
+      this._dateAdapter.createDate(
+        year,
+        this._chosenMonth,
+        this._dateAdapter.getDate(this._activeDate),
+      ),
+    );
     this._removeTable();
   }
 
@@ -1142,12 +1154,13 @@ export class SbbCalendarElement extends LitElement {
         ${yearLabel}
         <sbb-icon name="chevron-small-up-small"></sbb-icon>
       </button>
-      <sbb-screenreader-only role="status"> ${yearLabel} </sbb-screenreader-only>
+      <span role="status" class="sbb-calendar__visually-hidden"> ${yearLabel} </span>
     `;
   }
 
   /** Creates the table for the year selection view. */
   private _createYearTable(years: number[][], shiftRight = false): TemplateResult {
+    const now = this._now();
     return html` <table
       class="sbb-calendar__table"
       @animationend=${(e: AnimationEvent) => this._tableAnimationEnd(e)}
@@ -1160,10 +1173,10 @@ export class SbbCalendarElement extends LitElement {
                 const isOutOfRange = !this._isYearInRange(year);
                 const isFilteredOut = !this._isYearFilteredOut(year);
                 const selectedYear = this._selected
-                  ? this._dateAdapter.getYear(new Date(this._selected))
+                  ? this._dateAdapter.getYear(this._dateAdapter.deserialize(this._selected)!)
                   : undefined;
                 const selected: boolean = !!this._selected && year === selectedYear;
-                const isCurrentYear = this._dateAdapter.getYear(this._now()) === year;
+                const isCurrentYear = this._dateAdapter.getYear(now) === year;
                 return html` <td class="sbb-calendar__table-data sbb-calendar__table-year">
                   <button
                     class=${classMap({
@@ -1197,7 +1210,11 @@ export class SbbCalendarElement extends LitElement {
     this._chosenYear = rightSide ? year - 1 : year;
     this._nextCalendarView = 'month';
     this._assignActiveDate(
-      new Date(this._chosenYear, this._activeDate.getMonth(), this._activeDate.getDate()),
+      this._dateAdapter.createDate(
+        this._chosenYear,
+        this._dateAdapter.getMonth(this._activeDate),
+        this._dateAdapter.getDate(this._activeDate),
+      ),
     );
     this._removeTable();
   }

--- a/src/components/calendar/readme.md
+++ b/src/components/calendar/readme.md
@@ -17,7 +17,7 @@ using the two properties named `min` and `max`. For these three properties, the 
 It's recommended to set the time to 00:00:00.
 
 ```html
-<sbb-calendar min="1600000000" max="1700000000" selected-date="1650000000"></sbb-calendar>
+<sbb-calendar min="1600000000" max="1700000000" selected="1650000000"></sbb-calendar>
 ```
 
 ## Style
@@ -25,7 +25,7 @@ It's recommended to set the time to 00:00:00.
 The component displays one month by default; two months can be displayed setting the `wide` property to `true`.
 
 ```html
-<sbb-calendar wide="true" selected-date="1650000000"></sbb-calendar>
+<sbb-calendar wide="true" selected="1650000000"></sbb-calendar>
 ```
 
 It's also possible to filter out unwanted date using the `dateFilter` function property.
@@ -64,13 +64,13 @@ This is helpful if you need a specific state of the component.
 
 ## Properties
 
-| Name           | Attribute       | Privacy | Type                                           | Default | Description                                                                                                     |
-| -------------- | --------------- | ------- | ---------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------- |
-| `wide`         | `wide`          | public  | `boolean`                                      | `false` | If set to true, two months are displayed                                                                        |
-| `min`          | `min`           | public  | `SbbDateLike \| undefined`                     |         | The minimum valid date. Takes Date Object, ISOString, and Unix Timestamp (number of seconds since Jan 1, 1970). |
-| `max`          | `max`           | public  | `SbbDateLike \| undefined`                     |         | The maximum valid date. Takes Date Object, ISOString, and Unix Timestamp (number of seconds since Jan 1, 1970). |
-| `dateFilter`   | `date-filter`   | public  | `(date: Date \| null) => boolean \| undefined` |         | A function used to filter out dates.                                                                            |
-| `selectedDate` | `selected-date` | public  | `SbbDateLike \| undefined`                     |         | The selected date. Takes Date Object, ISOString, and Unix Timestamp (number of seconds since Jan 1, 1970).      |
+| Name         | Attribute     | Privacy | Type                                        | Default | Description                                                                                                  |
+| ------------ | ------------- | ------- | ------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------ |
+| `wide`       | `wide`        | public  | `boolean`                                   | `false` | If set to true, two months are displayed                                                                     |
+| `min`        | `min`         | public  | `T \| null`                                 |         | The minimum valid date. Takes T Object, ISOString, and Unix Timestamp (number of seconds since Jan 1, 1970). |
+| `max`        | `max`         | public  | `T \| null`                                 |         | The maximum valid date. Takes T Object, ISOString, and Unix Timestamp (number of seconds since Jan 1, 1970). |
+| `selected`   | `selected`    | public  | `T \| null`                                 |         | The selected date. Takes T Object, ISOString, and Unix Timestamp (number of seconds since Jan 1, 1970).      |
+| `dateFilter` | `date-filter` | public  | `(date: T \| null) => boolean \| undefined` |         | A function used to filter out dates.                                                                         |
 
 ## Methods
 
@@ -80,6 +80,6 @@ This is helpful if you need a specific state of the component.
 
 ## Events
 
-| Name           | Type                | Description                      | Inherited From |
-| -------------- | ------------------- | -------------------------------- | -------------- |
-| `dateSelected` | `CustomEvent<Date>` | Event emitted on date selection. |                |
+| Name           | Type             | Description                      | Inherited From |
+| -------------- | ---------------- | -------------------------------- | -------------- |
+| `dateSelected` | `CustomEvent<T>` | Event emitted on date selection. |                |

--- a/src/components/core/datetime/date-adapter.ts
+++ b/src/components/core/datetime/date-adapter.ts
@@ -1,117 +1,115 @@
-export interface DateAdapter<T = any> {
+export const DAYS_PER_ROW: number = 7;
+export const MONTHS_PER_ROW: number = 4;
+export const YEARS_PER_ROW: number = 4;
+export const YEARS_PER_PAGE: number = 24;
+export const FORMAT_DATE =
+  /(^0?[1-9]?|[12]?[0-9]?|3?[01]?)[.,\\/\-\s](0?[1-9]?|1?[0-2]?)?[.,\\/\-\s](\d{1,4}$)?/;
+
+/**
+ * Abstract date functionality.
+ *
+ * Adapted from https://github.com/angular/components/blob/main/src/material/core/datetime/date-adapter.ts
+ */
+export abstract class DateAdapter<T = any> {
   /**
    * Get the year as a number.
    * @param date
    */
-  getYear: (date: T) => number;
+  public abstract getYear(date: T): number;
 
   /**
-   * Get the Month as a number.
+   * Get the month as a number.
+   * Attention: This returns 1-12 and mitigates the default JavaScript Date behavior.
    * @param date
    */
-  getMonth: (date: T) => number;
+  public abstract getMonth(date: T): number;
 
   /**
-   * Get the Day as a number.
+   * Get the day of the month as a number.
    * @param date
    */
-  getDate: (date: T) => number;
+  public abstract getDate(date: T): number;
 
   /**
    * Get the Day of the week as a number.
    * @param date
    */
-  getDayOfWeek: (date: T) => number;
-
-  /**
-   * Get the offset of the first day of the month from the first day of the week.
-   * @param year
-   * @param month
-   */
-  getFirstWeekOffset: (year: number, month: number) => number;
+  public abstract getDayOfWeek(date: T): number;
 
   /* Get the first day of the week (0: sunday; 1: monday; etc.). */
-  getFirstDayOfWeek: () => number;
+  public abstract getFirstDayOfWeek(): number;
 
   /**
    * Get the number of days in a month.
    * @param year
    * @param month
    * */
-  getNumDaysInMonth: (year: number, month: number) => number;
+  public abstract getNumDaysInMonth(date: T): number;
 
   /**
    * Get a list of all the months in a given style.
    * @param style
    */
-  getMonthNames: (style: 'long' | 'short' | 'narrow') => string[];
+  public abstract getMonthNames(style: 'long' | 'short' | 'narrow'): string[];
 
   /** Get a string array with length = 31, filled with the days in a month, starting from 1. */
-  getDateNames: () => string[];
+  public abstract getDateNames(): string[];
 
   /**
    * Get a list of all the week days in a given style.
    * @param style
    */
-  getDayOfWeekNames: (style: 'long' | 'short' | 'narrow') => string[];
+  public abstract getDayOfWeekNames(style: 'long' | 'short' | 'narrow'): string[];
 
   /** Creates today's date. */
-  today: () => T;
+  public abstract today(): T;
 
   /**
    * Checks whether a given `date` is valid.
    * @param date
    * */
-  isValid: (date: T | null | undefined) => boolean;
+  public abstract isValid(date: T | null | undefined): boolean;
 
   /** Creates a new date by cloning the given one.
    * @param date
    * */
-  clone(date: T): T;
+  public abstract clone(date: T): T;
 
   /**
    * Creates a new date, given day, month and year; without date's overflow.
    * @param year
-   * @param month
+   * @param month The month of the date (1-indexed, 1 = January). Must be an integer 1 - 12.
    * @param date
    * */
-  createDate: (year: number, month: number, date: number) => T | undefined;
+  public abstract createDate(year: number, month: number, date: number): T;
 
   /**
-   * Creates a new date given a ISO String.
-   * @param date The ISO String to convert to date.
-   * */
-  createDateFromISOString: (date: string) => T | null;
-
-  /**
-   * Creates a Date from a valid input.
+   * Attempts to deserialize a value to a valid date object. This is different from parsing in that
+   * deserialize should only accept non-ambiguous, locale-independent formats (e.g. a ISO 8601
+   * string). The default implementation does not allow any deserialization, it simply checks that
+   * the given value is already a valid date object or null. The `<mat-datepicker>` will call this
+   * method on all of its `@Input()` properties that accept dates. It is therefore possible to
+   * support passing values from your backend directly to these properties by overriding this method
+   * to also deserialize the format used by your backend.
    * @param date Either Date, ISOString, Unix Timestamp (number of seconds since Jan 1, 1970).
    * @returns The date if the input is valid, `null` otherwise.
    * */
-  deserializeDate: (date: T | string | number | null | undefined) => T | null;
-
-  /**
-   * Checks whether the two dates are non-null and are in the same month of the same year.
-   * @param first
-   * @param second
-   * */
-  hasSameMonthAndYear: (first: T | null, second: T | null) => boolean;
-
-  /**
-   * Compares two dates.
-   * @param first The first date to compare.
-   * @param second The second date to compare.
-   * @returns 0 if the dates are equal, a number less than 0 if the first date is earlier,
-   *     a number greater than 0 if the first date is later.
-   */
-  compareDate: (first: T, second: T) => number;
+  public deserialize(value: T | string | number | null | undefined): T | null {
+    if (
+      value == null ||
+      (this.isDateInstance(value) && this.isValid(value as T | null | undefined))
+    ) {
+      return value as T | null;
+    }
+    return this.invalid();
+  }
 
   /**
    * Creates a new date adding the number of provided `years` to the provided `date`.
    * @param date The starting date.
    * @param years The number of years to add.
    */
-  addCalendarYears: (date: T, years: number) => T;
+  public abstract addCalendarYears(date: T, years: number): T;
 
   /**
    * Creates a new date adding the number of provided `months` to the provided `date`.
@@ -120,46 +118,119 @@ export interface DateAdapter<T = any> {
    * @param date The starting date.
    * @param months The number of months to add.
    */
-  addCalendarMonths: (date: T, months: number) => T;
+  public abstract addCalendarMonths(date: T, months: number): T;
 
   /** Creates a new date by adding the number of provided `days` to the provided `date`.
    * @param date The starting date.
    * @param days The number of days to add.
    */
-  addCalendarDays: (date: T, days: number) => T;
-
-  /**
-   * Calculates the first year that will be shown in the year selection panel.
-   * @param activeDate The active date.
-   * @param minDate The minimum date, if set.
-   * @param maxDate The maximum date, if set.
-   */
-  getStartValueYearView: (activeDate: T, minDate?: T | null, maxDate?: T | null) => number;
+  public abstract addCalendarDays(date: T, days: number): T;
 
   /** Get the date in the local format.
    * @param date The date to format
    * @returns The `date` in the local format as string.
    */
-  getAccessibilityFormatDate: (date: T | string) => string;
+  public abstract getAccessibilityFormatDate(date: T | string): string;
 
   /** Get the given string as Date.
    * @param value The date in the format DD.MM.YYYY.
    * @param now The current date as Date.
    */
-  parseDate: (value: string | null | undefined, now: Date) => T | undefined;
+  public abstract parse(value: string | null | undefined, now: Date): T | undefined;
 
   /** Format the given Date as string.
    * @param value The date to format.
    */
-  format: (date: T | null | undefined) => string;
+  public abstract format(date: T | null | undefined): string;
 
   /** Checks whether the given `obj` is a Date.
    * @param obj The object to check.
    */
-  isDateInstance: (obj: any) => boolean;
+  public abstract isDateInstance(obj: any): boolean;
+
+  /**
+   * Gets date instance that is not valid.
+   * @returns An invalid date.
+   */
+  public abstract invalid(): T;
 
   /** Get the given date as ISO String.
    * @param date The date to convert to ISO String.
    */
-  getISOString: (date: T) => string;
+  public toIso8601(date: T): string {
+    const pad = (value: number, length = 2): string => `${value}`.padStart(length, '0');
+    return `${pad(this.getYear(date), 4)}-${pad(this.getMonth(date))}-${pad(this.getDate(date))}`;
+  }
+
+  /**
+   * Given a potential date object, returns that same date object if it is
+   * a valid date, or `null` if it's not a valid date.
+   * @param value The object to check.
+   * @returns A date or `null`.
+   */
+  public getValidDateOrNull(value: unknown): T | null {
+    return this.isDateInstance(value) && this.isValid(value as T) ? (value as T) : null;
+  }
+
+  /**
+   * Calculates the day of the week of the first day of the month, and then its offset from the first day of the week.
+   */
+  public getFirstWeekOffset(date: T): number {
+    const firstOfMonth = this.createDate(this.getYear(date), this.getMonth(date), 1)!;
+    return (
+      (DAYS_PER_ROW + this.getDayOfWeek(firstOfMonth) - this.getFirstDayOfWeek()) % DAYS_PER_ROW
+    );
+  }
+
+  /**
+   * Compares two dates.
+   * @param first The first date to compare.
+   * @param second The second date to compare.
+   * @returns 0 if the dates are equal, a number less than 0 if the first date is earlier,
+   *     a number greater than 0 if the first date is later.
+   */
+  public compareDate(first: T, second: T): number {
+    return (
+      this.getYear(first) - this.getYear(second) ||
+      this.getMonth(first) - this.getMonth(second) ||
+      this.getDate(first) - this.getDate(second)
+    );
+  }
+
+  /**
+   * Checks if two dates are equal.
+   * @param first The first date to check.
+   * @param second The second date to check.
+   * @returns Whether the two dates are equal.
+   *     Null dates are considered equal to other null dates.
+   */
+  public sameDate(first: T | null, second: T | null): boolean {
+    if (first && second) {
+      const firstValid = this.isValid(first);
+      const secondValid = this.isValid(second);
+      if (firstValid && secondValid) {
+        return !this.compareDate(first, second);
+      }
+      return firstValid == secondValid;
+    }
+    return first == second;
+  }
+
+  /**
+   * Clamp the given date between min and max dates.
+   * @param date The date to clamp.
+   * @param min The minimum value to allow. If null or omitted no min is enforced.
+   * @param max The maximum value to allow. If null or omitted no max is enforced.
+   * @returns `min` if `date` is less than `min`, `max` if date is greater than `max`,
+   *     otherwise `date`.
+   */
+  public clampDate(date: T, min?: T | null, max?: T | null): T {
+    if (min && this.compareDate(date, min) < 0) {
+      return min;
+    }
+    if (max && this.compareDate(date, max) > 0) {
+      return max;
+    }
+    return date;
+  }
 }

--- a/src/components/core/datetime/date-adapter.ts
+++ b/src/components/core/datetime/date-adapter.ts
@@ -87,10 +87,7 @@ export abstract class DateAdapter<T = any> {
    * Attempts to deserialize a value to a valid date object. This is different from parsing in that
    * deserialize should only accept non-ambiguous, locale-independent formats (e.g. a ISO 8601
    * string). The default implementation does not allow any deserialization, it simply checks that
-   * the given value is already a valid date object or null. The `<mat-datepicker>` will call this
-   * method on all of its `@Input()` properties that accept dates. It is therefore possible to
-   * support passing values from your backend directly to these properties by overriding this method
-   * to also deserialize the format used by your backend.
+   * the given value is already a valid date object or null.
    * @param date Either Date, ISOString, Unix Timestamp (number of seconds since Jan 1, 1970).
    * @returns The date if the input is valid, `null` otherwise.
    * */

--- a/src/components/core/datetime/native-date-adapter.spec.ts
+++ b/src/components/core/datetime/native-date-adapter.spec.ts
@@ -10,19 +10,19 @@ describe('NativeDateAdapter', () => {
   });
 
   it('getFirstWeekOffset should return the right value', () => {
-    expect(nativeDateAdapter.getFirstWeekOffset(2023, 4)).to.be.equal(0);
-    expect(nativeDateAdapter.getFirstWeekOffset(2023, 7)).to.be.equal(1);
-    expect(nativeDateAdapter.getFirstWeekOffset(2023, 1)).to.be.equal(2);
-    expect(nativeDateAdapter.getFirstWeekOffset(2023, 5)).to.be.equal(3);
-    expect(nativeDateAdapter.getFirstWeekOffset(2023, 8)).to.be.equal(4);
-    expect(nativeDateAdapter.getFirstWeekOffset(2023, 3)).to.be.equal(5);
-    expect(nativeDateAdapter.getFirstWeekOffset(2023, 0)).to.be.equal(6);
+    expect(nativeDateAdapter.getFirstWeekOffset(new Date(2023, 4, 1))).to.be.equal(0);
+    expect(nativeDateAdapter.getFirstWeekOffset(new Date(2023, 7, 1))).to.be.equal(1);
+    expect(nativeDateAdapter.getFirstWeekOffset(new Date(2023, 1, 1))).to.be.equal(2);
+    expect(nativeDateAdapter.getFirstWeekOffset(new Date(2023, 5, 1))).to.be.equal(3);
+    expect(nativeDateAdapter.getFirstWeekOffset(new Date(2023, 8, 1))).to.be.equal(4);
+    expect(nativeDateAdapter.getFirstWeekOffset(new Date(2023, 3, 1))).to.be.equal(5);
+    expect(nativeDateAdapter.getFirstWeekOffset(new Date(2023, 0, 1))).to.be.equal(6);
   });
 
   it('should return the right value for year month, date and weekday', () => {
     const date: Date = new Date(2023, 0, 1);
     expect(nativeDateAdapter.getYear(date)).to.be.equal(2023);
-    expect(nativeDateAdapter.getMonth(date)).to.be.equal(0);
+    expect(nativeDateAdapter.getMonth(date)).to.be.equal(1);
     expect(nativeDateAdapter.getDate(date)).to.be.equal(1);
     expect(nativeDateAdapter.getDayOfWeek(date)).to.be.equal(0);
   });
@@ -71,43 +71,27 @@ describe('NativeDateAdapter', () => {
   });
 
   it('getNumDaysInMonth should return the correct value', () => {
-    expect(nativeDateAdapter.getNumDaysInMonth(2023, 1)).to.be.equal(28);
-    expect(nativeDateAdapter.getNumDaysInMonth(2024, 1)).to.be.equal(29);
-    expect(nativeDateAdapter.getNumDaysInMonth(2023, 3)).to.be.equal(30);
-    expect(nativeDateAdapter.getNumDaysInMonth(2023, 0)).to.be.equal(31);
+    expect(nativeDateAdapter.getNumDaysInMonth(new Date(2023, 1, 1))).to.be.equal(28);
+    expect(nativeDateAdapter.getNumDaysInMonth(new Date(2024, 1, 1))).to.be.equal(29);
+    expect(nativeDateAdapter.getNumDaysInMonth(new Date(2023, 3, 1))).to.be.equal(30);
+    expect(nativeDateAdapter.getNumDaysInMonth(new Date(2023, 0, 1))).to.be.equal(31);
   });
 
   it('createDate should return the correct value or error', () => {
-    expect(nativeDateAdapter.createDate(2023, 17, 1)).to.be.undefined;
-    expect(nativeDateAdapter.createDate(2023, 3, -11)).to.be.undefined;
-    expect(nativeDateAdapter.createDate(2023, -5, 1)).to.be.undefined;
-    expect(nativeDateAdapter.createDate(2023, 3, 99)).to.be.undefined;
-    const firstDate: Date = nativeDateAdapter.createDate(2023, 0, 1)!;
+    expect(() => nativeDateAdapter.createDate(2023, 17, 1)).to.throw();
+    expect(() => nativeDateAdapter.createDate(2023, 3, -11)).to.throw();
+    expect(() => nativeDateAdapter.createDate(2023, -5, 1)).to.throw();
+    expect(() => nativeDateAdapter.createDate(2023, 3, 99)).to.throw();
+    const firstDate: Date = nativeDateAdapter.createDate(2023, 1, 1)!;
     expect(firstDate instanceof Date).to.be.equal(true);
     expect(
       `${firstDate.getDate()}.${firstDate.getMonth() + 1}.${firstDate.getFullYear()}`,
     ).to.be.equal('1.1.2023');
-    const secondDate: Date = nativeDateAdapter.createDate(18, 0, 1)!;
+    const secondDate: Date = nativeDateAdapter.createDate(18, 1, 1)!;
     expect(secondDate instanceof Date).to.be.equal(true);
     expect(
       `${secondDate.getDate()}.${secondDate.getMonth() + 1}.${secondDate.getFullYear()}`,
     ).to.be.equal('1.1.18');
-  });
-
-  it('hasSameMonthAndYear should return the correct value', () => {
-    expect(
-      nativeDateAdapter.hasSameMonthAndYear(new Date(2023, 8, 15, 0, 0, 0, 0), new Date(0)),
-    ).to.be.equal(false);
-    expect(
-      nativeDateAdapter.hasSameMonthAndYear(new Date(2023, 0, 1), new Date(2023, 1, 4)),
-    ).to.be.equal(false);
-    expect(nativeDateAdapter.hasSameMonthAndYear(null, new Date(2023, 1, 4))).to.be.equal(false);
-    expect(nativeDateAdapter.hasSameMonthAndYear(new Date(2023, 0, 1), undefined)).to.be.equal(
-      false,
-    );
-    expect(
-      nativeDateAdapter.hasSameMonthAndYear(new Date(1677000000), new Date(1676000000)),
-    ).to.be.equal(true);
   });
 
   it('isDateInstance and isValid should return the correct value', () => {
@@ -177,48 +161,48 @@ describe('NativeDateAdapter', () => {
   });
 
   it('deserializeDate should return the correct value', () => {
-    expect(nativeDateAdapter.deserializeDate(null)).to.be.null;
+    expect(nativeDateAdapter.deserialize(null)).to.be.null;
 
-    const date: Date = nativeDateAdapter.deserializeDate(new Date(0))!;
+    const date: Date = nativeDateAdapter.deserialize(new Date(0))!;
     expect(date instanceof Date).to.be.equal(true);
     expect(`${date.getDate()}.${date.getMonth() + 1}.${date.getFullYear()}`).to.be.equal(
       '1.1.1970',
     );
 
-    const dateNumber: Date = nativeDateAdapter.deserializeDate(946684800)!;
+    const dateNumber: Date = nativeDateAdapter.deserialize(946684800)!;
     expect(dateNumber instanceof Date).to.be.equal(true);
     expect(
       `${dateNumber.getDate()}.${dateNumber.getMonth() + 1}.${dateNumber.getFullYear()}`,
     ).to.be.equal('1.1.2000');
 
-    const dateNumAsStr: Date = nativeDateAdapter.deserializeDate('946684800')!;
+    const dateNumAsStr: Date = nativeDateAdapter.deserialize('946684800')!;
     expect(dateNumAsStr instanceof Date).to.be.equal(true);
     expect(
       `${dateNumAsStr.getDate()}.${dateNumAsStr.getMonth() + 1}.${dateNumAsStr.getFullYear()}`,
     ).to.be.equal('1.1.2000');
 
-    const dateString: Date = nativeDateAdapter.deserializeDate('2024-01-01')!;
+    const dateString: Date = nativeDateAdapter.deserialize('2024-01-01')!;
     expect(dateString instanceof Date).to.be.equal(true);
     expect(
       `${dateString.getDate()}.${dateString.getMonth() + 1}.${dateString.getFullYear()}`,
     ).to.be.equal('1.1.2024');
 
-    const fakeDate: Date = nativeDateAdapter.deserializeDate({} as string)!;
-    expect(fakeDate instanceof Date).to.be.equal(false);
-    expect(fakeDate).to.be.null;
+    const fakeDate: Date = nativeDateAdapter.deserialize({} as string)!;
+    expect(fakeDate instanceof Date).to.be.equal(true);
+    expect(+fakeDate).to.be.NaN;
   });
 
   it('parseDate should return the correct value', function () {
     const now = new Date(2023, 8, 15, 0, 0, 0, 0);
-    expect(nativeDateAdapter.parseDate(null, now)).to.be.undefined;
-    expect(nativeDateAdapter.parseDate('Test', now)).to.be.undefined;
-    expect(nativeDateAdapter.parseDate('1.1', now)).to.be.undefined;
-    let formattedDate = nativeDateAdapter.parseDate('1/1/2000', now)!;
+    expect(nativeDateAdapter.parse(null, now)).to.be.undefined;
+    expect(nativeDateAdapter.parse('Test', now)).to.be.undefined;
+    expect(nativeDateAdapter.parse('1.1', now)).to.be.undefined;
+    let formattedDate = nativeDateAdapter.parse('1/1/2000', now)!;
     expect(formattedDate.getFullYear()).to.be.equal(2000);
     expect(formattedDate.getMonth()).to.be.equal(0);
     expect(formattedDate.getDate()).to.be.equal(1);
 
-    formattedDate = nativeDateAdapter.parseDate('1.1.2000', now)!;
+    formattedDate = nativeDateAdapter.parse('1.1.2000', now)!;
     expect(formattedDate.getFullYear()).to.be.equal(2000);
     expect(formattedDate.getMonth()).to.be.equal(0);
     expect(formattedDate.getDate()).to.be.equal(1);
@@ -250,23 +234,5 @@ describe('NativeDateAdapter', () => {
     expect(
       nativeDateAdapter.getAccessibilityFormatDate(new Date(2018, 7, 15, 0, 0, 0)),
     ).to.be.equal('15 août 2018');
-  });
-
-  it('should return the correct year', () => {
-    const startDate: Date = new Date(2023, 0, 1);
-    const minDate: Date = new Date(2000, 0, 1);
-    const maxDate: Date = new Date(2042, 0, 1);
-    const noMinAndMax: number = nativeDateAdapter.getStartValueYearView(startDate, null, null);
-    expect(noMinAndMax).to.be.equal(2016);
-    const withMin: number = nativeDateAdapter.getStartValueYearView(startDate, minDate, null);
-    expect(withMin).to.be.equal(2000);
-    const withMax: number = nativeDateAdapter.getStartValueYearView(startDate, null, maxDate);
-    expect(withMax).to.be.equal(2019);
-    const withMinAndMax: number = nativeDateAdapter.getStartValueYearView(
-      startDate,
-      minDate,
-      maxDate,
-    );
-    expect(withMinAndMax).to.be.equal(2019);
   });
 });

--- a/src/components/core/datetime/native-date-adapter.ts
+++ b/src/components/core/datetime/native-date-adapter.ts
@@ -1,30 +1,22 @@
 import { LanguageController } from '../common-behaviors';
 import type { SbbDateLike } from '../interfaces';
 
-import type { DateAdapter } from './date-adapter';
+import { DateAdapter, FORMAT_DATE } from './date-adapter';
 
-export const DAYS_PER_ROW: number = 7;
-export const MONTHS_PER_ROW: number = 4;
-export const YEARS_PER_ROW: number = 4;
-export const YEARS_PER_PAGE: number = 24;
-export const FORMAT_DATE =
-  /(^0?[1-9]?|[12]?[0-9]?|3?[01]?)[.,\\/\-\s](0?[1-9]?|1?[0-2]?)?[.,\\/\-\s](\d{1,4}$)?/;
+/**
+ * Matches strings that have the form of a valid RFC 3339 string
+ * (https://tools.ietf.org/html/rfc3339). Note that the string may not actually be a valid date
+ * because the regex will match strings an with out of bounds month, date, etc.
+ */
+const ISO_8601_REGEX =
+  /^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|(?:(?:\+|-)\d{2}:\d{2}))?)?$/;
 
-export class NativeDateAdapter implements DateAdapter<Date> {
+export class NativeDateAdapter extends DateAdapter<Date> {
   private _cutoffYearOffset: number;
 
   public constructor(cutoffYearOffset: number = 15) {
+    super();
     this._cutoffYearOffset = cutoffYearOffset;
-  }
-
-  /**
-   * Calculates the day of the week of the first day of the month, and then its offset from the first day of the week.
-   */
-  public getFirstWeekOffset(year: number, month: number): number {
-    const firstOfMonth = this.createDate(year, month, 1)!;
-    return (
-      (DAYS_PER_ROW + this.getDayOfWeek(firstOfMonth) - this.getFirstDayOfWeek()) % DAYS_PER_ROW
-    );
   }
 
   /** Gets the year of the input date. */
@@ -34,7 +26,7 @@ export class NativeDateAdapter implements DateAdapter<Date> {
 
   /** Gets the month of the input date. */
   public getMonth(date: Date): number {
-    return date.getMonth();
+    return date.getMonth() + 1;
   }
 
   /** Gets the day of the input date. */
@@ -89,8 +81,8 @@ export class NativeDateAdapter implements DateAdapter<Date> {
   }
 
   /** Calculates the number of days in a month given the year and the month. */
-  public getNumDaysInMonth(year: number, month: number): number {
-    return new Date(year, month + 1, 0, 0, 0, 0, 0).getDate();
+  public getNumDaysInMonth(date: Date): number {
+    return this.getDate(this._createDateWithOverflow(this.getYear(date), this.getMonth(date), 0));
   }
 
   /** Creates today's date. */
@@ -99,38 +91,23 @@ export class NativeDateAdapter implements DateAdapter<Date> {
   }
 
   /** Creates a new date, given day, month and year; the method doesn't allow date's overflow. */
-  public createDate(year: number, month: number, date: number): Date | undefined {
+  public createDate(year: number, month: number, date: number): Date {
     // Check for invalid month and date (except upper bound on date which we have to check after creating the Date).
-    if (month < 0 || month > 11) {
-      return undefined;
+    if (month < 1 || month > 12) {
+      throw Error(`Invalid month index "${month}". Month index has to be between 1 and 12.`);
     }
 
     if (date < 1) {
-      return undefined;
+      throw Error(`Invalid date "${date}". Date has to be greater than 0.`);
     }
 
-    const result = this._createDateWithOverflow(year, month, date);
+    const result = this._createDateWithOverflow(year, month - 1, date);
     // Check that the date wasn't above the upper bound for the month, causing the month to overflow
-    if (result.getMonth() !== month) {
-      return undefined;
+    if (result.getMonth() + 1 !== month) {
+      throw Error(`Invalid date "${date}" for month with index "${month}".`);
     }
 
     return result;
-  }
-
-  public createDateFromISOString(date: string): Date | null {
-    const d = new Date(date);
-    return this.isValid(d) ? d : null;
-  }
-
-  /** Checks whether the two dates are non-null and are in the same month of the same year. */
-  public hasSameMonthAndYear(first?: Date | null, second?: Date | null): boolean {
-    return !!(
-      first &&
-      second &&
-      this.getMonth(first) === this.getMonth(second) &&
-      this.getYear(first) === this.getYear(second)
-    );
   }
 
   /** Checks whether the given `obj` is a Date. */
@@ -165,10 +142,7 @@ export class NativeDateAdapter implements DateAdapter<Date> {
   public addCalendarMonths(date: Date, months: number): Date {
     const targetMonth = date.getMonth() + months;
     const dateWithCorrectMonth = new Date(date.getFullYear(), targetMonth, 1, 0, 0, 0, 0);
-    const daysInMonth = this.getNumDaysInMonth(
-      this.getYear(dateWithCorrectMonth),
-      this.getMonth(dateWithCorrectMonth),
-    );
+    const daysInMonth = this.getNumDaysInMonth(dateWithCorrectMonth);
     // Adapt the last day of month for shorter months
     return new Date(this.clone(date).setMonth(targetMonth, Math.min(daysInMonth, date.getDate())));
   }
@@ -179,70 +153,27 @@ export class NativeDateAdapter implements DateAdapter<Date> {
     return new Date(date.getFullYear(), date.getMonth(), targetDay, 0, 0, 0, 0);
   }
 
-  /**
-   * Calculates the first year that will be shown in the year selection panel.
-   * If `minDate` and `maxDate` are both null, the starting year is calculated as
-   * the multiple of YEARS_PER_PAGE closest to and less than activeDate,
-   * e.g., with `YEARS_PER_PAGE` = 24 and `activeDate` = 2020, the function will return 2016 (24 * 83),
-   * while with `activeDate` = 2000, the function will return 1992 (24 * 82).
-   * If `minDate` is not null, it returns the corresponding year; if `maxDate` is not null,
-   * it returns the corresponding year minus `YEARS_PER_PAGE`, so that the `maxDate` is the last rendered year.
-   * If both are not null, `maxDate` has priority over `minDate`.
-   */
-  public getStartValueYearView(
-    activeDate: Date,
-    minDate?: Date | null,
-    maxDate?: Date | null,
-  ): number {
-    let startingYear: number = 0;
-    if (maxDate) {
-      startingYear = this.getYear(maxDate) - YEARS_PER_PAGE + 1;
-    } else if (minDate) {
-      startingYear = this.getYear(minDate);
-    }
-    const activeYear: number = this.getYear(activeDate);
-    return (
-      activeYear -
-      ((((activeYear - startingYear) % YEARS_PER_PAGE) + YEARS_PER_PAGE) % YEARS_PER_PAGE)
-    );
-  }
-
-  /**
-   * Compares two dates.
-   * @param first The first date to compare.
-   * @param second The second date to compare.
-   * @returns 0 if the dates are equal, a number less than 0 if the first date is earlier,
-   *     a number greater than 0 if the first date is later.
-   */
-  public compareDate(first: Date, second: Date): number {
-    return (
-      this.getYear(first) - this.getYear(second) ||
-      this.getMonth(first) - this.getMonth(second) ||
-      this.getDate(first) - this.getDate(second)
-    );
-  }
-
   /** Creates a Date from a valid input (Date, string or number in seconds). */
-  public deserializeDate(date?: SbbDateLike | null | undefined): Date | null {
-    if (!date) {
-      return null;
-    }
+  public override deserialize(date: SbbDateLike | null | undefined): Date | null {
     if (typeof date === 'string') {
-      if (!Number.isNaN(+date)) {
-        return new Date(+date * 1000);
+      if (!date) {
+        return null;
+      } else if (!Number.isNaN(+date)) {
+        return this.getValidDateOrNull(new Date(+date * 1000));
+
+        // The `Date` constructor accepts formats other than ISO 8601, so we need to make sure the
+        // string is the right format first.
+      } else if (ISO_8601_REGEX.test(date)) {
+        return this.getValidDateOrNull(new Date(date));
       }
-      return new Date(date);
     } else if (typeof date === 'number') {
-      return new Date(date * 1000);
+      return this.getValidDateOrNull(new Date(date * 1000));
     }
-    if (this.isDateInstance(date) && this.isValid(date)) {
-      return date;
-    }
-    return null;
+    return super.deserialize(date);
   }
 
   /** Returns the right format for the `valueAsDate` property. */
-  public parseDate(value: string | null | undefined, now: Date): Date | undefined {
+  public parse(value: string | null | undefined, now: Date): Date | undefined {
     if (!value) {
       return undefined;
     }
@@ -255,7 +186,7 @@ export class NativeDateAdapter implements DateAdapter<Date> {
       match.index !== 0 ||
       match.length <= 2 ||
       match.some((e) => e === undefined) ||
-      !this.isValid(this.createDate(+match[3], +match[2] - 1, +match[1]))
+      !this.isValid(this.createDate(+match[3], +match[2], +match[1]))
     ) {
       return undefined;
     }
@@ -290,9 +221,8 @@ export class NativeDateAdapter implements DateAdapter<Date> {
     return `${weekday}, ${dateFormatter.format(value)}`;
   }
 
-  public getISOString(date: Date): string {
-    date?.setHours(0, 0, 0, 0);
-    return date?.toISOString();
+  public override invalid(): Date {
+    return new Date(NaN);
   }
 
   /**

--- a/src/components/core/interfaces/types.ts
+++ b/src/components/core/interfaces/types.ts
@@ -1,6 +1,6 @@
 export type SbbLanguage = 'de' | 'en' | 'fr' | 'it';
 
-export type SbbDateLike = Date | string | number;
+export type SbbDateLike<T = Date> = T | string | number;
 
 export type SbbHorizontalFrom = 'zero' | 'micro' | 'small' | 'medium' | 'large' | 'wide' | 'ultra';
 

--- a/src/components/datepicker/datepicker-toggle/datepicker-toggle.ts
+++ b/src/components/datepicker/datepicker-toggle/datepicker-toggle.ts
@@ -134,7 +134,7 @@ export class SbbDatepickerToggleElement extends SbbNegativeMixin(LitElement) {
 
   private _datePickerChanged(event: Event): void {
     this._datePickerElement = event.target as SbbDatepickerElement;
-    this._calendarElement.selectedDate = this._datePickerElement.getValueAsDate();
+    this._calendarElement.selected = this._datePickerElement.getValueAsDate();
   }
 
   private _assignCalendar(calendar: SbbCalendarElement): void {
@@ -149,7 +149,7 @@ export class SbbDatepickerToggleElement extends SbbNegativeMixin(LitElement) {
     ) {
       return;
     }
-    this._calendarElement.selectedDate = this._datePickerElement.getValueAsDate();
+    this._calendarElement.selected = this._datePickerElement.getValueAsDate();
     this._configureCalendar(this._calendarElement, this._datePickerElement);
     this._calendarElement.resetPosition();
   }
@@ -204,7 +204,7 @@ export class SbbDatepickerToggleElement extends SbbNegativeMixin(LitElement) {
           .dateFilter=${this._datePickerElement?.dateFilter}
           @dateSelected=${(d: CustomEvent<Date>) => {
             const newDate = new Date(d.detail);
-            this._calendarElement.selectedDate = newDate;
+            this._calendarElement.selected = newDate;
             this._datePickerElement?.setValueAsDate(newDate);
           }}
           ${ref((calendar?: Element) => this._assignCalendar(calendar as SbbCalendarElement))}

--- a/src/components/datepicker/datepicker/datepicker.ts
+++ b/src/components/datepicker/datepicker/datepicker.ts
@@ -87,7 +87,7 @@ export function findPreviousAvailableDate(
   min: string | number | null,
 ): Date {
   const previousDate = getAvailableDate(date, -1, dateFilter, dateAdapter);
-  const dateMin = dateAdapter.deserializeDate(min);
+  const dateMin = dateAdapter.deserialize(min);
 
   if (
     !dateMin ||
@@ -113,7 +113,7 @@ export function findNextAvailableDate(
   max: string | number | null,
 ): Date {
   const nextDate = getAvailableDate(date, 1, dateFilter, dateAdapter);
-  const dateMax = dateAdapter.deserializeDate(max);
+  const dateMax = dateAdapter.deserialize(max);
 
   if (
     !dateMax ||
@@ -140,8 +140,8 @@ export function isDateAvailable(
 ): boolean {
   // TODO: Get date adapter from config
   const dateAdapter: DateAdapter<Date> = defaultDateAdapter;
-  const dateMin = dateAdapter.deserializeDate(min);
-  const dateMax = dateAdapter.deserializeDate(max);
+  const dateMin = dateAdapter.deserialize(min);
+  const dateMax = dateAdapter.deserialize(max);
 
   if (
     (dateAdapter.isValid(dateMin) && dateAdapter.compareDate(date, dateMin!) < 0) ||
@@ -476,9 +476,7 @@ export class SbbDatepickerElement extends LitElement {
   }
 
   private _parse(value: string): Date | undefined {
-    return this.dateParser
-      ? this.dateParser(value)
-      : this._dateAdapter.parseDate(value, this.now());
+    return this.dateParser ? this.dateParser(value) : this._dateAdapter.parse(value, this.now());
   }
 
   private _format(date: Date): string {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,7 +40,10 @@
         "rules": {
           // The following rules are broken
           "no-incompatible-type-binding": "off",
-          "no-missing-import": "off"
+          "no-missing-import": "off",
+          // In the calendar we have properties, that support Date/string/number values
+          // TODO: Maybe change the signature to only accept a date object.
+          "no-incompatible-property-type": "off"
         },
         "globalAttributes": [
           "align-self",


### PR DESCRIPTION
This change allows us in the future to support different date libraries. However, this is only the implementation for the calendar. Datepicker will be done in a different PR.

BREAKING CHANGE:
The `SbbDatepicker` property `selectedDate` has been renamed to `selected`. This also applies to the attribute `selected-date`, which has been renamed to `selected`. Additionally the `DateAdapter` (and `NativeDateAdapter`) have been superficially refactored. An important change is that the month is now `1`-based, instead of `0`-based.