### PR TITLE
fix: update import paths missed in the migration

### DIFF
--- a/src/components/calendar/calendar.ts
+++ b/src/components/calendar/calendar.ts
@@ -12,8 +12,7 @@ import { classMap } from 'lit/directives/class-map.js';
 
 import { isArrowKeyOrPageKeysPressed, sbbInputModalityDetector } from '../core/a11y.js';
 import { SbbConnectedAbortController, SbbLanguageController } from '../core/controllers.js';
-import { readDataNow } from '../core/datetime/data-now.js';
-import type { DateAdapter } from '../core/datetime.js';
+import { type DateAdapter, readDataNow } from '../core/datetime.js';
 import {
   DAYS_PER_ROW,
   defaultDateAdapter,

--- a/src/components/clock/clock.ts
+++ b/src/components/clock/clock.ts
@@ -3,7 +3,7 @@ import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { ref } from 'lit/directives/ref.js';
 
-import { readDataNow } from '../core/datetime/data-now.js';
+import { readDataNow } from '../core/datetime.js';
 
 import clockFaceSVG from './assets/sbb_clock_face.svg?raw';
 import clockHandleHoursSVG from './assets/sbb_clock_hours.svg?raw';

--- a/src/components/core/datetime.ts
+++ b/src/components/core/datetime.ts
@@ -1,3 +1,4 @@
+export * from './datetime/data-now.js';
 export * from './datetime/date-adapter.js';
 export * from './datetime/date-helper.js';
 export * from './datetime/native-date-adapter.js';

--- a/src/components/datepicker/datepicker-next-day/datepicker-next-day.ts
+++ b/src/components/datepicker/datepicker-next-day/datepicker-next-day.ts
@@ -3,7 +3,7 @@ import { customElement } from 'lit/decorators.js';
 
 import { hostAttributes } from '../../core/decorators.js';
 import { i18nNextDay, i18nSelectNextDay } from '../../core/i18n.js';
-import { SbbDatepickerButton } from '../common/datepicker-button.js';
+import { SbbDatepickerButton } from '../common.js';
 import { findNextAvailableDate, type SbbInputUpdateEvent } from '../datepicker.js';
 
 import '../../icon.js';

--- a/src/components/datepicker/datepicker-previous-day/datepicker-previous-day.ts
+++ b/src/components/datepicker/datepicker-previous-day/datepicker-previous-day.ts
@@ -3,7 +3,7 @@ import { customElement } from 'lit/decorators.js';
 
 import { hostAttributes } from '../../core/decorators.js';
 import { i18nPreviousDay, i18nSelectPreviousDay } from '../../core/i18n.js';
-import { SbbDatepickerButton } from '../common/datepicker-button.js';
+import { SbbDatepickerButton } from '../common.js';
 import { findPreviousAvailableDate, type SbbInputUpdateEvent } from '../datepicker.js';
 import '../../icon.js';
 

--- a/src/components/datepicker/datepicker-toggle/datepicker-toggle.ts
+++ b/src/components/datepicker/datepicker-toggle/datepicker-toggle.ts
@@ -6,7 +6,7 @@ import { ref } from 'lit/directives/ref.js';
 import type { SbbCalendarElement } from '../../calendar.js';
 import { sbbInputModalityDetector } from '../../core/a11y.js';
 import { SbbLanguageController } from '../../core/controllers.js';
-import { readDataNow } from '../../core/datetime/data-now.js';
+import { readDataNow } from '../../core/datetime.js';
 import { hostAttributes } from '../../core/decorators.js';
 import { i18nShowCalendar } from '../../core/i18n.js';
 import { SbbNegativeMixin } from '../../core/mixins.js';

--- a/src/components/datepicker/datepicker/datepicker.ts
+++ b/src/components/datepicker/datepicker/datepicker.ts
@@ -4,15 +4,14 @@ import { customElement, property, state } from 'lit/decorators.js';
 
 import { readConfig } from '../../core/config.js';
 import { SbbConnectedAbortController, SbbLanguageController } from '../../core/controllers.js';
-import { readDataNow } from '../../core/datetime/data-now.js';
-import type { DateAdapter } from '../../core/datetime.js';
+import { type DateAdapter, readDataNow } from '../../core/datetime.js';
 import { defaultDateAdapter } from '../../core/datetime.js';
 import { findInput, findReferencedElement } from '../../core/dom.js';
 import { EventEmitter } from '../../core/eventing.js';
 import { i18nDateChangedTo, i18nDatePickerPlaceholder } from '../../core/i18n.js';
 import type { SbbDateLike, SbbValidationChangeEvent } from '../../core/interfaces.js';
 import { AgnosticMutationObserver } from '../../core/observers.js';
-import type { SbbDatepickerButton } from '../common/datepicker-button.js';
+import type { SbbDatepickerButton } from '../common.js';
 import type { SbbDatepickerToggleElement } from '../datepicker-toggle.js';
 
 import style from './datepicker.scss?lit&inline';

--- a/src/components/journey-summary/journey-summary.ts
+++ b/src/components/journey-summary/journey-summary.ts
@@ -4,11 +4,11 @@ import { html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { SbbLanguageController } from '../core/controllers.js';
-import { readDataNow } from '../core/datetime/data-now.js';
 import {
   defaultDateAdapter,
   durationToTime,
   removeTimezoneFromISOTimeString,
+  readDataNow,
 } from '../core/datetime.js';
 import { i18nTripDuration } from '../core/i18n.js';
 import type { Leg } from '../core/timetable.js';

--- a/src/components/pearl-chain-time/pearl-chain-time.ts
+++ b/src/components/pearl-chain-time/pearl-chain-time.ts
@@ -4,8 +4,7 @@ import { html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { SbbLanguageController } from '../core/controllers.js';
-import { readDataNow } from '../core/datetime/data-now.js';
-import { removeTimezoneFromISOTimeString } from '../core/datetime.js';
+import { readDataNow, removeTimezoneFromISOTimeString } from '../core/datetime.js';
 import { i18nArrival, i18nDeparture, i18nTransferProcedures } from '../core/i18n.js';
 import type { Leg, PtRideLeg } from '../core/timetable.js';
 import { getDepartureArrivalTimeAttribute, isRideLeg } from '../core/timetable.js';

--- a/src/components/pearl-chain/pearl-chain.ts
+++ b/src/components/pearl-chain/pearl-chain.ts
@@ -4,8 +4,7 @@ import { html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import { readDataNow } from '../core/datetime/data-now.js';
-import { removeTimezoneFromISOTimeString } from '../core/datetime.js';
+import { readDataNow, removeTimezoneFromISOTimeString } from '../core/datetime.js';
 import type { Leg, PtRideLeg } from '../core/timetable.js';
 import { isRideLeg } from '../core/timetable.js';
 

--- a/src/components/timetable-row/timetable-row.ts
+++ b/src/components/timetable-row/timetable-row.ts
@@ -4,8 +4,7 @@ import { html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import { SbbLanguageController } from '../core/controllers.js';
-import { readDataNow } from '../core/datetime/data-now.js';
-import { removeTimezoneFromISOTimeString, durationToTime } from '../core/datetime.js';
+import { readDataNow, removeTimezoneFromISOTimeString, durationToTime } from '../core/datetime.js';
 import { setOrRemoveAttribute } from '../core/dom.js';
 import {
   i18nArrival,

--- a/src/components/vite.config.ts
+++ b/src/components/vite.config.ts
@@ -12,6 +12,7 @@ import {
   isProdBuild,
   packageJsonTemplate,
   typography,
+  verifyEntryPoints,
 } from '../../tools/vite/index.js';
 import rootConfig from '../../vite.config.js';
 
@@ -46,6 +47,7 @@ export default defineConfig((config) =>
             copyAssets(['_index.scss', '../../README.md']),
             copySass('core/styles'),
             typography(),
+            verifyEntryPoints(),
           ]
         : []),
     ],

--- a/tools/vite/index.ts
+++ b/tools/vite/index.ts
@@ -7,3 +7,4 @@ export * from './generate-react-wrappers.js';
 export * from './package-json-template.js';
 export * from './resolve-entry-points.js';
 export * from './typography.js';
+export * from './verify-entry-points.js';

--- a/tools/vite/verify-entry-points.ts
+++ b/tools/vite/verify-entry-points.ts
@@ -1,0 +1,23 @@
+import { join, relative } from 'path';
+
+import type { LibraryOptions, PluginOption, ResolvedConfig } from 'vite';
+
+export function verifyEntryPoints(): PluginOption {
+  let viteConfig: ResolvedConfig;
+  return {
+    name: 'package-json-templating',
+    configResolved(config) {
+      viteConfig = config;
+    },
+    async closeBundle() {
+      if (viteConfig.command !== 'build') {
+        return;
+      }
+      const entry = (viteConfig.build.lib as LibraryOptions).entry as Record<string, string>;
+      const dir = new URL('./', import.meta.url);
+      for (const entryPoint of Object.keys(entry)) {
+        await import(relative(dir.pathname, join(viteConfig.build.outDir, entryPoint + '.js')));
+      }
+    },
+  };
+}


### PR DESCRIPTION
This PR fixes the remaining missed import paths that were not adapted. It additionally adds a vite plugin check, to ensure the build would break, if an illegal import was used.