### PR TITLE
build: re-enable chromatic stories

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -3,6 +3,7 @@ import '../src/components/core/styles/global.scss';
 
 const getViewportName = (key: string): string =>
   key.replace(/(^SbbBreakpoint|Min$)/g, '').toLowerCase();
+
 const breakpoints = Object.entries(tokens)
   .filter(([key]) => key.startsWith('SbbBreakpoint') && key.endsWith('Min'))
   .map(([key, value]) => ({ key: getViewportName(key), value: value as number }))

--- a/scripts/chromatic-stories-generator.ts
+++ b/scripts/chromatic-stories-generator.ts
@@ -1,8 +1,9 @@
+/* eslint-disable import-x/default, import-x/no-named-as-default-member */
 import { readdirSync, readFileSync, writeFileSync } from 'fs';
 import { basename, dirname, join, relative } from 'path';
 import { fileURLToPath } from 'url';
 
-import * as ts from 'typescript';
+import ts from 'typescript';
 
 const chromaticFile = join(
   dirname(fileURLToPath(import.meta.url)),

--- a/scripts/migrate-ssr-e2e.ts
+++ b/scripts/migrate-ssr-e2e.ts
@@ -1,10 +1,11 @@
+/* eslint-disable import-x/default, import-x/no-named-as-default-member */
 import { readFileSync, writeFileSync } from 'fs';
 import { basename, dirname, join, relative } from 'path';
 
 import * as glob from 'glob';
 // eslint-disable-next-line @typescript-eslint/naming-convention
 import MagicString from 'magic-string';
-import * as ts from 'typescript';
+import ts from 'typescript';
 
 /*
  * Convert e2e test files to use the lit fixture, to enable ssr testing.

--- a/scripts/migrate-toggle-data-entry.ts
+++ b/scripts/migrate-toggle-data-entry.ts
@@ -1,9 +1,10 @@
+/* eslint-disable import-x/default, import-x/no-named-as-default-member */
 import { readFileSync, writeFileSync } from 'fs';
 
 import * as glob from 'glob';
 // eslint-disable-next-line @typescript-eslint/naming-convention
 import MagicString from 'magic-string';
-import * as ts from 'typescript';
+import ts from 'typescript';
 
 function* iterate(node: ts.Node): Generator<ts.Node, void, unknown> {
   yield node;


### PR DESCRIPTION
Our chromatic story generation got disabled in the eslint migration. This PR re-enables it.