### PR TITLE
fix(sass): inline external .scss files during build

### DIFF
--- a/src/components/core/styles/core/functions.scss
+++ b/src/components/core/styles/core/functions.scss
@@ -1,8 +1,6 @@
 @use 'sass:math';
 
-/**
- * size: value in px (no unit)
- */
 @function px-to-rem-build($size) {
+  /* size: value in px (no unit) */
   @return ((math.div($size, 16)) * 1rem);
 }

--- a/src/components/core/styles/core/mediaqueries.scss
+++ b/src/components/core/styles/core/mediaqueries.scss
@@ -2,7 +2,7 @@
 
 @use 'sass:math';
 @use 'sass:string';
-@use '@sbb-esta/lyne-design-tokens/dist/scss/sbb-variables.scss' as sbb-tokens;
+@use 'node_modules/@sbb-esta/lyne-design-tokens/dist/scss/sbb-variables.scss' as sbb-tokens;
 
 $mq-breakpoints: (
   zero: sbb-tokens.$sbb-breakpoint-zero-min,

--- a/src/components/vite.config.ts
+++ b/src/components/vite.config.ts
@@ -4,6 +4,7 @@ import { defineConfig, mergeConfig, type UserConfig } from 'vite';
 
 import {
   copyAssets,
+  copySass,
   customElementsManifest,
   distDir,
   dts,
@@ -40,7 +41,8 @@ export default defineConfig((config) =>
                 },
               },
             }),
-            copyAssets(['_index.scss', 'core/styles/**/*.scss', '../../README.md']),
+            copyAssets(['_index.scss', '../../README.md']),
+            copySass('core/styles'),
             typography(),
           ]
         : []),

--- a/tools/vite/copy-sass.ts
+++ b/tools/vite/copy-sass.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'fs';
+import { dirname, join, relative } from 'path';
+
+import * as glob from 'glob';
+import type { PluginOption, ResolvedConfig } from 'vite';
+
+import { root } from './build-meta';
+
+export function copySass(sassRoot: string): PluginOption {
+  let viteConfig: ResolvedConfig;
+  return {
+    name: 'package-json-templating',
+    configResolved(config) {
+      viteConfig = config;
+    },
+    generateBundle() {
+      if (viteConfig.command !== 'build') {
+        return;
+      }
+      for (const file of glob.sync(`${sassRoot}/**/*.scss`, { cwd: viteConfig.root })) {
+        this.emitFile({
+          type: 'asset',
+          fileName: file,
+          source: readFileSync(join(viteConfig.root, file), 'utf8').replace(
+            /@use '(node_modules\/[^']+)'/g,
+            (_m, useFile: string) => {
+              const outFile = join(sassRoot, useFile.replaceAll('/', '_'));
+              this.emitFile({
+                type: 'asset',
+                fileName: outFile,
+                source: readFileSync(new URL(useFile, root), 'utf8'),
+              });
+              return `@use '${relative(dirname(file), outFile)}'`;
+            },
+          ),
+        });
+      }
+    },
+  };
+}

--- a/tools/vite/index.ts
+++ b/tools/vite/index.ts
@@ -1,5 +1,6 @@
 export * from './build-meta';
 export * from './copy-assets';
+export * from './copy-sass';
 export * from './custom-elements-manifest';
 export * from './dts';
 export * from './generate-react-wrappers';


### PR DESCRIPTION
This allows our .scss files to be consumed without depending on the `@sbb-esta/lyne-design-tokens` package.

Closes #2513