### PR TITLE
fix(sbb-form-field): remove label property and attribute

### DIFF
--- a/src/components/autocomplete/autocomplete.stories.ts
+++ b/src/components/autocomplete/autocomplete.stories.ts
@@ -252,9 +252,9 @@ const Template = (args: Args): TemplateResult => html`
       ?negative=${args.negative}
       ?borderless=${args.borderless}
       ?floating-label=${args.floatingLabel}
-      label="Label"
       data-testid="form-field"
     >
+      <label>Label</label>
       <input
         placeholder="Placeholder"
         data-testid="autocomplete-input"
@@ -279,9 +279,9 @@ const OptionGroupTemplate = (args: Args): TemplateResult => html`
       ?negative=${args.negative}
       ?borderless=${args.borderless}
       ?floating-label=${args.floatingLabel}
-      label="Label"
       data-testid="form-field"
     >
+      <label>Label</label>
       <input
         placeholder="Placeholder"
         data-testid="autocomplete-input"
@@ -309,9 +309,9 @@ const MixedTemplate = (args: Args): TemplateResult => html`
       ?negative=${args.negative}
       ?borderless=${args.borderless}
       ?floating-label=${args.floatingLabel}
-      label="Label"
       data-testid="form-field"
     >
+      <label>Label</label>
       <input
         placeholder="Placeholder"
         data-testid="autocomplete-input"
@@ -352,10 +352,10 @@ const RequiredTemplate = (args: Args): TemplateResult => {
         ?negative=${args.negative}
         ?borderless=${args.borderless}
         ?floating-label=${args.floatingLabel}
-        label="Label"
         data-testid="form-field"
         id="sbb-form-field"
       >
+        <label>Label</label>
         <input
           id="sbb-autocomplete"
           data-testid="autocomplete-input"

--- a/src/components/autocomplete/readme.md
+++ b/src/components/autocomplete/readme.md
@@ -25,7 +25,8 @@ it will automatically connect to the native `<input>` as trigger and will displa
 
 ```html
 <!-- Origin element -->
-<sbb-form-field label="Label">
+<sbb-form-field>
+  <label>Label</label>
   <!-- Trigger element -->
   <input placeholder="Trigger element" />
 
@@ -50,7 +51,8 @@ The displayed `sbb-option` can be collected into groups using `sbb-optgroup` ele
 
 ```html
 <!-- Origin element -->
-<sbb-form-field label="Label">
+<sbb-form-field>
+  <label>Label</label>
   <!-- Trigger element -->
   <input placeholder="Trigger element" />
 

--- a/src/components/button/mini-button/mini-button.stories.ts
+++ b/src/components/button/mini-button/mini-button.stories.ts
@@ -23,14 +23,16 @@ const wrapperStyle = (context: StoryContext): Record<string, string> => ({
 });
 
 const MiniButtonCommonTemplate = ({ slot, ...args }: Args): TemplateResult => html`
-  <sbb-form-field label="Demo sbb-mini-button" ?negative=${args.negative}>
+  <sbb-form-field ?negative=${args.negative}>
+    <label>Demo sbb-mini-button</label>
     <input placeholder="Placeholder" ?disabled=${args.disabled} />
     <sbb-mini-button slot=${slot} ${sbbSpread(args)}></sbb-mini-button>
   </sbb-form-field>
 `;
 
 const MiniButtonSlottedIconCommonTemplate = ({ slot, ...args }: Args): TemplateResult => html`
-  <sbb-form-field label="Demo sbb-mini-button" ?negative=${args.negative}>
+  <sbb-form-field ?negative=${args.negative}>
+    <label>Demo sbb-mini-button</label>
     <input placeholder="Placeholder" ?disabled=${args.disabled} />
     <sbb-mini-button slot=${slot} ${sbbSpread(args)}>
       <sbb-icon name="user-small" slot="icon"></sbb-icon>

--- a/src/components/button/mini-button/readme.md
+++ b/src/components/button/mini-button/readme.md
@@ -29,7 +29,8 @@ The component is internally rendered as a button,
 accepting its associated properties (`type`, `name`, `value` and `form`).
 
 ```html
-<sbb-form-field label="Tickets">
+<sbb-form-field>
+  <label>Tickets</label>
   <input placeholder="Insert the number of tickets you want to purchase." />
   <sbb-mini-button
     slot="suffix"

--- a/src/components/datepicker/datepicker/datepicker.stories.ts
+++ b/src/components/datepicker/datepicker/datepicker.stories.ts
@@ -10,7 +10,7 @@ import type {
   StoryContext,
 } from '@storybook/web-components';
 import isChromatic from 'chromatic';
-import type { TemplateResult } from 'lit';
+import { nothing, type TemplateResult } from 'lit';
 import { html } from 'lit';
 import { styleMap } from 'lit/directives/style-map.js';
 
@@ -382,11 +382,11 @@ const TemplateFormField = ({
     <sbb-form-field
       size=${size}
       ?negative=${negative}
-      label=${label}
       ?optional=${optional}
       ?borderless=${borderless}
       width="collapse"
     >
+      ${label ? html`<label>${label}</label>` : nothing}
       <sbb-datepicker-previous-day></sbb-datepicker-previous-day>
       <sbb-datepicker-next-day></sbb-datepicker-next-day>
       <sbb-datepicker-toggle

--- a/src/components/dialog/dialog.stories.ts
+++ b/src/components/dialog/dialog.stories.ts
@@ -264,10 +264,12 @@ const FormTemplate = (args: Args): TemplateResult => html`
       method and returning the form values to update the details.
     </div>
     <form style=${styleMap(formStyle)} @submit=${(e: SubmitEvent) => e.preventDefault()}>
-      <sbb-form-field error-space="none" label="Message" size="m">
+      <sbb-form-field error-space="none" size="m">
+        <label>Message</label>
         <input placeholder="Your custom massage" value="Hello 👋" name="message" />
       </sbb-form-field>
