### PR TITLE
fix: fix scrollbar styles for Chrome

### DIFF
--- a/src/components/core/styles/mixins/scrollbar.scss
+++ b/src/components/core/styles/mixins/scrollbar.scss
@@ -36,10 +36,14 @@
     display: none;
   }
 
-  /* Styles for Firefox */
-  scrollbar-width: var(--sbb-scrollbar-width-firefox);
-  scrollbar-color: var(--sbb-scrollbar-color, currentcolor)
-    var(--sbb-scrollbar-track-color, transparent);
+  //  Styles for Firefox.
+  //  We have to use the `not` selector as Chrome supports both, the -webkit-* and the following properties.
+  //  As long as possible we use the -webkit-* approach as we have more styling possibilities there.
+  @supports not selector(::-webkit-scrollbar) {
+    scrollbar-width: var(--sbb-scrollbar-width-firefox);
+    scrollbar-color: var(--sbb-scrollbar-color, currentcolor)
+      var(--sbb-scrollbar-track-color, transparent);
+  }
 }
 
 @mixin scrollbar-variables--size-thin {


### PR DESCRIPTION
Chrome started to support scrollbar-width and scrollbar-color CSS properties which we are currently using as a fallback for Firefox. However, when using it in Chrome, it disables all the -webkit-scrollbar stylings. With the new supports check we can avoid to switch to the scrollbar-color approach in Chrome as long as the old approach still works. Painpoint: the new approach doesn't allow a different color for hover.