-      <sbb-form-field error-space="none" label="Favorite animal" size="m">
+      <sbb-form-field error-space="none" size="m">
+        <label>Favorite animal</label>
         <select name="animal">
           <option>Red Panda</option>
           <option>Cheetah</option>

--- a/src/components/form-field/form-field-clear/__snapshots__/form-field-clear.spec.snap.js
+++ b/src/components/form-field/form-field-clear/__snapshots__/form-field-clear.spec.snap.js
@@ -6,12 +6,10 @@ snapshots["sbb-form-field-clear renders Formfield Dom"] =
   data-input-type="input"
   data-slot-names="label suffix unnamed"
   error-space="none"
-  label="Label"
   size="m"
   width="default"
 >
   <label
-    data-creator="sbb-form-field"
     for="sbb-form-field-input-0"
     slot="label"
   >

--- a/src/components/form-field/form-field-clear/form-field-clear.e2e.ts
+++ b/src/components/form-field/form-field-clear/form-field-clear.e2e.ts
@@ -14,7 +14,8 @@ describe(`sbb-form-field-clear with ${fixture.name}`, () => {
 
   beforeEach(async () => {
     formField = await fixture(
-      html` <sbb-form-field label="Label">
+      html` <sbb-form-field>
+        <label>Label</label>
         <input id="input" type="text" placeholder="Input placeholder" value="Input value" />
         <sbb-form-field-clear></sbb-form-field-clear>
       </sbb-form-field>`,

--- a/src/components/form-field/form-field-clear/form-field-clear.spec.ts
+++ b/src/components/form-field/form-field-clear/form-field-clear.spec.ts
@@ -15,7 +15,8 @@ describe(`sbb-form-field-clear`, () => {
 
     beforeEach(async () => {
       root = await fixture(html`
-        <sbb-form-field label="Label">
+        <sbb-form-field>
+          <label>Label</label>
           <input type="text" placeholder="Input placeholder" value="Input value" />
           <sbb-form-field-clear></sbb-form-field-clear>
         </sbb-form-field>

--- a/src/components/form-field/form-field-clear/form-field-clear.stories.ts
+++ b/src/components/form-field/form-field-clear/form-field-clear.stories.ts
@@ -59,7 +59,8 @@ const basicArgs: Args = {
 };
 
 const DefaultTemplate = ({ negative, ...args }: Args): TemplateResult => html`
-  <sbb-form-field label="Label" ?negative=${negative}>
+  <sbb-form-field ?negative=${negative}>
+    <label>Label</label>
     <sbb-icon slot="prefix" name="pie-small"></sbb-icon>
     <input type="text" placeholder="Input placeholder" value="Input value" ${sbbSpread(args)} />
     <sbb-form-field-clear></sbb-form-field-clear>

--- a/src/components/form-field/form-field-clear/readme.md
+++ b/src/components/form-field/form-field-clear/readme.md
@@ -2,7 +2,8 @@ The `sbb-form-field-clear` component can be used with the [sbb-form-field](/docs
 to provide the possibility to display a clear button which can clear the input value.
 
 ```html
-<sbb-form-field label="Label">
+<sbb-form-field>
+  <label>Label</label>
   <input type="text" placeholder="Input placeholder" value="Input value" />
   <sbb-form-field-clear></sbb-form-field-clear>
 </sbb-form-field>

--- a/src/components/form-field/form-field/__snapshots__/form-field.spec.snap.js
+++ b/src/components/form-field/form-field/__snapshots__/form-field.spec.snap.js
@@ -1,7 +1,30 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["sbb-form-field renders input"] = 
+snapshots["sbb-form-field renders input DOM"] = 
+`<sbb-form-field
+  data-input-empty=""
+  data-input-type="input"
+  data-slot-names="label unnamed"
+  error-space="none"
+  size="m"
+  width="default"
+>
+  <label
+    for="sbb-form-field-input-0"
+    slot="label"
+  >
+    Fill input
+  </label>
+  <input
+    id="sbb-form-field-input-0"
+    placeholder="This is an input"
+  >
+</sbb-form-field>
+`;
+/* end snapshot sbb-form-field renders input DOM */
+
+snapshots["sbb-form-field renders input Shadow DOM"] = 
 `<div class="sbb-form-field__space-wrapper">
   <div
     class="sbb-form-field__wrapper"
@@ -35,9 +58,35 @@ snapshots["sbb-form-field renders input"] =
   </div>
 </div>
 `;
-/* end snapshot sbb-form-field renders input */
+/* end snapshot sbb-form-field renders input Shadow DOM */
 
-snapshots["sbb-form-field renders slotted label"] = 
+snapshots["sbb-form-field renders disabled input DOM"] = 
+`<sbb-form-field
+  data-disabled=""
+  data-input-empty=""
+  data-input-type="input"
+  data-slot-names="label unnamed"
+  error-space="none"
+  size="m"
+  width="default"
+>
+  <label
+    for="sbb-form-field-input-2"
+    slot="label"
+  >
+    Fill input
+  </label>
+  <input
+    class="input"
+    disabled=""
+    id="sbb-form-field-input-2"
+    placeholder="This is an input"
+  >
+</sbb-form-field>
+`;
+/* end snapshot sbb-form-field renders disabled input DOM */
+
+snapshots["sbb-form-field renders disabled input Shadow DOM"] = 
 `<div class="sbb-form-field__space-wrapper">
   <div
     class="sbb-form-field__wrapper"
@@ -71,9 +120,44 @@ snapshots["sbb-form-field renders slotted label"] =
   </div>
 </div>
 `;
-/* end snapshot sbb-form-field renders slotted label */
+/* end snapshot sbb-form-field renders disabled input Shadow DOM */
 
-snapshots["sbb-form-field renders disabled input"] = 
+snapshots["sbb-form-field renders readonly input with error DOM"] = 
+`<sbb-form-field
+  data-has-error=""
+  data-input-empty=""
+  data-input-type="input"
+  data-readonly=""
+  data-slot-names="error label unnamed"
+  error-space="none"
+  size="m"
+  width="default"
+>
+  <label
+    for="sbb-form-field-input-4"
+    slot="label"
+  >
+    Fill input
+  </label>
+  <input
+    aria-describedby="error"
+    class="input"
+    id="sbb-form-field-input-4"
+    placeholder="This is an input"
+    readonly=""
+  >
+  <sbb-form-error
+    id="error"
+    role="status"
+    slot="error"
+  >
+    You can't change this value.
+  </sbb-form-error>
+</sbb-form-field>
+`;
+/* end snapshot sbb-form-field renders readonly input with error DOM */
+
+snapshots["sbb-form-field renders readonly input with error Shadow DOM"] = 
 `<div class="sbb-form-field__space-wrapper">
   <div
     class="sbb-form-field__wrapper"
@@ -107,45 +191,32 @@ snapshots["sbb-form-field renders disabled input"] =
   </div>
 </div>
 `;
-/* end snapshot sbb-form-field renders disabled input */
+/* end snapshot sbb-form-field renders readonly input with error Shadow DOM */
 
-snapshots["sbb-form-field renders readonly input with error"] = 
-`<div class="sbb-form-field__space-wrapper">
-  <div
-    class="sbb-form-field__wrapper"
-    id="overlay-anchor"
-  >
-    <slot name="prefix">
-    </slot>
-    <div class="sbb-form-field__input-container">
-      <span
-        aria-hidden="true"
-        class="sbb-form-field__label-spacer"
-      >
-      </span>
-      <span class="sbb-form-field__label">
-        <span class="sbb-form-field__label-ellipsis">
-          <slot name="label">
-          </slot>
-        </span>
-      </span>
-      <div class="sbb-form-field__input">
-        <slot>
-        </slot>
-      </div>
-    </div>
-    <slot name="suffix">
-    </slot>
-  </div>
-  <div class="sbb-form-field__error">
-    <slot name="error">
-    </slot>
-  </div>
-</div>
+snapshots["sbb-form-field should render select without label DOM"] = 
+`<sbb-form-field
+  data-input-type="select"
+  data-slot-names="unnamed"
+  error-space="none"
+  size="m"
+  width="default"
+>
+  <select>
+    <option>
+      Value 1
+    </option>
+    <option>
+      Value 2
+    </option>
+    <option>
+      Value 3
+    </option>
+  </select>
+</sbb-form-field>
 `;
-/* end snapshot sbb-form-field renders readonly input with error */
+/* end snapshot sbb-form-field should render select without label DOM */
 
-snapshots["sbb-form-field should render select without label"] = 
+snapshots["sbb-form-field should render select without label Shadow DOM"] = 
 `<div class="sbb-form-field__space-wrapper">
   <div
     class="sbb-form-field__wrapper"
@@ -187,9 +258,40 @@ snapshots["sbb-form-field should render select without label"] =
   </div>
 </div>
 `;
-/* end snapshot sbb-form-field should render select without label */
+/* end snapshot sbb-form-field should render select without label Shadow DOM */
 
-snapshots["sbb-form-field renders select with optional flag and borderless"] = 
+snapshots["sbb-form-field renders select with optional flag and borderless DOM"] = 
+`<sbb-form-field
+  borderless=""
+  data-input-type="select"
+  data-slot-names="label unnamed"
+  error-space="none"
+  optional=""
+  size="m"
+  width="default"
+>
+  <label
+    for="sbb-form-field-input-6"
+    slot="label"
+  >
+    Select option:
+  </label>
+  <select id="sbb-form-field-input-6">
+    <option>
+      Value 1
+    </option>
+    <option>
+      Value 2
+    </option>
+    <option>
+      Value 3
+    </option>
+  </select>
+</sbb-form-field>
+`;
+/* end snapshot sbb-form-field renders select with optional flag and borderless DOM */
+
+snapshots["sbb-form-field renders select with optional flag and borderless Shadow DOM"] = 
 `<div class="sbb-form-field__space-wrapper">
   <div
     class="sbb-form-field__wrapper"
@@ -234,7 +336,7 @@ snapshots["sbb-form-field renders select with optional flag and borderless"] =
   </div>
 </div>
 `;
-/* end snapshot sbb-form-field renders select with optional flag and borderless */
+/* end snapshot sbb-form-field renders select with optional flag and borderless Shadow DOM */
 
 snapshots["sbb-form-field A11y tree Chrome"] = 
 `<p>

--- a/src/components/form-field/form-field/form-field.e2e.ts
+++ b/src/components/form-field/form-field/form-field.e2e.ts
@@ -25,18 +25,6 @@ describe(`sbb-form-field with ${fixture.name}`, () => {
       assert.instanceOf(element, SbbFormFieldElement);
     });
 
-    it('should remove the label element if no label is configured', async () => {
-      expect(element.querySelector('label')).to.be.null;
-
-      element.setAttribute('label', 'Label');
-      await waitForLitRender(element);
-      expect(element.querySelector('label')).not.to.be.null;
-
-      element.removeAttribute('label');
-      await waitForLitRender(element);
-      expect(element.querySelector('label')).to.be.null;
-    });
-
     it('should update empty input state', async () => {
       expect(element).to.have.attribute('data-input-empty');
 
@@ -85,11 +73,12 @@ describe(`sbb-form-field with ${fixture.name}`, () => {
     });
 
     it('should assign id to input and reference it in the label', async () => {
-      element.setAttribute('label', 'Example');
-      await waitForLitRender(element);
-      const label = element.querySelector('label');
+      const newLabel = document.createElement('label');
+      newLabel.textContent = 'Example';
+      element.prepend(newLabel);
 
       await waitForLitRender(element);
+      const label = element.querySelector('label');
 
       expect(input.id).to.match(/^sbb-form-field-input-/);
       expect(label).to.have.attribute('for', input.id);
@@ -147,7 +136,8 @@ describe(`sbb-form-field with ${fixture.name}`, () => {
     beforeEach(async () => {
       element = await fixture(
         html`
-          <sbb-form-field label="Example">
+          <sbb-form-field>
+            <label>Example</label>
             <sbb-select><sbb-option>Test</sbb-option></sbb-select>
           </sbb-form-field>
         `,
@@ -198,8 +188,6 @@ describe(`sbb-form-field with ${fixture.name}`, () => {
     });
 
     it('should assign id to label and reference it in the sbb-select', async () => {
-      element.setAttribute('label', 'Example');
-      await waitForLitRender(element);
       const label = element.querySelector('label')!;
 
       expect(label.id).to.match(/^sbb-form-field-label-/);

--- a/src/components/form-field/form-field/form-field.spec.ts
+++ b/src/components/form-field/form-field/form-field.spec.ts
@@ -5,155 +5,120 @@ import { fixture, testA11yTreeSnapshot } from '../../core/testing/private';
 
 import './form-field';
 import '../../form-error';
+import type { SbbFormFieldElement } from './form-field';
 
 describe(`sbb-form-field`, () => {
-  it('renders input', async () => {
-    const root = await fixture(
-      html` <sbb-form-field label="Fill input">
-        <input placeholder="This is an input" />
-      </sbb-form-field>`,
-    );
+  describe('renders input', () => {
+    let element: SbbFormFieldElement;
 
-    expect(root).dom.to.be.equal(`
-      <sbb-form-field error-space="none" size="m" label="Fill input" width="default" data-input-empty data-input-type="input" data-slot-names="label unnamed">
-        <label data-creator="sbb-form-field" slot="label" for="sbb-form-field-input-0">
-          Fill input
-        </label>
-        <input placeholder="This is an input" id="sbb-form-field-input-0">
-      </sbb-form-field>
-    `);
-    await expect(root).shadowDom.to.be.equalSnapshot();
+    beforeEach(async () => {
+      element = await fixture(
+        html` <sbb-form-field>
+          <label>Fill input</label>
+          <input placeholder="This is an input" />
+        </sbb-form-field>`,
+      );
+    });
+
+    it('DOM', async () => {
+      await expect(element).dom.to.be.equalSnapshot();
+    });
+
+    it('Shadow DOM', async () => {
+      await expect(element).shadowDom.to.be.equalSnapshot();
+    });
   });
 
-  it('renders slotted label', async () => {
-    const root = await fixture(html`
-      <sbb-form-field>
-        <label slot="label">Fill input</label>
-        <input class="input" placeholder="This is an input" />
-      </sbb-form-field>
-    `);
+  describe('renders disabled input', () => {
+    let element: SbbFormFieldElement;
 
-    expect(root).dom.to.be.equal(`
-      <sbb-form-field error-space="none" size="m" width="default" data-input-empty data-input-type="input" data-slot-names="label unnamed">
-        <label for="sbb-form-field-input-1" slot="label">
-          Fill input
-        </label>
-        <input class="input" placeholder="This is an input" id="sbb-form-field-input-1">
-      </sbb-form-field>
-    `);
+    beforeEach(async () => {
+      element = await fixture(html`
+        <sbb-form-field>
+          <label>Fill input</label>
+          <input class="input" disabled placeholder="This is an input" />
+        </sbb-form-field>
+      `);
+    });
 
-    await expect(root).shadowDom.to.be.equalSnapshot();
+    it('DOM', async () => {
+      await expect(element).dom.to.be.equalSnapshot();
+    });
+
+    it('Shadow DOM', async () => {
+      await expect(element).shadowDom.to.be.equalSnapshot();
+    });
   });
 
-  it('renders disabled input', async () => {
-    const root = await fixture(html`
-      <sbb-form-field label="Fill input">
-        <input class="input" disabled placeholder="This is an input" />
-      </sbb-form-field>
-    `);
+  describe('renders readonly input with error', () => {
+    let element: SbbFormFieldElement;
 
-    expect(root).dom.to.be.equal(`
-      <sbb-form-field
-        error-space="none"
-        size="m"
-        label="Fill input"
-        width="default"
-        data-disabled
-        data-input-empty
-        data-input-type="input"
-        data-slot-names="label unnamed">
-        <label for="sbb-form-field-input-2" data-creator="sbb-form-field" slot="label">
-          Fill input
-        </label>
-        <input class="input" disabled="" placeholder="This is an input" id="sbb-form-field-input-2">
-      </sbb-form-field>
-    `);
-    await expect(root).shadowDom.to.be.equalSnapshot();
+    beforeEach(async () => {
+      element = await fixture(html`
+        <sbb-form-field>
+          <label>Fill input</label>
+          <input class="input" readonly placeholder="This is an input" />
+          <sbb-form-error id="error"> You can't change this value. </sbb-form-error>
+        </sbb-form-field>
+      `);
+    });
+
+    it('DOM', async () => {
+      await expect(element).dom.to.be.equalSnapshot();
+    });
+
+    it('Shadow DOM', async () => {
+      await expect(element).shadowDom.to.be.equalSnapshot();
+    });
   });
 
-  it('renders readonly input with error', async () => {
-    const root = await fixture(html`
-      <sbb-form-field label="Fill input">
-        <input class="input" readonly placeholder="This is an input" />
-        <sbb-form-error id="error"> You can't change this value. </sbb-form-error>
-      </sbb-form-field>
-    `);
+  describe('should render select without label', () => {
+    let element: SbbFormFieldElement;
+    beforeEach(async () => {
+      element = await fixture(html`
+        <sbb-form-field>
+          <select>
+            <option>Value 1</option>
+            <option>Value 2</option>
+            <option>Value 3</option>
+          </select>
+        </sbb-form-field>
+      `);
 
-    expect(root).dom.to.be.equal(`
-      <sbb-form-field
-        error-space="none"
-        size="m"
-        label="Fill input"
-        width="default"
-        data-has-error
-        data-input-empty
-        data-input-type="input"
-        data-readonly
-        data-slot-names="error label unnamed">
-        <label for="sbb-form-field-input-3" data-creator="sbb-form-field" slot="label">
-          Fill input
-        </label>
-        <input
-          aria-describedby="error"
-          class="input"
-          placeholder="This is an input"
-          readonly=""
-          id="sbb-form-field-input-3">
-        <sbb-form-error id="error" role="status" slot="error">
-          You can't change this value.
-        </sbb-form-error>
-      </sbb-form-field>
-    `);
-    await expect(root).shadowDom.to.be.equalSnapshot();
+    });
+
+    it('DOM', async () => {
+      await expect(element).dom.to.be.equalSnapshot();
+    });
+
+    it('Shadow DOM', async () => {
+      await expect(element).shadowDom.to.be.equalSnapshot();
+    });
   });
 
-  it('should render select without label', async () => {
-    const root = await fixture(html`
-      <sbb-form-field>
-        <select>
-          <option>Value 1</option>
-          <option>Value 2</option>
-          <option>Value 3</option>
-        </select>
-      </sbb-form-field>
-    `);
+  describe('renders select with optional flag and borderless', () => {
+    let element: SbbFormFieldElement;
 
-    expect(root).dom.to.be.equal(`
-      <sbb-form-field error-space="none" size="m" width="default" data-input-type="select" data-slot-names="unnamed">
-        <select>
-          <option>Value 1</option>
-          <option>Value 2</option>
-          <option>Value 3</option>
-        </select>
-      </sbb-form-field>
-    `);
-    await expect(root).shadowDom.to.be.equalSnapshot();
-  });
+    beforeEach(async () => {
+      element = await fixture(html`
+        <sbb-form-field optional borderless>
+          <label>Select option:</label>
+          <select>
+            <option>Value 1</option>
+            <option>Value 2</option>
+            <option>Value 3</option>
+          </select>
+        </sbb-form-field>
+      `);
+    });
 
-  it('renders select with optional flag and borderless', async () => {
-    const root = await fixture(html`
-      <sbb-form-field label="Select option:" optional borderless>
-        <select>
-          <option>Value 1</option>
-          <option>Value 2</option>
-          <option>Value 3</option>
-        </select>
-      </sbb-form-field>
-    `);
+    it('DOM', async () => {
+      await expect(element).dom.to.be.equalSnapshot();
+    });
 
-    expect(root).dom.to.be.equal(`
-      <sbb-form-field error-space="none" size="m" label="Select option:" optional borderless width="default" data-input-type="select" data-slot-names="label unnamed">
-        <label data-creator="sbb-form-field" slot="label" for="sbb-form-field-input-4">
-          Select option:
-        </label>
-        <select id="sbb-form-field-input-4">
-          <option>Value 1</option>
-          <option>Value 2</option>
-          <option>Value 3</option>
-        </select>
-      </sbb-form-field>
-    `);
-    await expect(root).shadowDom.to.be.equalSnapshot();
+    it('Shadow DOM', async () => {
+      await expect(element).shadowDom.to.be.equalSnapshot();
+    });
   });
 
   testA11yTreeSnapshot(html`

--- a/src/components/form-field/form-field/form-field.spec.ts
+++ b/src/components/form-field/form-field/form-field.spec.ts
@@ -84,7 +84,6 @@ describe(`sbb-form-field`, () => {
           </select>
         </sbb-form-field>
       `);
-
     });
 
     it('DOM', async () => {

--- a/src/components/form-field/form-field/form-field.stories.ts
+++ b/src/components/form-field/form-field/form-field.stories.ts
@@ -77,7 +77,6 @@ const TemplateInput = ({
 }: Args): TemplateResult => html`
   <sbb-form-field
     error-space=${errorSpace}
-    label=${label || nothing}
     ?optional=${optional}
     size=${size}
     ?borderless=${borderless}
@@ -86,11 +85,11 @@ const TemplateInput = ({
     ?floating-label=${floatingLabel}
     ?negative=${negative}
   >
-    ${TemplateBasicInput(args)}
+    ${label ? html`<label>${label}</label>` : nothing} ${TemplateBasicInput(args)}
   </sbb-form-field>
 `;
 
-const TemplateInputWithSlottedLabel = ({
+const TemplateInputWithSlottedSpanLabel = ({
   'error-space': errorSpace,
   label,
   optional,
@@ -127,7 +126,6 @@ const TemplateInputWithErrorSpace = (args: Args): TemplateResult => {
       <div>
         <sbb-form-field
           error-space=${args['error-space']}
-          label=${args.label}
           ?optional=${args.optional}
           size=${args.size}
           ?borderless=${args.borderless}
@@ -136,6 +134,7 @@ const TemplateInputWithErrorSpace = (args: Args): TemplateResult => {
           ?floating-label=${args['floating-label']}
           ?negative=${args.negative}
         >
+          ${args.label ? html`<label>${args.label}</label>` : nothing}
           <input
             @keyup=${(event: KeyboardEvent) => {
               const input = event.currentTarget as HTMLInputElement;
@@ -162,20 +161,23 @@ const TemplateInputWithErrorSpace = (args: Args): TemplateResult => {
   `;
 };
 
-const TemplateInputWithIcons = (args: Args): TemplateResult => html`
+const TemplateInputWithIcons = ({ label, ...args }: Args): TemplateResult => html`
   <sbb-form-field ${sbbSpread(args)}>
+    ${label ? html`<label>${label}</label>` : nothing}
     <sbb-icon slot="prefix" name="pie-small"></sbb-icon>
     ${TemplateBasicInput(args)} ${PopoverTrigger()}
   </sbb-form-field>
 `;
 
 const TemplateInputWithMiniButton = ({
+  label,
   disabled,
   readonly,
   active,
   ...args
 }: Args): TemplateResult => html`
   <sbb-form-field ${sbbSpread(args)}>
+    ${label ? html`<label>${label}</label>` : nothing}
     ${TemplateBasicInput({ disabled, readonly, ...args })}
     <sbb-mini-button
       slot="suffix"
@@ -188,12 +190,14 @@ const TemplateInputWithMiniButton = ({
 `;
 
 const TemplateInputWithClearButton = ({
+  label,
   disabled,
   readonly,
   active,
   ...args
 }: Args): TemplateResult => html`
   <sbb-form-field ${sbbSpread(args)}>
+    ${label ? html`<label>${label}</label>` : nothing}
     ${TemplateBasicInput({ disabled, readonly, ...args })}
     <sbb-form-field-clear ?data-active=${active}></sbb-form-field-clear>
   </sbb-form-field>
@@ -202,7 +206,6 @@ const TemplateInputWithClearButton = ({
 const TemplateSelect = (args: Args): TemplateResult => html`
   <sbb-form-field
     error-space=${args['error-space']}
-    label=${args.label}
     ?optional=${args.optional}
     size=${args.size}
     ?borderless=${args.borderless}
@@ -211,7 +214,7 @@ const TemplateSelect = (args: Args): TemplateResult => html`
     ?floating-label=${args['floating-label']}
     ?negative=${args.negative}
   >
-    ${TemplateBasicSelect(args)}
+    ${args.label ? html`<label>${args.label}</label>` : nothing} ${TemplateBasicSelect(args)}
   </sbb-form-field>
 `;
 
@@ -225,7 +228,6 @@ const TemplateSelectWithErrorSpace = (args: Args): TemplateResult => {
       <div>
         <sbb-form-field
           error-space=${args['error-space']}
-          label=${args.label}
           ?optional=${args.optional}
           size=${args.size}
           ?borderless=${args.borderless}
@@ -234,6 +236,7 @@ const TemplateSelectWithErrorSpace = (args: Args): TemplateResult => {
           ?floating-label=${args['floating-label']}
           ?negative=${args.negative}
         >
+          ${args.label ? html`<label>${args.label}</label>` : nothing}
           <select
             @change=${(event: Event) => {
               const select = event.currentTarget as HTMLSelectElement;
@@ -265,8 +268,9 @@ const TemplateSelectWithErrorSpace = (args: Args): TemplateResult => {
   `;
 };
 
-const TemplateSelectWithIcons = (args: Args): TemplateResult => html`
+const TemplateSelectWithIcons = ({ label, ...args }: Args): TemplateResult => html`
   <sbb-form-field ${sbbSpread(args)}>
+    ${label ? html`<label>${label}</label>` : nothing}
     <span slot="prefix">
       <sbb-icon name="pie-small"></sbb-icon>
     </span>
@@ -335,7 +339,7 @@ const errorSpace: InputType = {
   },
   options: ['none', 'reserve'],
   table: {
-    category: 'Form-field attribute',
+    category: 'Form-field',
   },
 };
 
@@ -345,7 +349,7 @@ const width: InputType = {
   },
   options: ['default', 'collapse'],
   table: {
-    category: 'Form-field attribute',
+    category: 'Form-field',
   },
 };
 
@@ -354,7 +358,7 @@ const label: InputType = {
     type: 'text',
   },
   table: {
-    category: 'Form-field attribute',
+    category: 'Form-field',
   },
 };
 
@@ -363,7 +367,7 @@ const hiddenLabel: InputType = {
     type: 'boolean',
   },
   table: {
-    category: 'Form-field attribute',
+    category: 'Form-field',
   },
 };
 
@@ -372,7 +376,7 @@ const floatingLabel: InputType = {
     type: 'boolean',
   },
   table: {
-    category: 'Form-field attribute',
+    category: 'Form-field',
   },
 };
 
@@ -381,7 +385,7 @@ const optional: InputType = {
     type: 'boolean',
   },
   table: {
-    category: 'Form-field attribute',
+    category: 'Form-field',
   },
 };
 
@@ -390,7 +394,7 @@ const borderless: InputType = {
     type: 'boolean',
   },
   table: {
-    category: 'Form-field attribute',
+    category: 'Form-field',
   },
 };
 
@@ -400,7 +404,7 @@ const size: InputType = {
   },
   options: ['m', 'l'],
   table: {
-    category: 'Form-field attribute',
+    category: 'Form-field',
   },
 };
 
@@ -409,7 +413,7 @@ const negative: InputType = {
     type: 'boolean',
   },
   table: {
-    category: 'Form-field attribute',
+    category: 'Form-field',
   },
 };
 
@@ -489,7 +493,7 @@ export const InputHiddenLabel: StoryObj = {
 };
 
 export const InputWithSlottedLabel: StoryObj = {
-  render: TemplateInputWithSlottedLabel,
+  render: TemplateInputWithSlottedSpanLabel,
   argTypes: basicArgTypes,
   args: { ...basicArgs, value: 'Random value' },
 };
@@ -652,7 +656,7 @@ export const InputNegative: StoryObj = {
 };
 
 export const InputWithSlottedLabelNegative: StoryObj = {
-  render: TemplateInputWithSlottedLabel,
+  render: TemplateInputWithSlottedSpanLabel,
   argTypes: basicArgTypes,
   args: { ...basicArgs, value: 'Random value', negative: true },
 };

--- a/src/components/form-field/form-field/form-field.stories.ts
+++ b/src/components/form-field/form-field/form-field.stories.ts
@@ -492,7 +492,7 @@ export const InputHiddenLabel: StoryObj = {
   args: { ...basicArgs, 'hidden-label': true },
 };
 
-export const InputWithSlottedLabel: StoryObj = {
+export const InputWithSlottedSpanLabel: StoryObj = {
   render: TemplateInputWithSlottedSpanLabel,
   argTypes: basicArgTypes,
   args: { ...basicArgs, value: 'Random value' },
@@ -655,7 +655,7 @@ export const InputNegative: StoryObj = {
   },
 };
 
-export const InputWithSlottedLabelNegative: StoryObj = {
+export const InputWithSlottedSpanLabelNegative: StoryObj = {
   render: TemplateInputWithSlottedSpanLabel,
   argTypes: basicArgTypes,
   args: { ...basicArgs, value: 'Random value', negative: true },

--- a/src/components/form-field/form-field/readme.md
+++ b/src/components/form-field/form-field/readme.md
@@ -1,7 +1,8 @@
 The `sbb-form-field` component is intended to be used as a form input wrapper with label and errors.
 
 ```html
-<sbb-form-field label="Example">
+<sbb-form-field>
+  <label>Example</label>
   <input />
 </sbb-form-field>
 
@@ -30,7 +31,7 @@ The following components are designed to work inside a `sbb-form-field`:
 
 ### Label
 
-Either use a `<label>` or the `label` attribute to provide a label for a form input. The
+Use a `<label>` element to provide a label for a form input. The
 `sbb-form-field` will automatically assign the correct id reference between label and input.
 
 It's possible to use the `floatingLabel` property to display the label inside the input.
@@ -38,9 +39,9 @@ When using it and setting the value programmatically to empty or from empty to a
 it's mandatory to call the `reset()` method of the `sbb-form-field` to update the state of the floating label.
 
 ```html
-<sbb-form-field label="Example" floating-label>
-  <input required />
-  <sbb-form-error>This field is required!</sbb-form-error>
+<sbb-form-field>
+  <label>Example</label>
+  <input />
 </sbb-form-field>
 ```
 
@@ -50,8 +51,10 @@ Error messages can be shown under the form field by adding `sbb-form-error` elem
 The component will automatically assign them to the `slot='error'`.
 
 ```html
-<sbb-form-field label="Example">
-  <input />
+<sbb-form-field floating-label>
+  <label>Example</label>
+  <input required />
+  <sbb-form-error>This field is required!</sbb-form-error>
 </sbb-form-field>
 ```
 
@@ -64,7 +67,8 @@ It is possible to add content as a prefix or suffix in a `sbb-form-field`.
 This can be done via the `prefix` and `suffix` slots.
 
 ```html
-<sbb-form-field label="Example">
+<sbb-form-field>
+  <label>Example</label>
   <sbb-icon slot="prefix" name="pie-small"></sbb-icon>
   <input />
   <sbb-icon slot="suffix" name="circle-information-small"></sbb-icon>
@@ -75,7 +79,8 @@ It's also possible to slot an icon-only button using the [sbb-mini-button](/docs
 Please note that only this component is correctly supported when slotting buttons in `negative` mode.
 
 ```html
-<sbb-form-field label="Example">
+<sbb-form-field>
+  <label>Example</label>
   <input />
   <sbb-mini-button slot="suffix" icon-name="pen-small"></sbb-mini-button>
 </sbb-form-field>
@@ -107,8 +112,8 @@ By itself, the `sbb-form-field` does not apply any additional accessibility trea
 element. However, several of the form field's optional features interact with the form element
 contained within the form field.
 
-When you provide a label via `<label>` or the `label` attribute, the `sbb-form-field` automatically
-associates this label with the field's form element via a native `<label>` element, using the `for`
+When you provide a label, the `sbb-form-field` automatically
+associates this label with the form element using the `for`
 attribute to reference the control's ID.
 When using a non-native form element (e.g. `sbb-select`), the `aria-labelledby` is used to connect the
 form element with the label, by setting an id on the label and referencing this id in the
@@ -130,7 +135,6 @@ technology will announce errors when they appear.
 | Name            | Attribute        | Privacy | Type                                                                | Default     | Description                                                                                                                                                           |
 | --------------- | ---------------- | ------- | ------------------------------------------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `errorSpace`    | `error-space`    | public  | `'none' \| 'reserve' \| undefined`                                  | `'none'`    | Whether to reserve space for an error message. `none` does not reserve any space. `reserve` does reserve one row for an error message.                                |
-| `label`         | `label`          | public  | `string \| undefined`                                               |             | Label text for the input which is internally rendered as `<label>`.                                                                                                   |
 | `optional`      | `optional`       | public  | `boolean \| undefined`                                              |             | Indicates whether the input is optional.                                                                                                                              |
 | `size`          | `size`           | public  | `'l' \| 'm' \| undefined`                                           | `'m'`       | Size variant, either l or m.                                                                                                                                          |
 | `borderless`    | `borderless`     | public  | `boolean`                                                           | `false`     | Whether to display the form field without a border.                                                                                                                   |

--- a/src/components/option/optgroup/optgroup.stories.ts
+++ b/src/components/option/optgroup/optgroup.stories.ts
@@ -133,7 +133,8 @@ const Template = ({ label, disabled, ...args }: Args): TemplateResult => html`
 
 const TemplateAutocomplete = (args: Args): TemplateResult => {
   return html`
-    <sbb-form-field label="Autocomplete" ?negative=${args.negative}>
+    <sbb-form-field ?negative=${args.negative}>
+      <label>Autocomplete</label>
       <input placeholder="Placeholder" />
       <sbb-autocomplete>${Template(args)}</sbb-autocomplete>
     </sbb-form-field>
@@ -142,7 +143,8 @@ const TemplateAutocomplete = (args: Args): TemplateResult => {
 
 const TemplateSelect = (args: Args): TemplateResult => {
   return html`
-    <sbb-form-field label="Select" ?negative=${args.negative}>
+    <sbb-form-field ?negative=${args.negative}>
+      <label>Select</label>
       <sbb-select ?multiple=${args.multiple} placeholder="Select"> ${Template(args)} </sbb-select>
     </sbb-form-field>
   `;

--- a/src/components/option/option/option.stories.ts
+++ b/src/components/option/option/option.stories.ts
@@ -123,14 +123,16 @@ const createOptions = ({
 const StandaloneTemplate = (args: Args): TemplateResult => html`${createOptions(args)}`;
 
 const AutocompleteTemplate = (args: Args): TemplateResult => html`
-  <sbb-form-field label="sbb-autocomplete" ?negative=${args.negative}>
+  <sbb-form-field ?negative=${args.negative}>
+    <label>sbb-autocomplete</label>
     <input placeholder="Please select." />
     <sbb-autocomplete>${createOptions(args)}</sbb-autocomplete>
   </sbb-form-field>
 `;
 
 const SelectTemplate = (args: Args): TemplateResult => html`
-  <sbb-form-field label="sbb-select" ?negative=${args.negative}>
+  <sbb-form-field ?negative=${args.negative}>
+    <label>sbb-select</label>
     <sbb-select placeholder="Please select.">${createOptions(args)}</sbb-select>
   </sbb-form-field>
 `;

--- a/src/components/select/readme.md
+++ b/src/components/select/readme.md
@@ -10,7 +10,8 @@ Options or groups of options (see [sbb-option](/docs/components-sbb-option-sbb-o
 can be provided via an unnamed slot.
 
 ```html
-<sbb-form-field label="Train types">
+<sbb-form-field>
+  <label>Train types</label>
   <sbb-select>
     <sbb-option value="Astoro" selected>Astoro</sbb-option>
     <sbb-option value="Flirt">Flirt</sbb-option>
@@ -32,7 +33,8 @@ It is possible to display the component in `disabled` or `readonly` state by usi
 has a `required` property, which can be useful for setting a custom `sbb-form-error` message within a `sbb-form-field`.
 
 ```html
-<sbb-form-field label="Pick one:">
+<sbb-form-field>
+  <label>Pick one:</label>
   <sbb-select placeholder="1st gen starters">
     <sbb-option value="Bulbasaur">Bulbasaur</sbb-option>
     <sbb-option value="Charmander">Charmander</sbb-option>
@@ -52,7 +54,8 @@ If the `multiple` attribute is set to true, a visual checkbox will appear on the
 the selected values will be displayed in selection order, separated by a comma.
 
 ```html
-<sbb-form-field label="Cities">
+<sbb-form-field>
+  <label>Cities</label>
   <sbb-select multiple>
     <sbb-optgroup label="Switzerland">
       <sbb-option value="Zurich">Zurich</sbb-option>

--- a/src/components/select/select.stories.ts
+++ b/src/components/select/select.stories.ts
@@ -299,9 +299,9 @@ const FormFieldTemplate = ({
       ?borderless=${borderless}
       ?negative=${negative}
       ?floating-label=${floatingLabel}
-      label="Select"
       data-testid="form-field"
     >
+      <label>Select</label>
       <sbb-select
         ${sbbSpread(args)}
         @change=${(event: Event) => changeEventHandler(event)}
@@ -338,9 +338,9 @@ const SelectEllipsisTemplate = ({
         ?borderless=${borderless}
         ?negative=${negative}
         ?floating-label=${floatingLabel}
-        label="Select"
         data-testid="form-field"
       >
+        <label>Select</label>
         <sbb-select
           ${sbbSpread(args)}
           @change=${(event: Event) => changeEventHandler(event)}
@@ -386,9 +386,9 @@ const FormFieldTemplateWithError = ({
         ?negative=${negative}
         ?floating-label=${floatingLabel}
         id="sbb-form-field"
-        label="Select"
         data-testid="form-field"
       >
+        <label>Select</label>
         <sbb-select
           ${sbbSpread(args)}
           id="sbb-select"
@@ -425,9 +425,9 @@ const KeyboardInteractionTemplate = ({
     ?borderless=${borderless}
     ?negative=${negative}
     ?floating-label=${floatingLabel}
-    label="Select"
     data-testid="form-field"
   >
+    <label>Select</label>
     <sbb-select
       ?multiple=${args.multiple}
       placeholder=${args.placeholder}

--- a/src/components/slider/readme.md
+++ b/src/components/slider/readme.md
@@ -15,7 +15,8 @@ If no value is provided, by default it is set halfway between the minimum and ma
 The component can be used within a `sbb-form-field` component.
 
 ```html
-<sbb-form-field label="Slider">
+<sbb-form-field>
+  <label>Slider</label>
   <sbb-slider value="0"></sbb-slider>
 </sbb-form-field>
 ```

--- a/src/components/slider/slider.stories.ts
+++ b/src/components/slider/slider.stories.ts
@@ -1,7 +1,7 @@
 import { withActions } from '@storybook/addon-actions/decorator';
 import type { InputType } from '@storybook/types';
 import type { Meta, StoryObj, ArgTypes, Args, Decorator } from '@storybook/web-components';
-import type { TemplateResult } from 'lit';
+import { nothing, type TemplateResult } from 'lit';
 import { html } from 'lit';
 
 import { sbbSpread } from '../core/dom';
@@ -41,7 +41,9 @@ const TemplateSlottedIcons = (args: Args): TemplateResult => html`
 `;
 
 const TemplateSbbSliderInFormField = ({ label, optional, ...args }: Args): TemplateResult => html`
-  <sbb-form-field label=${label} ?optional=${optional}> ${TemplateSbbSlider(args)} </sbb-form-field>
+  <sbb-form-field ?optional=${optional}>
+    ${label ? html`<label>${label}</label>` : nothing} ${TemplateSbbSlider(args)}
+  </sbb-form-field>
 `;
 
 const valueArg: InputType = {

--- a/src/components/time-input/time-input.stories.ts
+++ b/src/components/time-input/time-input.stories.ts
@@ -231,12 +231,12 @@ const TemplateSbbTimeInput = ({
   <div id="example-parent">
     <sbb-form-field
       size=${size}
-      label=${label}
       ?optional=${optional}
       ?borderless=${borderless}
       ?negative=${negative}
       width="collapse"
     >
+      ${label ? html`<label>${label}</label>` : nothing}
       ${iconStart ? html`<sbb-icon slot="prefix" name=${iconStart}></sbb-icon>` : nothing}
       <sbb-time-input
         @change=${(event: CustomEvent) => changeEventHandler(event)}


### PR DESCRIPTION
In order to support SSR we have to remove the label property. As replacement the `<label>` tag should be used.

BREAKING CHANGE: `label` property and attribute of `<sbb-form-field>` was removed. Use `<label>` tag inside `<sbb-form-field>` to provide the label information. E.g. `<sbb-form-field label="Example">...</sbb-form-field>` becomes `<sbb-form-field><label>Example</label>...</sbb-form-field>`